### PR TITLE
fix(download): prefer GitHub official source with ghfast mirror fallback

### DIFF
--- a/src-tauri/src/config/constants.rs
+++ b/src-tauri/src/config/constants.rs
@@ -9,12 +9,15 @@ pub const NODE_BASE_URL: &str = "https://nodejs.org/dist/";
 /// Node.js 镜像下载地址（npmmirror，302 重定向至 cdn.npmmirror.com）
 pub const NODE_MIRROR_BASE_URL: &str = "https://npmmirror.com/mirrors/node/";
 
-/// 打包的 DeepSeek Harness 发行版下载地址（GitHub Release）
+/// 打包的 DeepSeek Harness 发行版下载地址（GitHub Release，默认首选源）
 pub const DSH_CORE_URL: &str =
     "https://github.com/hairyf/deepseek-harness-pkg/releases/latest/download/";
 
-/// 打包的 DeepSeek Harness 发行版镜像下载地址（ghfast.top 中转 GitHub Release，
-/// 直接拼接官方 URL，下载内容一致、仍可做 SHA-256 完整性校验）
+/// GitHub Release 的 ghfast.top 中转前缀（透传官方 URL，下载内容一致、
+/// 仍可做 SHA-256 完整性校验），用作官方直连失败时的兜底镜像。
+pub const DSH_MIRROR_PREFIX: &str = "https://ghfast.top/";
+
+/// 打包的 DeepSeek Harness 发行版镜像下载地址（ghfast.top 中转 GitHub Release）
 pub const DSH_MIRROR_CORE_URL: &str =
     "https://ghfast.top/https://github.com/hairyf/deepseek-harness-pkg/releases/latest/download/";
 

--- a/src-tauri/src/config/runtime.rs
+++ b/src-tauri/src/config/runtime.rs
@@ -41,13 +41,15 @@ pub fn get_node_download_url() -> Result<String, String> {
     Ok(format!("{}/{}/{}", node_base_url(detect_region()), NODE_VERSION, filename))
 }
 
-/// 打包的 DeepSeek Harness 发行版官方/镜像下载前缀：
-/// 国内走 ghfast.top 中转 GitHub Release，其他直连 GitHub
-fn dsh_core_base_url(region: Region) -> &'static str {
-    match region {
-        Region::Domestic => DSH_MIRROR_CORE_URL,
-        Region::Overseas => DSH_CORE_URL,
-    }
+/// 打包的 DeepSeek Harness 发行版下载前缀：恒为 GitHub Release 官方直连，
+/// 作为首选下载源（镜像 ghfast.top 中转不稳定，仅作官方失败后的兜底）。
+fn dsh_core_base_url() -> &'static str {
+    DSH_CORE_URL
+}
+
+/// 打包的 DeepSeek Harness 发行版镜像下载前缀（ghfast.top 中转 GitHub Release）
+fn dsh_mirror_base_url() -> &'static str {
+    DSH_MIRROR_CORE_URL
 }
 
 /// Harness 发行版资产文件名（按平台与架构）
@@ -64,13 +66,30 @@ fn dsh_pkg_asset_filename() -> Result<String, String> {
     }
 }
 
-/// 打包的 DeepSeek Harness 发行版下载地址
+/// 打包的 DeepSeek Harness 发行版下载地址（GitHub 官方直连，首选源）
 pub fn get_dsh_download_url() -> Result<String, String> {
     Ok(format!(
         "{}{}",
-        dsh_core_base_url(detect_region()),
+        dsh_core_base_url(),
         dsh_pkg_asset_filename()?
     ))
+}
+
+/// 打包的 DeepSeek Harness 发行版下载地址列表（按顺序依次尝试）：
+/// GitHub 官方直连 → ghfast.top 镜像兜底。官方直连失败时由下载层自动
+/// 切换镜像并告知用户，避免 ghfast.top 不稳定导致首次安装失败。
+pub fn get_dsh_download_urls() -> Result<Vec<String>, String> {
+    let filename = dsh_pkg_asset_filename()?;
+    Ok(vec![
+        format!("{}{}", dsh_core_base_url(), filename),
+        format!("{}{}", dsh_mirror_base_url(), filename),
+    ])
+}
+
+/// 为任意 GitHub Release 资产 URL 生成 ghfast.top 镜像兜底地址
+/// （透传原 URL，下载内容一致，仍可做 SHA-256 完整性校验）。
+pub fn mirror_download_url(asset_url: &str) -> String {
+    format!("{DSH_MIRROR_PREFIX}{asset_url}")
 }
 
 /// 指定 tag 的 DeepSeek Harness 发行版下载地址。
