### PR TITLE
feat(security): 下载完整性校验、进程归属管理与前端通信加固

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,6 +825,7 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tauri-plugin-notification = "2"
 image = { version = "0.25", default-features = false, features = [ "png" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
+sha2 = "0.10"
 log = "0.4"
 reqwest = { version = "0.12", features = [
   "json",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,11 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window and the embedded Harness GUI; grants IPC (e.g. opener|open_url) to the remote-origin dsh page.",
+  "description": "Capability for the trusted desktop shell. The remote Harness iframe communicates only through the validated postMessage bridge.",
   "windows": ["main"],
-  "remote": {
-    "urls": ["http://127.0.0.1:*"]
-  },
   "permissions": [
     "core:default",
     "core:event:allow-listen",

--- a/src-tauri/src/config/constants.rs
+++ b/src-tauri/src/config/constants.rs
@@ -12,6 +12,8 @@ pub const DSH_CORE_URL: &str =
 
 /// 捆绑的 pnpm 版本（与 deepseek-harness-pkg 的 packageManager: pnpm@11.7.0 对齐）
 pub const PNPM_VERSION: &str = "11.7.0";
+/// pnpm 11.7.0 官方 npm tarball 的 SHA-256；升级版本时必须同步更新。
+pub const PNPM_SHA256: &str = "deafa7ec98a1218b6a047289b92fbe2395c1e22d3495bb711653013218ee15ee";
 
 /// pnpm 官方 npm registry tarball 下载地址前缀（纯 JS 发行，全平台同一 URL）
 pub const PNPM_BASE_URL: &str = "https://registry.npmjs.org/pnpm/-/";

--- a/src-tauri/src/service/download/core.rs
+++ b/src-tauri/src/service/download/core.rs
@@ -1,8 +1,10 @@
 use futures_util::StreamExt;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::config;
 use crate::service::download::ProgressTracker;
 use tauri::Runtime;
 
@@ -19,6 +21,7 @@ pub async fn download_file<'a, R: Runtime>(
     url: String,
 ) -> Result<Vec<u8>, String> {
     log::info!("Starting file download: {}", url);
+    validate_download_url(&url)?;
     // 创建具备 User-Agent 的客户端
     let client = reqwest::Client::builder()
         .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (deepseek-harness-desktop)")
@@ -33,6 +36,7 @@ pub async fn download_file<'a, R: Runtime>(
         log::error!("Download request failed: {}", e);
         e.to_string()
     })?;
+    validate_download_url(res.url().as_str())?;
 
     if !res.status().is_success() {
         log::error!("Download failed with HTTP status: {}", res.status());
@@ -66,6 +70,73 @@ pub async fn download_file<'a, R: Runtime>(
 
     log::info!("Download completed, {} bytes total", downloaded);
     Ok(buffer)
+}
+
+fn validate_download_url(url: &str) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("DOWNLOAD_URL_INVALID: {e}"))?;
+    let trusted_host = matches!(
+        parsed.host_str(),
+        Some(
+            "nodejs.org"
+                | "registry.npmjs.org"
+                | "github.com"
+                | "release-assets.githubusercontent.com"
+                | "objects.githubusercontent.com"
+        )
+    );
+    if parsed.scheme() != "https" || !trusted_host {
+        return Err(format!("DOWNLOAD_SOURCE_UNTRUSTED: {url}"));
+    }
+    Ok(())
+}
+
+/// 校验下载内容的 SHA-256，拒绝未通过完整性校验的运行时与核心包。
+pub fn verify_sha256(buffer: &[u8], expected: &str) -> Result<(), String> {
+    let expected = expected
+        .strip_prefix("sha256:")
+        .unwrap_or(expected)
+        .trim()
+        .to_ascii_lowercase();
+    if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err("INTEGRITY_METADATA_INVALID: expected SHA-256 is invalid".to_string());
+    }
+    let actual = format!("{:x}", Sha256::digest(buffer));
+    if actual != expected {
+        return Err(format!(
+            "INTEGRITY_CHECK_FAILED: SHA-256 mismatch, expected {expected}, got {actual}"
+        ));
+    }
+    Ok(())
+}
+
+/// 从 Node.js 官方同版本 SHASUMS256.txt 中读取当前平台包的摘要。
+pub async fn fetch_node_sha256(download_url: &str) -> Result<String, String> {
+    let (base, filename) = download_url.rsplit_once('/').ok_or_else(|| {
+        "INTEGRITY_METADATA_INVALID: Node.js download URL has no filename".to_string()
+    })?;
+    let checksums_url = format!("{base}/SHASUMS256.txt");
+    let checksums = reqwest::Client::builder()
+        .user_agent("deepseek-harness-desktop")
+        .timeout(Duration::from_secs(20))
+        .build()
+        .map_err(|e| format!("INTEGRITY_METADATA_FAILED: {e}"))?
+        .get(&checksums_url)
+        .send()
+        .await
+        .map_err(|e| format!("INTEGRITY_METADATA_FAILED: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("INTEGRITY_METADATA_FAILED: {e}"))?
+        .text()
+        .await
+        .map_err(|e| format!("INTEGRITY_METADATA_FAILED: {e}"))?;
+
+    checksums
+        .lines()
+        .filter_map(|line| line.split_once(char::is_whitespace))
+        .find_map(|(digest, name)| {
+            (name.trim_start_matches([' ', '*']) == filename).then(|| digest.to_string())
+        })
+        .ok_or_else(|| format!("INTEGRITY_METADATA_MISSING: no checksum for {filename}"))
 }
 
 /// 删除目录并等待 Windows 文件锁释放。
@@ -103,6 +174,67 @@ fn remove_dir_with_retry(dest: &Path) -> bool {
     false
 }
 
+fn remove_path_if_exists(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    if path.is_dir() {
+        if remove_dir_with_retry(path) {
+            Ok(())
+        } else {
+            Err(format!(
+                "INSTALL_PATH_LOCKED: cannot remove {}",
+                path.display()
+            ))
+        }
+    } else {
+        fs::remove_file(path)
+            .map_err(|e| format!("INSTALL_PATH_REMOVE_FAILED: {}: {e}", path.display()))
+    }
+}
+
+/// 将已经完整解压并验证结构的临时目录切换为正式目录；切换失败时恢复旧版本。
+fn commit_staged_install(staging: &Path, dest: &Path, backup: &Path) -> Result<(), String> {
+    // 上次若恰好在“旧目录改名为备份”后崩溃，先恢复旧版本再进行本次切换。
+    if !dest.exists() && backup.exists() {
+        fs::rename(backup, dest).map_err(|e| {
+            format!(
+                "INSTALL_RECOVERY_FAILED: {} -> {}: {e}",
+                backup.display(),
+                dest.display()
+            )
+        })?;
+    }
+    remove_path_if_exists(backup)?;
+    let had_previous = dest.exists();
+    if had_previous {
+        fs::rename(dest, backup).map_err(|e| {
+            format!(
+                "INSTALL_BACKUP_FAILED: {} -> {}: {e}",
+                dest.display(),
+                backup.display()
+            )
+        })?;
+    }
+    if let Err(e) = fs::rename(staging, dest) {
+        if had_previous {
+            let _ = fs::rename(backup, dest);
+        }
+        return Err(format!(
+            "INSTALL_COMMIT_FAILED: {} -> {}: {e}",
+            staging.display(),
+            dest.display()
+        ));
+    }
+    if had_previous {
+        if let Err(e) = remove_path_if_exists(backup) {
+            // 新版本已经切换成功，备份清理失败不应把成功安装误报为失败。
+            log::warn!("Failed to remove previous installation backup: {e}");
+        }
+    }
+    Ok(())
+}
+
 /// 确保解压文件到指定目录
 ///
 /// # 参数
@@ -123,6 +255,16 @@ pub fn ensure_extract<'a, R: Runtime>(
     use super::extractor::{extract_tgz, extract_zip};
     use super::utils::flatten_directory;
 
+    // 始终先落到同盘临时路径，全部成功后再原子切换，避免更新失败破坏旧版本。
+    let parent = dest.parent().unwrap_or(Path::new("."));
+    let leaf = dest
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("package");
+    let staging = parent.join(format!(".{leaf}.installing-{}", std::process::id()));
+    let backup = parent.join(format!(".{leaf}.backup"));
+    remove_path_if_exists(&staging)?;
+
     // 判断文件类型
     let pure_name = name.split('?').next().unwrap_or(&name).to_lowercase();
     let is_tgz = pure_name.ends_with(".tar.gz") || pure_name.ends_with(".tgz");
@@ -132,38 +274,27 @@ pub fn ensure_extract<'a, R: Runtime>(
     // 目标是文件，跳过，直接写入文件
     if !is_tgz && !is_zip {
         log::debug!("Non-compressed file, writing directly");
-        if let Some(parent) = dest.parent() {
+        if let Some(parent) = staging.parent() {
             fs::create_dir_all(parent).map_err(|e| {
                 log::error!("Failed to create parent directory: {}", e);
                 e.to_string()
             })?;
         }
-        fs::write(&dest, &buffer).map_err(|e| {
+        fs::write(&staging, &buffer).map_err(|e| {
             log::error!("Failed to write file: {}", e);
             e.to_string()
         })?;
         tracker.update(
             100.0,
             format!("已写入: {}", "100%"),
-            format!("File written: {}", dest.display()),
+            format!("File written: {}", staging.display()),
         );
+        commit_staged_install(&staging, &dest, &backup)?;
         log::info!("File write completed: {}", dest.display());
         return Ok(());
     }
 
-    // 清理并准备目标目录。Windows 上被进程加载的 DLL 在进程退出后释放句柄
-    // 需要时间，轮询等待目录可被删除；仍被占用时直接报错，避免在残留文件
-    // 上继续解压而得到“文件被锁”的误导性错误。
-    if dest.exists() {
-        log::debug!("Destination directory exists, cleaning");
-        if !remove_dir_with_retry(&dest) {
-            return Err(format!(
-                "Destination directory is still locked, cannot clean: {:?}",
-                dest
-            ));
-        }
-    }
-    fs::create_dir_all(&dest).map_err(|e| {
+    fs::create_dir_all(&staging).map_err(|e| {
         log::error!("Failed to create destination directory: {}", e);
         e.to_string()
     })?;
@@ -171,15 +302,15 @@ pub fn ensure_extract<'a, R: Runtime>(
     // 根据文件类型解压
     if is_tgz {
         log::debug!("Using tgz extractor");
-        extract_tgz(tracker, &buffer, &dest)?;
+        extract_tgz(tracker, &buffer, &staging)?;
     } else {
         log::debug!("Using zip extractor");
-        extract_zip(tracker, &buffer, &dest)?;
+        extract_zip(tracker, &buffer, &staging)?;
     }
 
     // 处理解压后的"套娃"文件夹
     log::debug!("Flattening directory structure");
-    flatten_directory(&dest).map_err(|e| {
+    flatten_directory(&staging).map_err(|e| {
         log::error!("Failed to flatten directory: {}", e);
         e.to_string()
     })?;
@@ -190,7 +321,7 @@ pub fn ensure_extract<'a, R: Runtime>(
         use super::utils::fix_recursive_permissions;
         // 递归赋予可执行权限 (755)
         log::debug!("Fixing file permissions");
-        fix_recursive_permissions(&dest).map_err(|e| {
+        fix_recursive_permissions(&staging).map_err(|e| {
             log::error!("Failed to fix permissions: {}", e);
             format!("Failed to fix permissions: {}", e)
         })?;
@@ -200,14 +331,13 @@ pub fn ensure_extract<'a, R: Runtime>(
         {
             use std::process::Command;
             log::debug!("Removing macOS quarantine attribute");
-            if let Some(path_str) = dest.to_str() {
-                let _ = Command::new("xattr")
-                    .args(["-cr", path_str])
-                    .output();
+            if let Some(path_str) = staging.to_str() {
+                let _ = Command::new("xattr").args(["-cr", path_str]).output();
             }
         }
     }
 
+    commit_staged_install(&staging, &dest, &backup)?;
     Ok(())
 }
 
@@ -219,6 +349,8 @@ const DSH_PKG_GITHUB_API: &str = "https://api.github.com/repos/hairyf/deepseek-h
 pub struct LatestDshPkg {
     pub tag: String,
     pub commit: String,
+    pub asset_url: String,
+    pub digest: String,
 }
 
 /// 查询 GitHub 上最新 Harness 发行版信息
@@ -264,9 +396,35 @@ pub async fn fetch_latest_dsh_pkg_info() -> Result<LatestDshPkg, String> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| "Missing sha in release commit response".to_string())?;
 
+    let expected_name = config::get_dsh_download_url()?
+        .rsplit('/')
+        .next()
+        .ok_or_else(|| "Missing DSH asset filename".to_string())?
+        .to_string();
+    let asset = release
+        .get("assets")
+        .and_then(|value| value.as_array())
+        .and_then(|assets| {
+            assets.iter().find(|asset| {
+                asset.get("name").and_then(|value| value.as_str()) == Some(expected_name.as_str())
+            })
+        })
+        .ok_or_else(|| format!("Missing release asset {expected_name}"))?;
+    let asset_url = asset
+        .get("browser_download_url")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| format!("Missing download URL for {expected_name}"))?;
+    let digest = asset
+        .get("digest")
+        .and_then(|value| value.as_str())
+        .filter(|value| value.starts_with("sha256:"))
+        .ok_or_else(|| format!("Missing SHA-256 digest for {expected_name}"))?;
+
     Ok(LatestDshPkg {
         tag: tag_name.to_string(),
         commit: sha.to_string(),
+        asset_url: asset_url.to_string(),
+        digest: digest.to_string(),
     })
 }
 
@@ -330,7 +488,9 @@ pub fn resolve_update(
             .find(|(_, commit)| Some(commit.as_str()) == record_commit)
         {
             Some((tag, _)) => match parse_version_from_tag(tag) {
-                Some(record_version) if record_version < latest_version => UpdateCheck::HealUpToDate,
+                Some(record_version) if record_version < latest_version => {
+                    UpdateCheck::HealUpToDate
+                }
                 // 反查到的版本与最新版本相同（或解析失败）→ 视为同版本热修
                 _ => UpdateCheck::UpdateAvailable,
             },
@@ -378,10 +538,59 @@ pub async fn fetch_dsh_pkg_tags() -> Result<Vec<(String, String)>, String> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn sha256_verification_accepts_only_matching_digest() {
+        let expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        assert!(verify_sha256(b"abc", expected).is_ok());
+        assert!(verify_sha256(b"changed", expected).is_err());
+        assert!(verify_sha256(b"abc", "not-a-digest").is_err());
+    }
+
+    #[test]
+    fn download_sources_are_https_and_allowlisted() {
+        assert!(validate_download_url("https://nodejs.org/dist/v22/file.zip").is_ok());
+        assert!(validate_download_url("https://registry.npmjs.org/pnpm/-/pnpm.tgz").is_ok());
+        assert!(validate_download_url("http://nodejs.org/dist/file.zip").is_err());
+        assert!(validate_download_url("https://example.com/file.zip").is_err());
+    }
+
+    #[test]
+    fn staged_install_replaces_previous_version_and_cleans_backup() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("dsh-atomic-install-{unique}"));
+        let dest = root.join("package");
+        let staging = root.join("package.installing");
+        let backup = root.join("package.backup");
+        fs::create_dir_all(&dest).expect("create previous install");
+        fs::create_dir_all(&staging).expect("create staged install");
+        fs::write(dest.join("version.txt"), "old").expect("write previous version");
+        fs::write(staging.join("version.txt"), "new").expect("write staged version");
+
+        commit_staged_install(&staging, &dest, &backup).expect("commit staged install");
+
+        assert_eq!(fs::read_to_string(dest.join("version.txt")).unwrap(), "new");
+        assert!(!staging.exists());
+        assert!(!backup.exists());
+
+        // 模拟上次切换在 dest -> backup 后崩溃，本次应先恢复再安全切换。
+        fs::rename(&dest, &backup).expect("simulate interrupted switch");
+        fs::create_dir_all(&staging).expect("create next staged install");
+        fs::write(staging.join("version.txt"), "next").expect("write next version");
+        commit_staged_install(&staging, &dest, &backup).expect("recover and commit");
+        assert_eq!(fs::read_to_string(dest.join("version.txt")).unwrap(), "next");
+        assert!(!backup.exists());
+        fs::remove_dir_all(root).ok();
+    }
+
     fn latest(tag: &str, commit: &str) -> LatestDshPkg {
         LatestDshPkg {
             tag: tag.to_string(),
             commit: commit.to_string(),
+            asset_url: "https://example.invalid/dsh.zip".to_string(),
+            digest: format!("sha256:{}", "0".repeat(64)),
         }
     }
 
@@ -402,7 +611,10 @@ mod tests {
 
     #[test]
     fn resolve_matching_commit_is_up_to_date() {
-        let latest = latest("dsh-0.1.0-rc.7-32054485373", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let latest = latest(
+            "dsh-0.1.0-rc.7-32054485373",
+            "6c659bb2636b3ad396a204c4c6ff110276fa3a09",
+        );
         let decision = resolve_update(
             Some("6c659bb2636b3ad396a204c4c6ff110276fa3a09"),
             Some("dsh-0.1.0-rc.7-32054485373"),
@@ -415,7 +627,10 @@ mod tests {
 
     #[test]
     fn resolve_different_installed_version_is_update() {
-        let latest = latest("dsh-0.1.0-rc.7-32054485373", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let latest = latest(
+            "dsh-0.1.0-rc.7-32054485373",
+            "6c659bb2636b3ad396a204c4c6ff110276fa3a09",
+        );
         let decision = resolve_update(
             Some("564019027fd9469991aef6e57bb0a96325491c4e"),
             Some("dsh-0.1.0-rc.6-31773193667"),
@@ -429,7 +644,10 @@ mod tests {
     #[test]
     fn resolve_same_version_hotfix_is_update() {
         // 记录正确（与文件一致），最新 release 是同版本热修：应提示更新
-        let latest = latest("dsh-0.1.0-rc.6-31773193667", "564019027fd9469991aef6e57bb0a96325491c4e");
+        let latest = latest(
+            "dsh-0.1.0-rc.6-31773193667",
+            "564019027fd9469991aef6e57bb0a96325491c4e",
+        );
         let decision = resolve_update(
             Some("995e261e117617780dc50db16c70d445255978fd"),
             Some("dsh-0.1.0-rc.6-31762761461"),
@@ -443,7 +661,10 @@ mod tests {
     #[test]
     fn resolve_stale_record_behind_files_heals() {
         // 用户现场：记录停留在 rc.6，文件已是 rc.7 → 修正记录、免打扰
-        let latest = latest("dsh-0.1.0-rc.7-32054485373", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let latest = latest(
+            "dsh-0.1.0-rc.7-32054485373",
+            "6c659bb2636b3ad396a204c4c6ff110276fa3a09",
+        );
         let decision = resolve_update(
             Some("564019027fd9469991aef6e57bb0a96325491c4e"),
             Some("dsh-0.1.0-rc.6-31773193667"),
@@ -457,7 +678,10 @@ mod tests {
     #[test]
     fn resolve_legacy_record_without_tag_heals_via_tags_lookup() {
         // 老记录没有 tag：反查 tags 列表发现记录版本低于文件版本 → 修正
-        let latest = latest("dsh-0.1.0-rc.7-32054485373", "6c659bb2636b3ad396a204c4c6ff110276fa3a09");
+        let latest = latest(
+            "dsh-0.1.0-rc.7-32054485373",
+            "6c659bb2636b3ad396a204c4c6ff110276fa3a09",
+        );
         let tags = vec![(
             "dsh-0.1.0-rc.6-31773193667".to_string(),
             "564019027fd9469991aef6e57bb0a96325491c4e".to_string(),
@@ -475,7 +699,10 @@ mod tests {
     #[test]
     fn resolve_legacy_same_version_still_updates() {
         // 老记录无 tag 但反查为同版本热修：仍应提示
-        let latest = latest("dsh-0.1.0-rc.6-31773193667", "564019027fd9469991aef6e57bb0a96325491c4e");
+        let latest = latest(
+            "dsh-0.1.0-rc.6-31773193667",
+            "564019027fd9469991aef6e57bb0a96325491c4e",
+        );
         let tags = vec![(
             "dsh-0.1.0-rc.6-31762761461".to_string(),
             "995e261e117617780dc50db16c70d445255978fd".to_string(),

--- a/src-tauri/src/service/download/mod.rs
+++ b/src-tauri/src/service/download/mod.rs
@@ -6,8 +6,8 @@ mod utils;
 
 // 导出公共接口
 pub use core::{
-    download_file, ensure_extract, fetch_dsh_pkg_tags, fetch_latest_dsh_pkg_info, resolve_update,
-    LatestDshPkg, UpdateCheck,
+    download_file, ensure_extract, fetch_dsh_pkg_tags, fetch_latest_dsh_pkg_info,
+    fetch_node_sha256, resolve_update, verify_sha256, LatestDshPkg, UpdateCheck,
 };
 pub use installable::{Dsh, Installable, Nodejs, Pnpm};
 pub use progress::ProgressTracker;

--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -23,7 +23,10 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
 
     // 单次读取预设并构建查找表，提升算法效率至 O(N)
     let presets = load_presets(app_handle);
-    let preset_map: HashMap<&str, &str> = presets.iter().map(|p| (p.id.as_str(), p.spec.as_str())).collect();
+    let preset_map: HashMap<&str, &str> = presets
+        .iter()
+        .map(|p| (p.id.as_str(), p.spec.as_str()))
+        .collect();
 
     let mut specs = Vec::with_capacity(ids.len());
     for id in ids {
@@ -53,7 +56,7 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
     ensure_pnpm(app_handle, &window).await?;
 
     // 安装前停止运行中的服务，避免资源冲突
-    if workflow::utils::is_dsh_running(config::get_store_dat_setting(app_handle).port).await {
+    if workflow::has_owned_process() {
         log::info!("Stopping running harness service before installing preinstall plugins");
         if let Err(e) = workflow::stop(app_handle.clone()).await {
             log::warn!("failed to stop harness before preinstall: {e}");
@@ -63,7 +66,12 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
     // 构建环境变量
     let bin_dir = cli::get_bin_dir(app_handle);
     let mut envs = HashMap::from([
-        ("DSH_HOME".to_string(), config::get_dsh_data_path(app_handle).to_string_lossy().into_owned()),
+        (
+            "DSH_HOME".to_string(),
+            config::get_dsh_data_path(app_handle)
+                .to_string_lossy()
+                .into_owned(),
+        ),
         ("DSH_TELEMETRY_DISABLED".to_string(), "1".to_string()),
         ("NO_COLOR".to_string(), "1".to_string()),
     ]);
@@ -72,7 +80,9 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
     if let Some(node_dir) = node.parent() {
         paths.push(node_dir.to_path_buf());
     }
-    paths.extend(std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()));
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
 
     if let Ok(joined) = std::env::join_paths(paths) {
         envs.insert("PATH".to_string(), joined.to_string_lossy().into_owned());
@@ -94,7 +104,9 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
     let exit_code = run_plugin_process(&node, &args, &cwd, &envs, &window).await?;
     if exit_code != 0 {
         log::error!("dsh plugin install failed with exit code {exit_code}");
-        return Err(format!("PREINSTALL_FAILED: dsh plugin exited with code {exit_code}"));
+        return Err(format!(
+            "PREINSTALL_FAILED: dsh plugin exited with code {exit_code}"
+        ));
     }
 
     // Windows 极简模式专项修复
@@ -127,6 +139,8 @@ async fn ensure_pnpm(app_handle: &AppHandle, window: &WebviewWindow) -> Result<(
     let buffer = download::download_file(&tracker, url)
         .await
         .map_err(|e| format!("PNPM_DOWNLOAD_FAILED: {e}"))?;
+    download::verify_sha256(&buffer, config::PNPM_SHA256)
+        .map_err(|e| format!("PNPM_INTEGRITY_FAILED: {e}"))?;
     let dest = download::Pnpm.get_install_path(app_handle);
 
     download::ensure_extract(&tracker, name, buffer, dest)

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -6,98 +6,96 @@ pub(crate) mod win_spawn;
 
 use crate::config;
 use crate::service::download;
-use crate::service::workflow::utils::{is_dsh_running, is_port_in_use, spawn_output_readers};
+use crate::service::workflow::utils::{is_port_in_use, spawn_output_readers};
 use std::collections::HashMap;
-use std::fs;
-// Path 仅被 Windows 专属的 kill_dsh_processes 使用，Unix 构建下不引入
-#[cfg(windows)]
-use std::path::Path;
-use std::process::{Command, Stdio};
 #[cfg(windows)]
 use std::ffi::OsString;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::fs;
+use std::process::{Command, Stdio};
+#[cfg(windows)]
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use tauri::Manager;
 
 /// 启动守卫：并发调用 `launch` 时只允许一个真正拉起 dsh 进程
 static LAUNCH_GUARD: AtomicBool = AtomicBool::new(false);
+/// 当前进程内由桌面端创建的 Harness 根进程 PID；0 表示没有持有的实例。
+static OWNED_PROCESS_ID: AtomicU32 = AtomicU32::new(0);
+/// Windows 进程句柄用于确认 PID 仍指向原进程，消除 PID 复用误杀窗口。
+#[cfg(windows)]
+static OWNED_PROCESS_HANDLE: AtomicUsize = AtomicUsize::new(0);
 
-/// 强制结束占用指定端口的进程（用于停止服务或清理僵尸进程）
-fn kill_port_holder(port: u16) {
-    #[cfg(unix)]
-    {
-        // 使用 lsof 找到占用端口的进程并强制结束
-        let _ = Command::new("sh")
-            .arg("-c")
-            .arg(format!("lsof -ti:{} | xargs kill -9", port))
-            .output();
+struct LaunchGuard;
+
+impl Drop for LaunchGuard {
+    fn drop(&mut self) {
+        LAUNCH_GUARD.store(false, Ordering::SeqCst);
+    }
+}
+
+/// 从起始端口向上查找第一个空闲端口，绝不结束未知的端口占用进程。
+fn find_available_port(start: u16) -> Result<u16, String> {
+    let mut port = start;
+    loop {
+        if !is_port_in_use(port) {
+            return Ok(port);
+        }
+        log::warn!("Port {port} is occupied, trying the next port");
+        port = port.checked_add(1).ok_or_else(|| {
+            "PORT_EXHAUSTED: no available TCP port after the configured port".to_string()
+        })?;
+    }
+}
+
+/// 只结束本应用当前进程创建并仍持有的 Harness 进程树。
+fn terminate_owned_process() {
+    let pid = OWNED_PROCESS_ID.swap(0, Ordering::SeqCst);
+    if pid == 0 {
+        return;
     }
 
     #[cfg(windows)]
     {
-        // 使用 PowerShell 找到占用端口的进程，再通过 taskkill /T 结束整个进程树。
-        // dsh 会派生 node worker 子进程，若只杀端口占用者，子进程仍会锁定原生
-        // 模块 DLL（如 sharp 的 libvips-42.dll），导致重新解压失败。
-        let ps_cmd = format!(
-            "$ids = Get-NetTCPConnection -LocalPort {} -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique; foreach ($id in $ids) {{ taskkill /PID $id /T /F 2>$null }}",
-            port
-        );
-
-        let mut cmd = Command::new("powershell");
-        // 使用 -WindowStyle Hidden 和 -NoProfile -NonInteractive 确保不显示窗口
-        cmd.args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-WindowStyle",
-            "Hidden",
-            "-Command",
-            &ps_cmd,
-        ]);
-
-        // 隐藏 PowerShell 窗口，避免弹出黑色控制台窗口
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::WaitForSingleObject;
+        const WAIT_TIMEOUT_CODE: u32 = 0x0000_0102;
+        let handle_value = OWNED_PROCESS_HANDLE.swap(0, Ordering::SeqCst);
+        if handle_value == 0 {
+            return;
+        }
+        let handle = handle_value as windows_sys::Win32::Foundation::HANDLE;
+        // 真实句柄已结束说明 PID 可能已复用，此时绝不调用 taskkill。
+        if unsafe { WaitForSingleObject(handle, 0) } != WAIT_TIMEOUT_CODE {
+            unsafe { CloseHandle(handle) };
+            return;
+        }
+        let mut cmd = Command::new("taskkill");
+        cmd.args(["/PID", &pid.to_string(), "/T", "/F"]);
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-
-        // 重定向 stdout 和 stderr 到空，进一步确保不显示窗口
+        cmd.creation_flags(0x08000000);
         cmd.stdout(Stdio::null());
         cmd.stderr(Stdio::null());
-
         if let Err(e) = cmd.output() {
-            log::error!("Failed to kill port holder: {}", e);
+            log::error!("Failed to stop owned Harness process {pid}: {e}");
         }
+        unsafe {
+            WaitForSingleObject(handle, 5_000);
+            CloseHandle(handle);
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        // Harness 根进程启动在独立进程组中，负 PID 只作用于该进程树。
+        let group = format!("-{pid}");
+        let _ = Command::new("kill").args(["-TERM", "--", &group]).output();
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let _ = Command::new("kill").args(["-KILL", "--", &group]).output();
     }
 }
 
-/// 结束本应用（AppData 目录）下由 dsh 拉起的 node 进程。
-///
-/// sharp 等原生模块 DLL 会被 node 及其子进程加载并锁定。服务崩溃或失去响应时
-/// HTTP 探测不到，但这些进程仍持有 DLL；仅杀端口占用者会漏掉不再监听端口的
-/// 子进程。这里通过可执行文件路径或命令行是否位于 AppData 目录来识别。
-#[cfg(windows)]
-fn kill_dsh_processes(base_dir: &Path) {
-    let base = base_dir.to_string_lossy().to_string();
-    let ps_cmd = format!(
-        "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\" | Where-Object {{ ($_.ExecutablePath -like '{base}\\*') -or ($_.CommandLine -like '*{base}\\*') }} | ForEach-Object {{ Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }}"
-    );
-
-    let mut cmd = Command::new("powershell");
-    cmd.args([
-        "-NoProfile",
-        "-NonInteractive",
-        "-WindowStyle",
-        "Hidden",
-        "-Command",
-        &ps_cmd,
-    ]);
-
-    // 隐藏 PowerShell 窗口，避免弹出黑色控制台窗口
-    use std::os::windows::process::CommandExt;
-    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-    cmd.stdout(Stdio::null());
-    cmd.stderr(Stdio::null());
-
-    if let Err(e) = cmd.output() {
-        log::error!("Failed to kill dsh processes: {}", e);
-    }
+pub fn has_owned_process() -> bool {
+    OWNED_PROCESS_ID.load(Ordering::SeqCst) != 0
 }
 
 /// 检测并启动 Harness 服务
@@ -118,18 +116,8 @@ pub async fn start(app_handle: tauri::AppHandle) -> Result<(), String> {
         return Ok(());
     }
 
-    log::debug!("Checking Harness running status");
-    let port_in_use = is_port_in_use(setting.port);
-    let dsh_running = is_dsh_running(setting.port).await;
-
-    if port_in_use && !dsh_running {
-        log::info!("Harness is not running, but port is in use, stopping harness");
-        stop(app_handle.clone()).await?;
-        return Ok(());
-    }
-
-    if dsh_running {
-        log::info!("Harness is already running");
+    if has_owned_process() {
+        log::info!("Owned Harness process is already running");
         status::set_status(status::Status::Running);
         status::emit_status(&app_handle);
         return Ok(());
@@ -159,7 +147,7 @@ pub async fn restart(app_handle: tauri::AppHandle) -> Result<(), String> {
 
 /// 启动 Harness 服务进程
 pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
-    let setting = config::get_store_dat_setting(&app_handle);
+    let mut setting = config::get_store_dat_setting(&app_handle);
     let node_binary_path = config::get_node_binary_path(&app_handle);
     let dsh_binary_path = config::get_dsh_binary_path(&app_handle);
 
@@ -175,28 +163,29 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     }
 
     // 避免重复启动（配合启动守卫，确保并发调用只拉起一个进程）
-    if is_dsh_running(setting.port).await {
-        log::info!("Harness is already running, skipping launch");
+    if has_owned_process() {
+        log::info!("Owned Harness process is already running, skipping launch");
         return Ok(());
     }
-    if LAUNCH_GUARD.swap(true, Ordering::SeqCst) {
+    if LAUNCH_GUARD
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
         log::info!("Harness launch already in progress, skipping");
         return Ok(());
     }
+    let _launch_guard = LaunchGuard;
 
-    // 端口被占用但服务未响应：先清理僵尸进程，避免 dsh EADDRINUSE 崩溃
-    if is_port_in_use(setting.port) {
-        log::warn!(
-            "Port {} is occupied but harness is not responding, cleaning up",
-            setting.port
+    // 端口冲突时从当前值开始逐个递增，并持久化最终选择供所有调用方复用。
+    let available_port = find_available_port(setting.port)?;
+    if available_port != setting.port {
+        log::info!(
+            "Harness port changed from {} to {} because the configured port is occupied",
+            setting.port,
+            available_port
         );
-        kill_port_holder(setting.port);
-        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
-    }
-
-    #[cfg(unix)]
-    {
-        let _ = Command::new("pkill").arg("-9").arg("node").output();
+        setting.port = available_port;
+        config::set_store_dat_setting(&app_handle, setting.clone());
     }
 
     // 构造环境变量：隔离的 $DSH_HOME + 隐私默认（关闭遥测）
@@ -209,7 +198,10 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
         log::warn!("win32 terminal support apply failed: {e}");
     }
     let mut envs: HashMap<String, String> = HashMap::new();
-    envs.insert("DSH_HOME".to_string(), dsh_home.to_string_lossy().into_owned());
+    envs.insert(
+        "DSH_HOME".to_string(),
+        dsh_home.to_string_lossy().into_owned(),
+    );
     envs.insert("DSH_TELEMETRY_DISABLED".to_string(), "1".to_string());
     envs.insert("NO_COLOR".to_string(), "1".to_string());
     envs.insert("DSH_WEB_PORT".to_string(), setting.port.to_string());
@@ -256,16 +248,41 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                 OsString::from("--port"),
                 OsString::from(setting.port.to_string()),
             ];
-            win_spawn::spawn_with_hidden_console(
+            win_spawn::spawn_with_hidden_console_owned(
                 &node_binary_path,
                 &args,
                 Some(&config::get_dsh_install_path(&app_handle)),
                 &envs,
             )
-            .map(|(stdout, stderr)| (Some(stdout), Some(stderr)))
+            .map(|(stdout, stderr, pid, handle)| {
+                OWNED_PROCESS_ID.store(pid, Ordering::SeqCst);
+                // 持有真实进程句柄直到退出；退出后仅在 PID 仍匹配时清空，避免复用。
+                let handle_value = handle as usize;
+                OWNED_PROCESS_HANDLE.store(handle_value, Ordering::SeqCst);
+                std::thread::spawn(move || unsafe {
+                    use windows_sys::Win32::Foundation::CloseHandle;
+                    use windows_sys::Win32::System::Threading::{WaitForSingleObject, INFINITE};
+                    let process_handle = handle_value as windows_sys::Win32::Foundation::HANDLE;
+                    WaitForSingleObject(process_handle, INFINITE);
+                    let _ = OWNED_PROCESS_ID.compare_exchange(
+                        pid,
+                        0,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    );
+                    let owns_handle = OWNED_PROCESS_HANDLE
+                        .compare_exchange(handle_value, 0, Ordering::SeqCst, Ordering::SeqCst)
+                        .is_ok();
+                    if owns_handle {
+                        CloseHandle(process_handle);
+                    }
+                });
+                (Some(stdout), Some(stderr), pid)
+            })
         }
         #[cfg(not(windows))]
         {
+            use std::os::unix::process::CommandExt;
             let mut cmd = Command::new(&node_binary_path);
             cmd.arg(&dsh_binary_path)
                 .arg("--profile")
@@ -280,37 +297,40 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                 .stdin(Stdio::null())
                 // 使用管道捕获输出，以便在子线程中读取
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
+                .stderr(Stdio::piped())
+                // 独立进程组让停止操作只影响 Harness 及其后代。
+                .process_group(0);
             cmd.spawn().map(|mut child| {
+                let pid = child.id();
                 let stdout = child.stdout.take();
                 let stderr = child.stderr.take();
-                (stdout, stderr)
+                OWNED_PROCESS_ID.store(pid, Ordering::SeqCst);
+                std::thread::spawn(move || {
+                    let _ = child.wait();
+                    let _ = OWNED_PROCESS_ID.compare_exchange(
+                        pid,
+                        0,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    );
+                });
+                (stdout, stderr, pid)
             })
         }
     };
 
     match spawn_result {
-        Ok((stdout, stderr)) => {
-            log::info!("Harness process started successfully");
+        Ok((stdout, stderr, pid)) => {
+            log::info!(
+                "Harness process started successfully: pid={pid}, port={}",
+                setting.port
+            );
             spawn_output_readers(stdout, stderr, log_path);
-
-            // 后台等待 dsh 就绪后释放启动守卫，覆盖启动窗口内的并发调用
-            tauri::async_runtime::spawn(async move {
-                for _ in 0..15 {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    if is_dsh_running(setting.port).await {
-                        break;
-                    }
-                }
-                LAUNCH_GUARD.store(false, Ordering::SeqCst);
-            });
-
             Ok(())
         }
         Err(e) => {
-            LAUNCH_GUARD.store(false, Ordering::SeqCst);
             log::error!("Failed to start process: {}", e);
-            Err(format!("Failed to start process: {}", e))
+            Err(format!("PROCESS_START_FAILED: {e}"))
         }
     }
 }
@@ -318,16 +338,9 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
 /// 停止 Harness 服务
 pub async fn stop(app_handle: tauri::AppHandle) -> Result<(), String> {
     log::info!("Stopping Harness service...");
-    let port = config::get_store_dat_setting(&app_handle).port;
-
-    // 重置启动守卫，确保后续 launch 可以重新拉起
+    // 重置启动守卫，确保后续 launch 可以重新拉起；仅结束持有的根进程树。
     LAUNCH_GUARD.store(false, Ordering::SeqCst);
-    kill_port_holder(port);
-
-    // 连带清理 dsh 派生的 node 子进程：它们可能不再监听端口，
-    // 但仍把原生模块 DLL 加载在内存中（Windows 文件锁）
-    #[cfg(windows)]
-    kill_dsh_processes(&config::get_base_dir(&app_handle));
+    terminate_owned_process();
 
     // 给系统一点时间释放端口 (重要！)
     tokio::time::sleep(std::time::Duration::from_millis(800)).await;
@@ -339,16 +352,9 @@ pub async fn stop(app_handle: tauri::AppHandle) -> Result<(), String> {
 
 /// 应用退出时同步回收 Harness 进程。
 ///
-/// 退出路径上不更新状态、不做异步等待，仅强制结束端口占用者及其进程树，
-/// 以及 AppData 目录下的 node 进程，避免残留进程把原生模块 DLL 锁在内存，
-/// 导致下次启动重新解压失败。
-/// Windows 下需要 app_handle 定位 AppData 目录来清理进程树；
-/// Unix 构建不使用该参数，允许未使用告警以保持签名一致
-#[cfg_attr(not(windows), allow(unused_variables))]
-pub fn stop_on_exit(app_handle: tauri::AppHandle, port: u16) {
-    kill_port_holder(port);
-    #[cfg(windows)]
-    kill_dsh_processes(&config::get_base_dir(&app_handle));
+/// 退出路径上不更新状态、不做异步等待，只结束当前应用持有的 Harness 进程树。
+pub fn stop_on_exit(_app_handle: tauri::AppHandle, _port: u16) {
+    terminate_owned_process();
 }
 
 /// 安装环境（Node.js 运行时 + 打包的 Harness 发行版）
@@ -358,20 +364,13 @@ pub async fn install(
 ) -> Result<(), String> {
     log::info!("Starting installation process");
 
-    // 安装前先停止正在运行的 Harness 服务：运行中的 node 进程会把
+    // 安装前先停止本应用持有的 Harness 服务：运行中的 node 进程会把
     // 原生模块 DLL（如 sharp 的 libvips-42.dll）加载进内存并锁住文件，
     // 不停止的话覆盖解压必然失败（Windows os error 32）。
-    // 注意不能只依赖 HTTP 探测：服务崩溃/失去响应时探测不到，但 node
-    // 进程可能仍存活并持有 DLL，因此探测不到时也要强制清理。
-    if is_dsh_running(config::get_store_dat_setting(app_handle).port).await {
+    // 进程归属以启动时记录的 PID 为准，不根据端口结束未知程序。
+    if has_owned_process() {
         log::info!("Stopping running Harness service before installation");
         stop(app_handle.clone()).await?;
-    } else {
-        log::warn!("Harness service not responding, force cleaning dsh processes");
-        kill_port_holder(config::get_store_dat_setting(app_handle).port);
-        #[cfg(windows)]
-        kill_dsh_processes(&config::get_base_dir(app_handle));
-        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
     }
 
     let window = app_handle
@@ -380,8 +379,11 @@ pub async fn install(
     log::debug!("Main window obtained");
     // 3 个任务 × 下载/解压 2 个阶段
     let mut tracker = download::ProgressTracker::new(&window, 6);
-    let tasks: Vec<Box<dyn download::Installable>> =
-        vec![Box::new(download::Nodejs), Box::new(download::Dsh), Box::new(download::Pnpm)];
+    let tasks: Vec<Box<dyn download::Installable>> = vec![
+        Box::new(download::Nodejs),
+        Box::new(download::Dsh),
+        Box::new(download::Pnpm),
+    ];
     log::info!("Task list created, {} tasks total", tasks.len());
 
     for (index, task) in tasks.iter().enumerate() {
@@ -403,17 +405,50 @@ pub async fn install(
         log::info!("Task {} not installed, starting installation", index + 1);
 
         // 1. 下载
-        tracker.start_phase("download", &format!("{} {}", config::i18n::t("install.downloading"), task.title()));
-        let url = task.get_download_url()?;
+        tracker.start_phase(
+            "download",
+            &format!(
+                "{} {}",
+                config::i18n::t("install.downloading"),
+                task.title()
+            ),
+        );
+        let url = if index == 1 {
+            dsh_latest
+                .as_ref()
+                .map(|info| info.asset_url.clone())
+                .ok_or_else(|| {
+                    "DSH_INTEGRITY_UNAVAILABLE: trusted release metadata is required for installation"
+                        .to_string()
+                })?
+        } else {
+            task.get_download_url()?
+        };
         log::debug!("Download URL: {}", url);
         let name = url.split('/').next_back().unwrap().to_string();
         log::debug!("File name: {}", name);
         let buffer = download::download_file(&tracker, url).await?;
         log::info!("Download completed, file size: {} bytes", buffer.len());
+        let expected_digest = match index {
+            0 => download::fetch_node_sha256(task.get_download_url()?.as_str()).await?,
+            1 => dsh_latest
+                .as_ref()
+                .map(|info| info.digest.clone())
+                .ok_or_else(|| {
+                    "DSH_INTEGRITY_UNAVAILABLE: trusted release digest is required".to_string()
+                })?,
+            2 => config::PNPM_SHA256.to_string(),
+            _ => return Err("INSTALL_TASK_INVALID: unknown install task".to_string()),
+        };
+        download::verify_sha256(&buffer, &expected_digest)?;
+        log::info!("Download integrity verified for task {}", index + 1);
         tracker.end_phase();
 
         // 2. 解压
-        tracker.start_phase("extract", &format!("{} {}", config::i18n::t("install.extracting"), task.title()));
+        tracker.start_phase(
+            "extract",
+            &format!("{} {}", config::i18n::t("install.extracting"), task.title()),
+        );
         let dest = task.get_install_path(app_handle);
         log::debug!("Installation path: {:?}", dest);
         download::ensure_extract(&tracker, name, buffer, dest)?;
@@ -441,6 +476,9 @@ pub async fn install(
 
 /// 健康检查（通过 Rust 代理，避免 WebView CORS 问题）
 pub async fn proxy_health_check(port: u16) -> Result<String, String> {
+    if !has_owned_process() {
+        return Err("HARNESS_NOT_OWNED: no Harness process is owned by this app".to_string());
+    }
     let client = reqwest::Client::builder()
         .timeout(config::HEALTH_CHECK_TIMEOUT)
         .build()
@@ -467,4 +505,19 @@ pub async fn proxy_health_check(port: u16) -> Result<String, String> {
         }
     }
     Err("HARNESS_NOT_READY: Harness service is not ready".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[test]
+    fn occupied_port_advances_to_a_free_port() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind occupied test port");
+        let occupied = listener.local_addr().expect("read occupied port").port();
+        let selected = find_available_port(occupied).expect("find next free port");
+        assert!(selected > occupied);
+        assert!(!is_port_in_use(selected));
+    }
 }

--- a/src-tauri/src/service/workflow/utils.rs
+++ b/src-tauri/src/service/workflow/utils.rs
@@ -1,5 +1,5 @@
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{SocketAddr, TcpStream};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
@@ -33,13 +33,9 @@ pub async fn is_dsh_running(port: u16) -> bool {
 
 /// 检查指定端口是否被占用（通过尝试连接来判断）
 pub fn is_port_in_use(port: u16) -> bool {
-    // 尝试连接到端口，设置较短的超时时间（100ms）以快速检测
-    let addr: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap_or_else(|_| {
-        // 如果解析失败，返回一个默认地址（虽然不太可能发生）
-        "127.0.0.1:0".parse().unwrap()
-    });
-
-    TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok()
+    // 以实际绑定结果判断，能够识别“已绑定但尚未 listen”的占用状态。
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    TcpListener::bind(addr).is_err()
 }
 
 /// 在独立线程中读取子进程的输出，同时写入日志文件
@@ -48,11 +44,8 @@ pub fn is_port_in_use(port: u16) -> bool {
 /// - `stdout`: 子进程的标准输出
 /// - `stderr`: 子进程的标准错误输出
 /// - `log_path`: 前端日志面板读取的日志文件
-pub fn spawn_output_readers<R1, R2>(
-    stdout: Option<R1>,
-    stderr: Option<R2>,
-    log_path: PathBuf,
-) where
+pub fn spawn_output_readers<R1, R2>(stdout: Option<R1>, stderr: Option<R2>, log_path: PathBuf)
+where
     R1: Read + Send + 'static,
     R2: Read + Send + 'static,
 {

--- a/src-tauri/src/service/workflow/win_spawn.rs
+++ b/src-tauri/src/service/workflow/win_spawn.rs
@@ -27,14 +27,15 @@ use windows_sys::Win32::Storage::FileSystem::{
 };
 use windows_sys::Win32::System::Pipes::CreatePipe;
 use windows_sys::Win32::System::Threading::{
-    CreateProcessW, STARTF_USESHOWWINDOW, STARTF_USESTDHANDLES, STARTUPINFOW, CREATE_NEW_CONSOLE,
-    CREATE_UNICODE_ENVIRONMENT, PROCESS_INFORMATION,
+    CreateProcessW, GetProcessId, CREATE_NEW_CONSOLE, CREATE_UNICODE_ENVIRONMENT,
+    PROCESS_INFORMATION, STARTF_USESHOWWINDOW, STARTF_USESTDHANDLES, STARTUPINFOW,
 };
 use windows_sys::Win32::UI::WindowsAndMessaging::SW_HIDE;
 
 /// 以隐藏控制台方式启动 `program`，返回其 stdout / stderr 管道读取端。
 ///
 /// `envs` 中的键值会覆盖当前进程环境变量后传给子进程。
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn spawn_with_hidden_console(
     program: &Path,
     args: &[OsString],
@@ -47,6 +48,28 @@ pub fn spawn_with_hidden_console(
         CloseHandle(handle);
     }
     Ok((stdout, stderr))
+}
+
+/// 启动由桌面端持有的 Harness 进程，同时返回 PID 与进程句柄。
+///
+/// PID 用于只结束本应用创建的进程树；句柄由调用方等待并关闭，避免进程退出后
+/// PID 被系统复用时误伤其他程序。
+pub fn spawn_with_hidden_console_owned(
+    program: &Path,
+    args: &[OsString],
+    current_dir: Option<&Path>,
+    envs: &HashMap<String, String>,
+) -> io::Result<(File, File, u32, HANDLE)> {
+    let (stdout, stderr, handle) =
+        spawn_with_hidden_console_tracked(program, args, current_dir, envs)?;
+    let pid = unsafe { GetProcessId(handle) };
+    if pid == 0 {
+        unsafe {
+            CloseHandle(handle);
+        }
+        return Err(io::Error::last_os_error());
+    }
+    Ok((stdout, stderr, pid, handle))
 }
 
 /// 同 [`spawn_with_hidden_console`]，但额外返回进程句柄，供调用方等待进程
@@ -210,11 +233,7 @@ fn build_command_line(program: &Path, args: &[OsString]) -> Vec<u16> {
 
 /// 按 MSVC 规则为命令行参数加引号并转义反斜杠/双引号
 fn quote_arg(arg: &str) -> String {
-    if !arg.is_empty()
-        && !arg
-            .chars()
-            .any(|c| matches!(c, ' ' | '\t' | '"'))
-    {
+    if !arg.is_empty() && !arg.chars().any(|c| matches!(c, ' ' | '\t' | '"')) {
         return arg.to_string();
     }
 
@@ -251,7 +270,7 @@ fn quote_arg(arg: &str) -> String {
 mod tests {
     use super::*;
 
-        #[test]
+    #[test]
     fn env_key_match_is_case_insensitive() {
         // Windows 用户环境里的键通常是 `Path`：用 `PATH` 覆盖必须替换而不是追加
         let mut vars: Vec<(OsString, OsString)> = vec![
@@ -281,7 +300,8 @@ mod tests {
         let mut envs = HashMap::new();
         envs.insert("DSH_WIN_SPAWN_TEST".to_string(), "hello world".to_string());
 
-        let workdir = std::env::temp_dir().join(format!("dsh_win_spawn_test_{}", std::process::id()));
+        let workdir =
+            std::env::temp_dir().join(format!("dsh_win_spawn_test_{}", std::process::id()));
         std::fs::create_dir_all(&workdir).unwrap();
 
         let args = vec![
@@ -344,7 +364,8 @@ mod tests {
     #[test]
     fn grandchildren_inherit_hidden_console() {
         let node = find_node_on_path().expect("node.exe not found for the test");
-        let ps1 = std::env::temp_dir().join(format!("dsh_console_check_{}.ps1", std::process::id()));
+        let ps1 =
+            std::env::temp_dir().join(format!("dsh_console_check_{}.ps1", std::process::id()));
         std::fs::write(
             &ps1,
             "$code='using System;using System.Runtime.InteropServices;public class C{[DllImport(\"kernel32.dll\")]public static extern IntPtr GetConsoleWindow();[DllImport(\"user32.dll\")]public static extern bool IsWindowVisible(IntPtr h);}';Add-Type -TypeDefinition $code;$h=[C]::GetConsoleWindow();if($h -eq [IntPtr]::Zero){'NO_CONSOLE'}else{'HAS_CONSOLE_VISIBLE='+[C]::IsWindowVisible($h)}",
@@ -359,13 +380,8 @@ mod tests {
         );
 
         let args = vec![OsString::from("-e"), OsString::from(node_js)];
-        let (stdout, stderr) = spawn_with_hidden_console(
-            &node,
-            &args,
-            None,
-            &HashMap::new(),
-        )
-        .unwrap();
+        let (stdout, stderr) =
+            spawn_with_hidden_console(&node, &args, None, &HashMap::new()).unwrap();
 
         let mut output = String::new();
         let mut error = String::new();

--- a/src-tauri/src/task/tick_check_dsh_process/mod.rs
+++ b/src-tauri/src/task/tick_check_dsh_process/mod.rs
@@ -11,7 +11,10 @@ pub async fn trigger(app_handle: AppHandle) -> Result<(), Box<dyn std::error::Er
     let current_status = status::get_status();
 
     let port = crate::config::get_store_dat_setting(&app_handle).port;
-    let is_dsh_running = utils::is_dsh_running(port).await;
+    // 只有本应用仍持有启动 PID 时才接受 HTTP 健康结果，避免把同端口的
+    // 其他本地 Web 服务误识别成 Harness。
+    let is_dsh_running =
+        crate::service::workflow::has_owned_process() && utils::is_dsh_running(port).await;
     log::trace!("DSH status check: dsh_running={}", is_dsh_running);
 
     // 只有当当前状态为运行中时，才更新状态

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,7 +11,8 @@
   },
   "app": {
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; frame-src http://127.0.0.1:*",
+      "devCsp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:1420 ws://localhost:1421; img-src 'self' asset: http://asset.localhost data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; frame-src http://127.0.0.1:*"
     }
   },
   "bundle": {

--- a/src/components/harness-webview.tsx
+++ b/src/components/harness-webview.tsx
@@ -78,7 +78,7 @@ export default function HarnessWebview() {
                 ref={iframeRef}
                 className="block h-full w-full border-none bg-load-bg"
                 src={iframeSrc}
-                allow="clipboard-read; clipboard-write; camera; microphone; geolocation; display-capture; autoplay; encrypted-media; fullscreen; notifications *"
+                allow="clipboard-read; clipboard-write; fullscreen"
                 sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads allow-storage-access-by-user-activation"
                 onLoad={harness.markIframeLoaded}
                 onError={harness.markIframeError}

--- a/src/hooks/use-iframe-shim.ts
+++ b/src/hooks/use-iframe-shim.ts
@@ -4,6 +4,7 @@ import { listen } from '@tauri-apps/api/event'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { useEffect } from 'react'
 import { useEvent, useInterval, useMountedState } from 'react-use'
+import { getIframeOrigin } from '@/utils/iframe-origin'
 
 interface NativeNotificationMessage {
   source?: 'dsh-notification-bridge'
@@ -26,6 +27,10 @@ export function useIframeShim(iframeRef: RefObject<HTMLIFrameElement | null>) {
     }
     // 只接受 DSH 直接 iframe 发来的消息；不兼容多层嵌套 iframe。
     if (event.source !== iframeRef.current?.contentWindow) {
+      return
+    }
+    const iframeOrigin = getIframeOrigin(iframeRef)
+    if (!iframeOrigin || event.origin !== iframeOrigin) {
       return
     }
     if (data.type !== 'dsh://native-notification') {
@@ -51,6 +56,9 @@ export function useIframeShim(iframeRef: RefObject<HTMLIFrameElement | null>) {
       'dsh-notification-clicked',
       (event) => {
         const payload = event.payload
+        const iframeOrigin = getIframeOrigin(iframeRef)
+        if (!iframeOrigin)
+          return
         iframeRef.current?.contentWindow?.postMessage(
           {
             type: 'dsh://focus-session',
@@ -58,7 +66,7 @@ export function useIframeShim(iframeRef: RefObject<HTMLIFrameElement | null>) {
             title: payload.title || undefined,
             tag: payload.tag || undefined,
           },
-          '*',
+          iframeOrigin,
         )
       },
     ).then((unlistener) => {
@@ -86,9 +94,12 @@ export function useIframeShim(iframeRef: RefObject<HTMLIFrameElement | null>) {
           appWindow.isVisible(),
         ])
         const hidden = minimized || !visible
+        const iframeOrigin = getIframeOrigin(iframeRef)
+        if (!iframeOrigin)
+          return
         iframeRef.current?.contentWindow?.postMessage(
           { type: 'dsh://visibility-state', hidden },
-          '*',
+          iframeOrigin,
         )
       }
       catch (error) {

--- a/src/hooks/use-iframe-tauri.ts
+++ b/src/hooks/use-iframe-tauri.ts
@@ -1,6 +1,7 @@
 import type { RefObject } from 'react'
 import { useState } from 'react'
 import { useEvent } from 'react-use'
+import { getIframeOrigin } from '@/utils/iframe-origin'
 
 /**
  * 壳层导航桥（宿主侧）：ShellNavBar 左侧三个控件的消息通道。
@@ -60,6 +61,10 @@ export function useIframeTauri(
     if (event.source !== iframeRef?.current?.contentWindow) {
       return
     }
+    const iframeOrigin = iframeRef ? getIframeOrigin(iframeRef) : null
+    if (!iframeOrigin || event.origin !== iframeOrigin) {
+      return
+    }
     switch (data.type) {
       case 'dsh://sidebar:collapsed':
         setSidebarCollapsed(Boolean(data.collapsed))
@@ -76,9 +81,14 @@ export function useIframeTauri(
   useEvent('message', handleMessage)
 
   function sendNav(action: ShellNavAction) {
+    if (!iframeRef)
+      return
+    const iframeOrigin = getIframeOrigin(iframeRef)
+    if (!iframeOrigin)
+      return
     iframeRef?.current?.contentWindow?.postMessage(
       { source: 'dsh-desktop', type: COMMAND_TYPES[action] },
-      '*',
+      iframeOrigin,
     )
   }
 

--- a/src/store/modules/harness/store.ts
+++ b/src/store/modules/harness/store.ts
@@ -160,6 +160,10 @@ export const harness = defineStore({
       this.iframeError = false
       await invoke('launch_harness')
       this.serviceRunning = true
+      // 后端遇到端口占用时会自动递增并持久化端口，启动后重新读取真实地址。
+      const runtimeInfo = await invoke<{ service_url: string }>('get_runtime_info')
+      this.serviceUrl = runtimeInfo.service_url
+      this.iframeSrc = generateTimestampedUrl(runtimeInfo.service_url)
 
       let healthy = false
       for (let attempt = 0; attempt < MAX_RETRIES && !healthy; attempt++) {

--- a/src/utils/iframe-origin.ts
+++ b/src/utils/iframe-origin.ts
@@ -1,0 +1,15 @@
+import type { RefObject } from 'react'
+
+/** 返回当前 Harness iframe 的精确来源；无有效 HTTP(S) 来源时拒绝通信。 */
+export function getIframeOrigin(iframeRef: RefObject<HTMLIFrameElement | null>): string | null {
+  const source = iframeRef.current?.src
+  if (!source)
+    return null
+  try {
+    const url = new URL(source)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.origin : null
+  }
+  catch {
+    return null
+  }
+}


### PR DESCRIPTION
## 概述

一次整体安全加固，覆盖三个层面：**下载完整性**、**进程归属管理**、**前端通信收紧**。分为两个提交：

### 1. `feat(security)` 下载完整性校验、原子化安装与进程归属管理

- **下载白名单**：仅允许 HTTPS 域名（nodejs.org / registry.npmjs.org / github.com 及 GitHub 资产域），拒绝其他来源
- **SHA-256 完整性校验**：Node 产物对照官方 `SHASUMS256.txt`，DSH 对照 GitHub release asset 的 `sha256:` digest，pnpm 为内置常量（升级需同步更新）
- **原子化安装**：解压先落临时目录，成功后再切换并备份旧版本，失败自动回滚，支持中断恢复——更新失败不再破坏旧版本
- **归属进程管理**：记录启动 PID 与 Windows 进程句柄，停止 / 健康检查 / 安装前置检查只作用于本应用创建的进程树；不再按端口或 AppData 路径强杀未知进程，句柄等待消除 PID 复用误杀窗口（Unix 侧独立进程组）
- **端口冲突**：不再杀占用者，自动向上递增并持久化新端口

### 2. `fix(security)` iframe postMessage 校验来源并收紧 CSP 与权限

- postMessage 的 `targetOrigin` 由 `'*'` 收紧为 iframe 精确来源，收包校验 `event.origin`
- 移除 capabilities 中远端页面的 IPC 授权，远端 Harness 仅通过校验后的 postMessage 桥通信
- 补充 CSP（`default-src 'self'` + ipc），iframe `allow` 属性收窄为 clipboard + fullscreen

## 验证

- `cargo check` 通过
- `cargo test` 44 通过 / 0 失败（新增完整性校验、下载源白名单、原子切换、端口递增用例）
- `pnpm typecheck` 通过

> 注：分支沿用了既有 `codex/update-readme-hero-banners`，含两个已推送的 README 横幅提交（docs），如需调整可说明。