### PR TITLE
fix: allow tauri IPC origin in CSP to prevent startup error dialog

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*; frame-src http://127.0.0.1:*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'"
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost 'self' http://127.0.0.1:* ws://127.0.0.1:*; frame-src http://127.0.0.1:*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'"
     }
   },
   "bundle": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,24 +97,29 @@ export default function App() {
 
     try {
       // Install-progress stream: only ever move the percentage forward, like
-      // the reference installer store.
-      unlistenInstall = await listen<InstallProgress>("install-progress", (e) => {
-        const payload = e.payload;
-        setInstaller((prev) => {
-          if (payload.percentage < prev.percentage) {
-            return prev;
-          }
-          const logs = payload.log
-            ? [...prev.logs, payload.log].slice(-5)
-            : prev.logs;
-          return {
-            title: payload.title || prev.title,
-            detail: payload.detail || prev.detail,
-            percentage: payload.percentage,
-            logs,
-          };
+      // the reference installer store. 事件监听失败（例如 IPC 自定义协议被
+      // CSP 拦截、回退 postMessage 也异常）不应阻断启动流程，因此容错跳过。
+      try {
+        unlistenInstall = await listen<InstallProgress>("install-progress", (e) => {
+          const payload = e.payload;
+          setInstaller((prev) => {
+            if (payload.percentage < prev.percentage) {
+              return prev;
+            }
+            const logs = payload.log
+              ? [...prev.logs, payload.log].slice(-5)
+              : prev.logs;
+            return {
+              title: payload.title || prev.title,
+              detail: payload.detail || prev.detail,
+              percentage: payload.percentage,
+              logs,
+            };
+          });
         });
-      });
+      } catch (err) {
+        console.error("[App] failed to listen install-progress:", err);
+      }
 
       const runtimeInfo = await invoke<{ service_url: string }>("get_runtime_info");
       setServiceUrl(runtimeInfo.service_url);


### PR DESCRIPTION
## 问题

检测环境阶段会出现错误弹窗，关闭后页面才正常显示。控制台报错：

```
Connecting to 'http://ipc.localhost/plugin%3Aevent%7Clisten' violates the Content Security Policy directive: "connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
IPC custom protocol failed, Tauri will now use the postMessage interface instead
```

## 根因

`src-tauri/tauri.conf.json` 的 CSP `connect-src` 缺少 Tauri 2 的 IPC origin（`ipc: http://ipc.localhost`），导致首次事件监听（`listen('install-progress')`）被 CSP 拦截并抛出异常，进入错误弹窗。

## 修复

1. CSP `connect-src` 增加 `ipc: http://ipc.localhost`，允许 Tauri IPC 自定义协议（官方推荐写法，见 `@tauri-apps/api/core.js` 注释）。
2. `src/App.tsx` 中 `boot()` 的事件监听加 `try/catch`，即使监听失败也只打日志，不再阻断启动流程（与 `useAutoSync.ts` 的既有容错一致）。

## 验证

- `pnpm build`（tsc + vite build）通过
- `cargo check` 通过