@@ -79,7 +98,7 @@ pub fn get_dsh_download_url() -> Result<String, String> {
 /// `releases/download/<tag>/`，镜像/直连与平台文件名逻辑与最新版完全一致
 /// （GitHub 的 tag 下载路径是固定的 release 资产地址，可被确定性推导）。
 pub fn get_dsh_download_url_for_tag(tag: &str) -> Result<String, String> {
-    let base = dsh_core_base_url(detect_region())
+    let base = dsh_core_base_url()
         .replace("releases/latest/download/", &format!("releases/download/{tag}/"));
     Ok(format!("{}{}", base, dsh_pkg_asset_filename()?))
 }
@@ -386,9 +405,24 @@ mod tests {
     }
 
     #[test]
-    fn dsh_base_url_switches_on_region() {
-        assert_eq!(dsh_core_base_url(Region::Overseas), DSH_CORE_URL);
-        assert_eq!(dsh_core_base_url(Region::Domestic), DSH_MIRROR_CORE_URL);
+    fn dsh_download_urls_prefer_official_then_mirror() {
+        // 无论哪个地域，首选源都是 GitHub 官方直连；镜像仅作兜底
+        let urls = get_dsh_download_urls().expect("dsh urls");
+        assert_eq!(urls.len(), 2);
+        assert!(urls[0].starts_with(DSH_CORE_URL), "first source must be official GitHub: {}", urls[0]);
+        assert!(urls[1].starts_with(DSH_MIRROR_PREFIX), "fallback must be ghfast mirror: {}", urls[1]);
+        // 两个源的文件名一致（镜像只是换前缀，解压类型判定不受影响）
+        let name = |u: &str| u.rsplit('/').next().unwrap_or("").to_string();
+        assert_eq!(name(&urls[0]), name(&urls[1]));
+    }
+
+    #[test]
+    fn mirror_url_prepends_ghfast_prefix() {
+        let asset = "https://github.com/hairyf/deepseek-harness-pkg/releases/download/v1.0.0/deepseek-harness-pkg-windows.zip";
+        assert_eq!(
+            mirror_download_url(asset),
+            format!("{DSH_MIRROR_PREFIX}{asset}")
+        );
     }
 
     #[test]

--- a/src-tauri/src/service/core/mod.rs
+++ b/src-tauri/src/service/core/mod.rs
@@ -513,12 +513,17 @@ pub async fn download_version(app_handle: &AppHandle, tag: &str) -> Result<Harne
     })?;
 
     // 2. 下载 + 校验 + 原子解压到历史槽位（两阶段进度：下载 0-50，解压 50-100）
+    //    下载默认走 GitHub 官方直连，失败自动切换 ghfast.top 镜像兜底。
     let window = app_handle
         .get_webview_window("main")
         .ok_or("WINDOW_NOT_FOUND: main window missing")?;
     let mut tracker = download::ProgressTracker::new(&window, 2);
     tracker.start_phase("download", &format!("正在下载核心版本 {tag}"));
-    let buffer = download::download_file(&tracker, info.asset_url.clone())
+    let urls = vec![
+        info.asset_url.clone(),
+        config::mirror_download_url(&info.asset_url),
+    ];
+    let buffer = download::download_file_from_sources(&tracker, urls)
         .await
         .map_err(|e| format!("CORE_DOWNLOAD_FAILED: {e}"))?;
     download::verify_sha256(&buffer, &digest)

