### PR TITLE
fix(macos): reopen main window on dock icon click after close

### DIFF
--- a/src-tauri/src/core/utils/mod.rs
+++ b/src-tauri/src/core/utils/mod.rs
@@ -1,9 +1,20 @@
-use tauri::{Runtime, WebviewWindow};
+use tauri::{AppHandle, Manager, Runtime, WebviewWindow};
 
 pub fn show_window<R: Runtime>(window: &WebviewWindow<R>) {
     let _ = window.unminimize();
     let _ = window.show();
     let _ = window.set_focus();
+}
+
+/// 显示主窗口：托盘「打开面板」、托盘左键点击、macOS Dock 图标点击共用。
+/// 关闭按钮只隐藏窗口（见 builder 的 on_window_event），所以这里取到即可 show；
+/// 若窗口确实不存在（非预期路径），仅记录日志，不重建。
+pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        show_window(&window);
+    } else {
+        log::warn!("[window] main window not found, skip show");
+    }
 }
 
 pub fn app_icon_temp_path(app: &tauri::AppHandle) -> Option<std::path::PathBuf> {

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -7,10 +7,10 @@ use tauri::{
     ipc::Invoke,
     menu::{Menu, MenuEvent, MenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
-    Manager, Runtime, WebviewUrl, WebviewWindowBuilder, Wry,
+    Runtime, WebviewUrl, WebviewWindowBuilder, Wry,
 };
 
-use crate::core::utils::show_window;
+use crate::core::utils::show_main_window;
 use crate::desktop::window::{on_download, on_new_window};
 #[cfg(windows)]
 use crate::desktop::window::on_page_load;
@@ -62,11 +62,7 @@ pub fn tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
 
     fn handle_menu_event<R: Runtime>(app: &tauri::AppHandle<R>, event: &MenuEvent) {
         match event.id().as_ref() {
-            "open" => {
-                if let Some(window) = app.get_webview_window("main") {
-                    show_window(&window);
-                }
-            }
+            "open" => show_main_window(app),
             "quit" => {
                 app.exit(0);
             }
@@ -75,15 +71,12 @@ pub fn tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
     }
 
     fn handle_tray_icon_event<R: Runtime>(tray: &tauri::tray::TrayIcon<R>, event: &TrayIconEvent) {
-        let app = tray.app_handle();
         if let TrayIconEvent::Click {
             button: MouseButton::Left,
             ..
         } = event
         {
-            if let Some(window) = app.get_webview_window("main") {
-                show_window(&window);
-            }
+            show_main_window(tray.app_handle());
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,15 +14,23 @@ pub fn run() {
         .invoke_handler(desktop::handler())
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|app_handle, event| {
+        .run(|app_handle, event| match event {
+            // macOS：关闭按钮只是隐藏窗口（见 builder 的 on_window_event），
+            // 点击 Dock 图标时系统回调 applicationShouldHandleReopen 触发
+            // RunEvent::Reopen，这里重新显示主窗口，否则窗口会一直隐藏在托盘。
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen { .. } => {
+                crate::core::utils::show_main_window(&app_handle);
+            }
             // 退出时回收 Harness 进程：不回收的话，node 进程会在应用退出后
             // 残留并把原生模块 DLL（如 sharp 的 libvips-42.dll）锁在内存，
             // 下次启动重新解压时会失败（Windows os error 32）
-            if let tauri::RunEvent::Exit = event {
+            tauri::RunEvent::Exit => {
                 let setting = config::get_store_dat_setting(app_handle);
                 if setting.installed {
                     service::workflow::stop_on_exit(app_handle.clone(), setting.port);
                 }
             }
+            _ => {}
         });
 }


### PR DESCRIPTION
## Problem

On macOS, clicking the window close button only hides the window (the app stays in the tray). Clicking the Dock icon afterwards did nothing — the main window could not be reopened without fully quitting (Cmd+Q / tray Quit) and restarting.

## Fix

- Handle Tauri `RunEvent::Reopen` on macOS: when the Dock icon is clicked, re-show the main window instead of leaving it hidden
- Extract a shared `show_main_window` helper (`core::utils`) used by the tray "open" menu item, tray left-click, and the macOS reopen event

Fixes #18
