### PR TITLE
fix(harness-updater): stop false update prompt when installed files are current

### DIFF
--- a/src-tauri/src/bridge/cmd.rs
+++ b/src-tauri/src/bridge/cmd.rs
@@ -36,17 +36,18 @@ pub async fn install_dependencies(app_handle: AppHandle) -> Result<(), String> {
     // 不一致时，说明上游 pkg 有更新/修复，需要自动重新下载。
     let node_ok = download::Nodejs.check_installed(&app_handle);
     let dsh_files_ok = download::Dsh.check_installed(&app_handle);
-    let dsh_latest = download::fetch_latest_dsh_pkg_commit().await;
+    let dsh_latest = download::fetch_latest_dsh_pkg_info().await;
 
     let dsh_ok = match &dsh_latest {
-        Ok(commit) => {
+        Ok(latest) => {
             dsh_files_ok
-                && config::get_dsh_pkg_commit(&app_handle).as_deref() == Some(commit.as_str())
+                && config::get_dsh_pkg_commit(&app_handle).as_deref()
+                    == Some(latest.commit.as_str())
         }
         Err(e) => {
             // 网络不可用或 GitHub API 限流时保留本地安装，不阻塞启动
             log::warn!(
-                "Failed to check latest dsh release commit, keeping local install: {}",
+                "Failed to check latest dsh release info, keeping local install: {}",
                 e
             );
             dsh_files_ok
@@ -82,6 +83,10 @@ pub async fn install_dependencies(app_handle: AppHandle) -> Result<(), String> {
 }
 
 /// 静默检查是否有新版 Harness 可用（只查不装，供进入页面后后台调用）
+///
+/// 以“实际安装文件”为准核对，而不是只看本地记录：记录可能因安装时 API
+/// 失败或外围途径更新而滞后于文件，此时修正记录并免打扰；同版本热修
+/// （版本相同但 commit 不同）仍正常提示。
 #[tauri::command]
 pub async fn check_dsh_update(
     app_handle: AppHandle,
@@ -93,11 +98,39 @@ pub async fn check_dsh_update(
     }
 
     let latest = download::fetch_latest_dsh_pkg_info().await?;
-    let current = config::get_dsh_pkg_commit(&app_handle);
-    if current.as_deref() == Some(latest.commit.as_str()) {
-        Ok(None)
+    let record_commit = config::get_dsh_pkg_commit(&app_handle);
+    let record_tag = config::get_dsh_pkg_tag(&app_handle);
+    let installed_version = config::get_dsh_version(&app_handle);
+
+    // 老记录没有 tag，反查 pkg 仓库 tags 列表确认记录对应的发布版本；
+    // 反查失败时由 resolve_update 回退到“以实际文件为准”的保守分支
+    let legacy_tags = if record_tag.is_none() {
+        download::fetch_dsh_pkg_tags().await.unwrap_or_default()
     } else {
-        Ok(Some(latest))
+        Vec::new()
+    };
+
+    match download::resolve_update(
+        record_commit.as_deref(),
+        record_tag.as_deref(),
+        installed_version.as_deref(),
+        &latest,
+        &legacy_tags,
+    ) {
+        download::UpdateCheck::UpToDate => Ok(None),
+        download::UpdateCheck::UpdateAvailable => Ok(Some(latest)),
+        download::UpdateCheck::HealUpToDate => {
+            // 安装文件已是最新 release，只是记录滞后：修正记录后下次启动
+            // 直接走 commit 比对快速路径，不再误报
+            log::info!(
+                "Installed Harness files already at latest release, healing stale record: {} ({})",
+                latest.tag,
+                latest.commit
+            );
+            config::set_dsh_pkg_commit(&app_handle, latest.commit.clone());
+            config::set_dsh_pkg_tag(&app_handle, latest.tag.clone());
+            Ok(None)
+        }
     }
 }
 

--- a/src-tauri/src/config/setting.rs
+++ b/src-tauri/src/config/setting.rs
@@ -12,6 +12,10 @@ pub struct Setting {
     pub language: String,
     #[serde(default)]
     pub dsh_pkg_commit: Option<String>,
+    /// 已安装 Harness 发行版对应的 GitHub release tag（与 dsh_pkg_commit 配套，
+    /// 用于甄别“记录滞后于文件”与“同版本热修”两种不一致）
+    #[serde(default)]
+    pub dsh_pkg_tag: Option<String>,
     /// 命令行集成开关：安装后在用户 PATH 中注册 `dsh` 命令
     #[serde(default = "default_cli_link_enabled")]
     pub cli_link_enabled: bool,
@@ -42,6 +46,7 @@ impl Default for Setting {
             auto_start: true,
             language: "zh-CN".to_string(),
             dsh_pkg_commit: None,
+            dsh_pkg_tag: None,
             cli_link_enabled: default_cli_link_enabled(),
             preinstall_done: false,
         }
@@ -83,5 +88,17 @@ pub fn get_dsh_pkg_commit(app_handle: &AppHandle) -> Option<String> {
 pub fn set_dsh_pkg_commit(app_handle: &AppHandle, commit: String) {
     let mut setting = get_store_dat_setting(app_handle);
     setting.dsh_pkg_commit = Some(commit);
+    set_store_dat_setting(app_handle, setting);
+}
+
+/// 已安装 Harness 发行版对应的 GitHub release tag
+pub fn get_dsh_pkg_tag(app_handle: &AppHandle) -> Option<String> {
+    get_store_dat_setting(app_handle).dsh_pkg_tag
+}
+
+/// 记录已安装 Harness 发行版的 GitHub release tag
+pub fn set_dsh_pkg_tag(app_handle: &AppHandle, tag: String) {
+    let mut setting = get_store_dat_setting(app_handle);
+    setting.dsh_pkg_tag = Some(tag);
     set_store_dat_setting(app_handle, setting);
 }

--- a/src-tauri/src/service/download/core.rs
+++ b/src-tauri/src/service/download/core.rs
@@ -270,7 +270,237 @@ pub async fn fetch_latest_dsh_pkg_info() -> Result<LatestDshPkg, String> {
     })
 }
 
-/// 查询 GitHub 上最新 Harness 发行版对应的 commit hash
-pub async fn fetch_latest_dsh_pkg_commit() -> Result<String, String> {
-    fetch_latest_dsh_pkg_info().await.map(|info| info.commit)
+/// 从 release tag 中解析版本号：`dsh-0.1.0-rc.7-32054485373` → `0.1.0-rc.7`。
+///
+/// tag 约定为 `dsh-<version>-<commit 后缀>`；格式不符时返回 `None`，
+/// 调用方据此回退到仅 commit 比对的旧行为，避免误判。
+pub fn parse_version_from_tag(tag: &str) -> Option<String> {
+    let version = tag.strip_prefix("dsh-")?.rsplit_once('-')?.0;
+    (!version.is_empty()).then(|| version.to_string())
+}
+
+/// 更新判定结果
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateCheck {
+    /// 无更新
+    UpToDate,
+    /// 无更新，但本地记录滞后于实际安装文件，需要修正记录
+    HealUpToDate,
+    /// 有更新
+    UpdateAvailable,
+}
+
+/// 结合本地记录与实际安装文件判定是否有新版 Harness 可用。
+///
+/// 本地记录（release commit + tag）由安装流程写入；但当安装文件被外围途径
+/// 更新、或安装时 GitHub API 失败未落盘，记录会滞后于文件，造成每次都误报
+/// 更新。这里以磁盘上实际的 `@deepseek-ai/dsh` 版本为准核对：
+/// - commit 一致 → 无更新；
+/// - 文件版本与最新 release 不同 → 有更新；
+/// - 文件版本相同：记录 tag 版本也相同 → 同版本热修 → 有更新；
+///   记录 tag 版本更旧（或记录无 tag，经 `legacy_tags` 反查）→ 记录滞后 → 修正记录。
+///
+/// `legacy_tags` 是 pkg 仓库的 tags 列表（tag, commit），仅用于反查历史安装
+/// 记录的版本；反查不到时以实际文件为准（视为记录滞后）。
+pub fn resolve_update(
+    record_commit: Option<&str>,
+    record_tag: Option<&str>,
+    installed_version: Option<&str>,
+    latest: &LatestDshPkg,
+    legacy_tags: &[(String, String)],
+) -> UpdateCheck {
+    if record_commit == Some(latest.commit.as_str()) {
+        return UpdateCheck::UpToDate;
+    }
+    let (Some(installed), Some(latest_version)) =
+        (installed_version, parse_version_from_tag(&latest.tag))
+    else {
+        // 版本信息不可解析时回退到旧行为：记录不一致即视为有更新
+        return UpdateCheck::UpdateAvailable;
+    };
+    if installed != latest_version {
+        return UpdateCheck::UpdateAvailable;
+    }
+    // 文件已经是“最新版本”，此时需要甄别记录是否滞后
+    match record_tag.and_then(parse_version_from_tag) {
+        Some(record_version) if record_version < latest_version => UpdateCheck::HealUpToDate,
+        Some(_) => UpdateCheck::UpdateAvailable,
+        None => match legacy_tags
+            .iter()
+            .find(|(_, commit)| Some(commit.as_str()) == record_commit)
+        {
+            Some((tag, _)) => match parse_version_from_tag(tag) {
+                Some(record_version) if record_version < latest_version => UpdateCheck::HealUpToDate,
+                // 反查到的版本与最新版本相同（或解析失败）→ 视为同版本热修
+                _ => UpdateCheck::UpdateAvailable,
+            },
+            // 无法考证记录对应的版本 → 以实际安装文件为准，修正记录
+            None => UpdateCheck::HealUpToDate,
+        },
+    }
+}
+
+/// 拉取 pkg 仓库的 release tag 列表（tag, commit），用于反查历史记录对应的版本。
+///
+/// 仅在更新判定需要反查“无 tag 的老记录”时调用，失败时由调用方回退到
+/// “以实际文件为准”的保守分支。
+pub async fn fetch_dsh_pkg_tags() -> Result<Vec<(String, String)>, String> {
+    let client = reqwest::Client::builder()
+        .user_agent("deepseek-harness-desktop")
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let tags: serde_json::Value = client
+        .get(format!("{}/tags?per_page=100", DSH_PKG_GITHUB_API))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to request release tags: {}", e))?
+        .error_for_status()
+        .map_err(|e| format!("Release tags request failed: {}", e))?
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse release tags response: {}", e))?;
+
+    Ok(tags
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.get("name")?.as_str()?.to_string();
+            let sha = entry.get("commit")?.get("sha")?.as_str()?.to_string();
+            Some((name, sha))
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn latest(tag: &str, commit: &str) -> LatestDshPkg {
+        LatestDshPkg {
+            tag: tag.to_string(),
+            commit: commit.to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_version_from_tag_formats() {
+        assert_eq!(
+            parse_version_from_tag("dsh-0.1.0-rc.7-32054485373").as_deref(),
+            Some("0.1.0-rc.7")
+        );
+        assert_eq!(
+            parse_version_from_tag("dsh-0.1.0-rc.6-31773193667").as_deref(),
+            Some("0.1.0-rc.6")
+        );
+        assert_eq!(parse_version_from_tag("dsh-0.2.0"), None);
+        assert_eq!(parse_version_from_tag("0.1.0-rc.7-abc"), None);
+        assert_eq!(parse_version_from_tag(""), None);
+    }
+
+    #[test]
+    fn resolve_matching_commit_is_up_to_date() {
+        let latest = latest("dsh-0.1.0-rc.7-32054485373", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let decision = resolve_update(
+            Some("6c659bb2636b3ad396a204c4c6ff110276fa3a09"),
+            Some("dsh-0.1.0-rc.7-32054485373"),
+            Some("0.1.0-rc.7"),
+            &latest,
+            &[],
+        );
+        assert_eq!(decision, UpdateCheck::UpToDate);
+    }
+
+    #[test]
+    fn resolve_different_installed_version_is_update() {
+        let latest = latest("dsh-0.1.0-rc.7-32054485373", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let decision = resolve_update(
+            Some("564019027fd9469991aef6e57bb0a96325491c4e"),
+            Some("dsh-0.1.0-rc.6-31773193667"),
+            Some("0.1.0-rc.6"),
+            &latest,
+            &[],
+        );
+        assert_eq!(decision, UpdateCheck::UpdateAvailable);
+    }
+
+    #[test]
+    fn resolve_same_version_hotfix_is_update() {
+        // 记录正确（与文件一致），最新 release 是同版本热修：应提示更新
+        let latest = latest("dsh-0.1.0-rc.6-31773193667", "564019027fd9469991aef6e57bb0a96325491c4e");
+        let decision = resolve_update(
+            Some("995e261e117617780dc50db16c70d445255978fd"),
+            Some("dsh-0.1.0-rc.6-31762761461"),
+            Some("0.1.0-rc.6"),
+            &latest,
+            &[],
+        );
+        assert_eq!(decision, UpdateCheck::UpdateAvailable);
+    }
+
+    #[test]
+    fn resolve_stale_record_behind_files_heals() {
+        // 用户现场：记录停留在 rc.6，文件已是 rc.7 → 修正记录、免打扰
+        let latest = latest("dsh-0.1.0-rc.7-32054485373", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let decision = resolve_update(
+            Some("564019027fd9469991aef6e57bb0a96325491c4e"),
+            Some("dsh-0.1.0-rc.6-31773193667"),
+            Some("0.1.0-rc.7"),
+            &latest,
+            &[],
+        );
+        assert_eq!(decision, UpdateCheck::HealUpToDate);
+    }
+
+    #[test]
+    fn resolve_legacy_record_without_tag_heals_via_tags_lookup() {
+        // 老记录没有 tag：反查 tags 列表发现记录版本低于文件版本 → 修正
+        let latest = latest("dsh-0.1.0-rc.7-32054485373", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let tags = vec![(
+            "dsh-0.1.0-rc.6-31773193667".to_string(),
+            "564019027fd9469991aef6e57bb0a96325491c4e".to_string(),
+        )];
+        let decision = resolve_update(
+            Some("564019027fd9469991aef6e57bb0a96325491c4e"),
+            None,
+            Some("0.1.0-rc.7"),
+            &latest,
+            &tags,
+        );
+        assert_eq!(decision, UpdateCheck::HealUpToDate);
+    }
+
+    #[test]
+    fn resolve_legacy_same_version_still_updates() {
+        // 老记录无 tag 但反查为同版本热修：仍应提示
+        let latest = latest("dsh-0.1.0-rc.6-31773193667", "564019027fd9469991aef6e57bb0a96325491c4e");
+        let tags = vec![(
+            "dsh-0.1.0-rc.6-31762761461".to_string(),
+            "995e261e117617780dc50db16c70d445255978fd".to_string(),
+        )];
+        let decision = resolve_update(
+            Some("995e261e117617780dc50db16c70d445255978fd"),
+            None,
+            Some("0.1.0-rc.6"),
+            &latest,
+            &tags,
+        );
+        assert_eq!(decision, UpdateCheck::UpdateAvailable);
+    }
+
+    #[test]
+    fn resolve_without_version_metadata_falls_back_to_update() {
+        // 最新 tag 无法解析出版本时回退旧行为：记录不一致即提示
+        let latest = latest("0.1.0-rc.7", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let decision = resolve_update(
+            Some("564019027fd9469991aef6e57bb0a96325491c4e"),
+            None,
+            Some("0.1.0-rc.7"),
+            &latest,
+            &[],
+        );
+        assert_eq!(decision, UpdateCheck::UpdateAvailable);
+    }
 }

--- a/src-tauri/src/service/download/mod.rs
+++ b/src-tauri/src/service/download/mod.rs
@@ -6,8 +6,8 @@ mod utils;
 
 // 导出公共接口
 pub use core::{
-    download_file, ensure_extract, fetch_latest_dsh_pkg_commit, fetch_latest_dsh_pkg_info,
-    LatestDshPkg,
+    download_file, ensure_extract, fetch_dsh_pkg_tags, fetch_latest_dsh_pkg_info, resolve_update,
+    LatestDshPkg, UpdateCheck,
 };
 pub use installable::{Dsh, Installable, Nodejs, Pnpm};
 pub use progress::ProgressTracker;

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -354,7 +354,7 @@ pub fn stop_on_exit(app_handle: tauri::AppHandle, port: u16) {
 /// 安装环境（Node.js 运行时 + 打包的 Harness 发行版）
 pub async fn install(
     app_handle: &tauri::AppHandle,
-    dsh_latest_commit: Option<String>,
+    dsh_latest: Option<download::LatestDshPkg>,
 ) -> Result<(), String> {
     log::info!("Starting installation process");
 
@@ -388,8 +388,9 @@ pub async fn install(
         log::debug!("Processing task {}/{}", index + 1, tasks.len());
         // 已安装但 commit 与最新 release 不一致时强制重新下载
         let outdated = index == 1
-            && dsh_latest_commit.is_some()
-            && config::get_dsh_pkg_commit(app_handle).as_deref() != dsh_latest_commit.as_deref();
+            && dsh_latest.as_ref().is_some_and(|info| {
+                config::get_dsh_pkg_commit(app_handle).as_deref() != Some(info.commit.as_str())
+            });
         if task.check_installed(app_handle) && !outdated {
             log::debug!(
                 "Task {} already installed and up to date, skipping",
@@ -419,10 +420,11 @@ pub async fn install(
         log::info!("Extraction completed");
         tracker.end_phase();
 
-        // 记录本次安装对应的 release commit，供下次启动比对
+        // 记录本次安装对应的 release tag 与 commit，供下次启动比对
         if index == 1 {
-            if let Some(commit) = &dsh_latest_commit {
-                config::set_dsh_pkg_commit(app_handle, commit.clone());
+            if let Some(info) = &dsh_latest {
+                config::set_dsh_pkg_commit(app_handle, info.commit.clone());
+                config::set_dsh_pkg_tag(app_handle, info.tag.clone());
             }
         }
     }


### PR DESCRIPTION
## 问题

用户更新后仍提示「发现新版本 dsh-0.1.0-rc.7-32054485373，是否立即更新？6c659bb」。

现场证据（用户机器实测）：
- `store.dat` 中 `dsh_pkg_commit = 564019027f...`，对应 pkg tag `dsh-0.1.0-rc.6-31773193667`（上一版 release）
- 磁盘 `dependencies/dsh/package.json` 已固定 `@deepseek-ai/dsh: 0.1.0-rc.7`（文件已是最新版）
- 最新 release：tag `dsh-0.1.0-rc.7-32054485373`，commit `6c659bb263...`（即 toast 里的 `6c659bb`）

## 根因

`check_dsh_update` 只用 store.dat 里的记录 commit 与最新 release 比对；该记录仅在 `workflow::install` 中、且安装时 GitHub API 请求成功的情况下写入。当安装文件被更新而记录未同步（API 限流/失败、外围途径安装等），记录永久滞后，每次启动都误报。

pkg 仓库 tag 约定为 `dsh-<version>-<commit>`，且同版本多次打 tag 是常态（rc.6 有 3 个），因此不能简单地「版本相同即免打扰」。

## 修复

- 记录安装的 release **tag**（`dsh_pkg_tag`），与 commit 配套持久化（`#[serde(default)]` 兼容老配置）
- 新增纯函数 `resolve_update`，以实际安装文件的 `@deepseek-ai/dsh` 版本为准核对：

| 条件 | 结论 |
| --- | --- |
| 记录 commit == 最新 commit | 无更新 |
| 文件版本 != 最新版本 | 有更新 |
| 文件版本 = 最新版本，记录 tag 版本更旧 | 记录滞后 → 修正记录，免打扰 |
| 文件版本 = 最新版本，记录 tag 版本相同 | 同版本热修 → 正常提示 |
| 老记录无 tag | 反查 pkg 仓库 `/tags` 列表确认记录版本（仅一次，收敛后走快速路径） |

- `workflow::install` 同时写入 tag + commit
- 新增 8 个单元测试覆盖上述分支

## 验证

- `cargo check --all-targets`：通过
- `cargo test`：34 passed（含新增 8 个）

本次修复后，用户机器上的「已更新但仍提示」场景进入 HealUpToDate 分支：修正记录、免打扰并自愈，下一次启动即静默。