--- a/src-tauri/src/service/download/core.rs
+++ b/src-tauri/src/service/download/core.rs
@@ -20,8 +20,60 @@ pub async fn download_file<'a, R: Runtime>(
     tracker: &'a ProgressTracker<'a, R>,
     url: String,
 ) -> Result<Vec<u8>, String> {
+    download_file_from_sources(tracker, vec![url]).await
+}
+
+/// 按顺序依次尝试多个下载源（如 GitHub 官方直连 → ghfast.top 镜像兜底），
+/// 某个源全部重试失败后自动切换下一个源，并通过 `tracker` 在界面上告知用户
+/// 当前使用的下载源；全部源均失败时返回最后一个源的错误并注明尝试过的源数。
+///
+/// 每个源内部仍走 `download_with_retry` 的断点续传重试；切换源时保留已下载
+/// 的字节续传（镜像透传同一文件，内容一致，且最终有 SHA-256 完整性校验兜底；
+/// 服务端不支持 Range 时 `download_attempt` 会自动清空从头下载）。
+pub async fn download_file_from_sources<'a, R: Runtime>(
+    tracker: &'a ProgressTracker<'a, R>,
+    urls: Vec<String>,
+) -> Result<Vec<u8>, String> {
+    if urls.is_empty() {
+        return Err("DOWNLOAD_URL_EMPTY: no download source provided".to_string());
+    }
+    let mut last_err = String::new();
+    for (index, url) in urls.iter().enumerate() {
+        // 切换下载源时告知用户（detail 展示在进度面板，log 进入日志流）
+        if index > 0 {
+            let host = reqwest::Url::parse(url)
+                .ok()
+                .and_then(|parsed| parsed.host_str().map(|h| h.to_string()))
+                .unwrap_or_else(|| url.clone());
+            log::warn!(
+                "Primary download source failed, switching to fallback source: {}",
+                url
+            );
+            tracker.update(
+                0.0,
+                format!("主下载源不可用，已切换镜像源重试（{host}）"),
+                format!("Switch to fallback download source: {url}"),
+            );
+        }
+        match download_with_retry(tracker, url).await {
+            Ok(buffer) => return Ok(buffer),
+            Err(e) => last_err = e,
+        }
+    }
+    Err(if urls.len() > 1 {
+        format!("{last_err}（已尝试 {} 个下载源）", urls.len())
+    } else {
+        last_err
+    })
+}
+
+/// 对单个 URL 执行断点续传重试，全部尝试失败返回中文可读错误。
+async fn download_with_retry<'a, R: Runtime>(
+    tracker: &'a ProgressTracker<'a, R>,
+    url: &str,
+) -> Result<Vec<u8>, String> {
     log::info!("Starting file download: {}", url);
-    validate_download_url(&url)?;
+    validate_download_url(url)?;
 
     // 创建具备 User-Agent 的客户端
     let client = reqwest::Client::builder()
@@ -53,7 +105,7 @@ pub async fn download_file<'a, R: Runtime>(
             );
             tokio::time::sleep(delay).await;
         }
-        match download_attempt(&client, tracker, &url, attempt, MAX_DOWNLOAD_ATTEMPTS, &mut buffer)
+        match download_attempt(&client, tracker, url, attempt, MAX_DOWNLOAD_ATTEMPTS, &mut buffer)
             .await
         {
             Ok(()) => {

--- a/src-tauri/src/service/download/mod.rs
+++ b/src-tauri/src/service/download/mod.rs
@@ -6,9 +6,9 @@ mod utils;
 
 // 导出公共接口
 pub use core::{
-    download_file, ensure_extract, fetch_dsh_pkg_asset, fetch_dsh_pkg_tags,
-    fetch_latest_dsh_pkg_info, fetch_node_sha256, parse_version_from_tag, resolve_update,
-    verify_sha256, LatestDshPkg, UpdateCheck,
+    download_file, download_file_from_sources, ensure_extract, fetch_dsh_pkg_asset,
+    fetch_dsh_pkg_tags, fetch_latest_dsh_pkg_info, fetch_node_sha256, parse_version_from_tag,
+    resolve_update, verify_sha256, LatestDshPkg, UpdateCheck,
 };
 // 供核心面板切换版本时使用（跨模块内部接口，不进公共 API）
 pub(crate) use core::{remove_dir_with_retry, rename_with_retry};

--- a/src-tauri/src/service/update/mod.rs
+++ b/src-tauri/src/service/update/mod.rs
@@ -18,6 +18,8 @@ use futures_util::StreamExt;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_opener::OpenerExt;
 
+use crate::config;
+
 /// 仓库主页（同时用于构造 atom / expanded_assets / 下载地址）
 const REPO_URL: &str = "https://github.com/hairyf/deepseek-harness-desktop";
 /// 版权信息（与 tauri.conf.json bundle.copyright 保持一致）
@@ -278,33 +280,22 @@ pub struct DesktopDownloadProgress {
     pub percentage: f64,
     pub downloaded: u64,
     pub total: u64,
+    /// 附加提示（如切换下载源），无提示时为 None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
-/// 下载桌面端安装包；已下载则直接返回。
-///
-/// 下载期间通过 `desktop-update-progress` 事件推送进度；完成后返回
-/// `DesktopUpdateInfo`（path/downloaded 已更新）。
-pub async fn download(app_handle: &AppHandle) -> Result<DesktopUpdateInfo, String> {
-    let release = fetch_latest_release()
-        .await?
-        .ok_or_else(|| "UPDATE_NONE".to_string())?;
-    let path = installer_path(app_handle, &release.asset_name)?;
-
-    if path.exists() {
-        log::info!("Installer already downloaded: {}", path.display());
-        return check(app_handle)
-            .await?
-            .ok_or_else(|| "UPDATE_NONE".to_string());
-    }
-
-    log::info!("Downloading desktop installer from {}", release.url);
-    let client = reqwest::Client::builder()
-        .user_agent("deepseek-harness-desktop")
-        .build()
-        .map_err(|e| format!("UPDATE_CLIENT: {e}"))?;
-
+/// 从单个下载源流式下载安装包到临时文件；失败时清理半成品（避免残留
+/// 部分字节被误判为「已下载」）。
+async fn download_from_source(
+    client: &reqwest::Client,
+    url: &str,
+    tmp: &std::path::Path,
+    app_handle: &AppHandle,
+) -> Result<(), String> {
+    log::info!("Downloading desktop installer from {}", url);
     let res = client
-        .get(&release.url)
+        .get(url)
         .send()
         .await
         .map_err(|e| format!("UPDATE_DOWNLOAD: {e}"))?
@@ -312,10 +303,7 @@ pub async fn download(app_handle: &AppHandle) -> Result<DesktopUpdateInfo, Strin
         .map_err(|e| format!("UPDATE_DOWNLOAD: {e}"))?;
 
     let total = res.content_length().unwrap_or(0);
-    // 先写临时文件再原子改名，避免下载中断残留半成品被误判为「已下载」
-    let tmp = path.with_extension("part");
-    let mut file = std::fs::File::create(&tmp).map_err(|e| format!("UPDATE_FILE: {e}"))?;
-
+    let mut file = std::fs::File::create(tmp).map_err(|e| format!("UPDATE_FILE: {e}"))?;
     use std::io::Write;
     let mut downloaded: u64 = 0;
     let mut stream = res.bytes_stream();
@@ -334,10 +322,83 @@ pub async fn download(app_handle: &AppHandle) -> Result<DesktopUpdateInfo, Strin
                 percentage: pct,
                 downloaded,
                 total,
+                message: None,
             },
         );
     }
     drop(file);
+    Ok(())
+}
+
+/// 下载桌面端安装包；已下载则直接返回。
+///
+/// 下载期间通过 `desktop-update-progress` 事件推送进度；完成后返回
+/// `DesktopUpdateInfo`（path/downloaded 已更新）。
+///
+/// 下载源策略与 dsh 核心一致：默认先走 GitHub 官方直连，失败自动切换
+/// ghfast.top 镜像兜底；切换时通过进度事件的 message 字段在界面上告知用户。
+pub async fn download(app_handle: &AppHandle) -> Result<DesktopUpdateInfo, String> {
+    let release = fetch_latest_release()
+        .await?
+        .ok_or_else(|| "UPDATE_NONE".to_string())?;
+    let path = installer_path(app_handle, &release.asset_name)?;
+
+    if path.exists() {
+        log::info!("Installer already downloaded: {}", path.display());
+        return check(app_handle)
+            .await?
+            .ok_or_else(|| "UPDATE_NONE".to_string());
+    }
+
+    let client = reqwest::Client::builder()
+        .user_agent("deepseek-harness-desktop")
+        .build()
+        .map_err(|e| format!("UPDATE_CLIENT: {e}"))?;
+
+    // 官方直连 → ghfast.top 镜像兜底。安装包无 SHA-256 元数据，切换源时
+    // 丢弃上一源的部分字节从头下载，避免混用两个源的字节流。
+    let urls = vec![
+        release.url.clone(),
+        config::mirror_download_url(&release.url),
+    ];
+    let tmp = path.with_extension("part");
+    let mut last_err = String::new();
+    for (index, url) in urls.iter().enumerate() {
+        if index > 0 {
+            let host = reqwest::Url::parse(url)
+                .ok()
+                .and_then(|parsed| parsed.host_str().map(|h| h.to_string()))
+                .unwrap_or_else(|| url.clone());
+            log::warn!(
+                "Primary desktop update source failed, switching to fallback: {}",
+                url
+            );
+            let _ = app_handle.emit(
+                "desktop-update-progress",
+                DesktopDownloadProgress {
+                    percentage: 0.0,
+                    downloaded: 0,
+                    total: 0,
+                    message: Some(format!("主下载源不可用，已切换镜像源重试（{host}）")),
+                },
+            );
+        }
+        // 先写临时文件再原子改名，避免下载中断残留半成品被误判为「已下载」
+        let _ = std::fs::remove_file(&tmp);
+        match download_from_source(&client, url, &tmp, app_handle).await {
+            Ok(()) => {
+                last_err.clear();
+                break;
+            }
+            Err(e) => last_err = e,
+        }
+    }
+    if !last_err.is_empty() {
+        return Err(format!(
+            "UPDATE_DOWNLOAD: {last_err}（已尝试 {} 个下载源）",
+            urls.len()
+        ));
+    }
     std::fs::rename(&tmp, &path).map_err(|e| format!("UPDATE_FILE: {e}"))?;
 
     check(app_handle)

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -763,14 +763,27 @@ pub async fn install(
         // 下载 URL 对 dsh 也是完全确定可算的（DSH_CORE_URL + 平台文件名），
         // 无需依赖 GitHub API 元数据；api.github.com 限流/被代理拦截时
         // （mac 首次启动常见）仍能拿到真实下载地址，避免整次安装被瞬时失败卡死。
-        let url = task.get_download_url()?;
-        log::debug!("Download URL: {}", url);
+        // dsh 核心默认先走 GitHub 官方直连，失败自动切换 ghfast.top 镜像兜底
+        // （下载层会在界面上告知用户）；其余任务保持单一官方源。
+        let (urls, name) = if index == 1 {
+            let urls = config::get_dsh_download_urls()?;
+            let name = urls
+                .first()
+                .and_then(|u| u.rsplit('/').next())
+                .unwrap_or("")
+                .to_string();
+            (urls, name)
+        } else {
+            let url = task.get_download_url()?;
+            let name = url.rsplit('/').next().unwrap_or("").to_string();
+            (vec![url], name)
+        };
         // 取文件名用于解压类型判定；下载 URL 正常必含 '/'，但这里不 panic，
         // 防御性兜底为空串（后续 ensure_extract 会因无法判定类型而报错返回，
         // 不再让进程崩溃）。
-        let name = url.rsplit('/').next().unwrap_or("").to_string();
+        log::debug!("Download URL: {}", urls.join(" -> "));
         log::debug!("File name: {}", name);
-        let buffer = download::download_file(&tracker, url).await?;
+        let buffer = download::download_file_from_sources(&tracker, urls).await?;
         log::info!("Download completed, file size: {} bytes", buffer.len());
         let expected_digest = match index {
             0 => download::fetch_node_sha256(task.get_download_url()?.as_str()).await?,

--- a/src/store/modules/desktop-update/store.ts
+++ b/src/store/modules/desktop-update/store.ts
@@ -202,6 +202,13 @@ export const desktopUpdate = defineStore({
 // 模块级监听下载进度（应用生命周期内常驻）
 listen<DesktopDownloadProgress>('desktop-update-progress', (e) => {
   desktopUpdate.downloadProgress = e.payload.percentage
+  // 后端附加提示（如主源失败已切换镜像源重试）→ toast 告知用户
+  if (e.payload.message) {
+    toast(e.payload.message, {
+      variant: 'default',
+      placement: 'bottom end',
+    })
+  }
 }).catch((err) => {
   console.error('[DesktopUpdate] failed to listen desktop-update-progress:', err)
 })

--- a/src/store/modules/desktop-update/types.ts
+++ b/src/store/modules/desktop-update/types.ts
@@ -17,6 +17,8 @@ export interface DesktopDownloadProgress {
   percentage: number
   downloaded: number
   total: number
+  /** 附加提示（如切换下载源），无提示时缺省 */
+  message?: string
 }
 
 /** Rust 侧 get_desktop_about 返回的关于信息 */


### PR DESCRIPTION
## fix

- **dsh 核心包下载源策略反转**：原逻辑按地域检测，`zh-CN`/中国时区用户首次安装直接走 `ghfast.top` 镜像（该中转不稳定，实测当前完全不可达），导致安装必然失败。现统一**默认直连 GitHub Release 官方源**，失败后自动切换 ghfast.top 镜像兜底。
  - `config/runtime.rs`：`get_dsh_download_urls()` 返回 `[官方, 镜像]` 有序列表；新增 `mirror_download_url()` 为任意 GitHub asset URL 生成镜像地址；`get_dsh_download_url()` 恒返回官方源（不再受地域影响）
  - `download/core.rs`：新增 `download_file_from_sources()` 依次尝试多个源，每个源内部保留原有 5 次断点续传重试；全部失败时错误注明「已尝试 N 个下载源」
- **首次安装 / 核心升级**（`workflow::install`）：dsh 任务接入多源下载；Node/pnpm 保持单一官方源不变
- **核心版本下载**（`core::download_version`）：历史 tag 下载同样接入 `[GitHub asset URL, 镜像]` 多源
- **桌面端自更新**（`service/update/mod.rs`）：安装包下载原本是单请求、单一 GitHub URL、无兜底，现改为多源依次尝试；切换源时丢弃 `.part` 半成品从头下载（安装包无 SHA-256 元数据，避免混用两源字节流）
- **界面告知用户**：切换下载源时——
  - 安装流程通过 `install-progress` 事件 detail/log 展示「主下载源不可用，已切换镜像源重试（ghfast.top）」
  - 桌面端更新通过 `desktop-update-progress` 事件新增 `message` 字段，前端 toast 提示
- 测试：新增/更新 `runtime` 单元测试（官方在前、镜像兜底、文件名一致、镜像 URL 拼接）

## review aids

下载源顺序（dsh 核心包与桌面端安装包一致）：

```mermaid
flowchart LR
    A[GitHub 官方直连] -->|成功| B[完成下载]
    A -->|5 次重试失败| C[ghfast.top 镜像兜底]
    C -->|成功| B
    C -->|失败| D[报错: 已尝试 2 个下载源]
    A -.->|切换时| E[界面提示用户]
    C -.->|切换时| E
```

端到端验证（真实首次安装，本机 `zh-CN` + `China Standard Time`）：
- 按旧逻辑本机会判 `Region::Domestic` → 走 ghfast.top（实测 curl 20s 超时不可达）→ 安装必失败
- 新逻辑：`Starting file download: https://github.com/hairyf/deepseek-harness-pkg/...` 官方直连一次成功，39MB 下载 + SHA-256 校验通过，解压 13923 文件，服务正常启动监听 127.0.0.1:3080
- `cargo check` 无警告；`cargo test` 107 通过（1 个失败为本机 PowerShell ExecutionPolicy 环境问题，与本次改动无关，改动前已存在）；`pnpm typecheck` 通过
