### PR TITLE
feat(window): remember window size and position across restarts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,34 @@
+# Issue #63 — 自动记住调整后的窗口大小和位置
+
+## 目标
+
+调整窗口大小与位置后，重启应用保持窗口的大小、位置与最大化状态。
+
+## 实现方案
+
+不使用官方 `tauri-plugin-window-state`：本项目主窗口是程序化创建、无标题栏
+（`decorations(false)`）、关闭时隐藏到托盘而非销毁、release 叠加单例复用，且要求
+几何数据落进与本项目一致的 store 文件（`.store.dat` / `.store.dev.dat`）。因此基于
+已有的 `tauri-plugin-store` 手动读写，几何记录的时机与恢复流程完全可控。
+
+## 改动清单
+
+- [x] `src-tauri/src/config/window_state.rs`（新增）：`WindowState` 几何结构体 +
+      `get_window_state` / `save_geometry` / `restore_main_window`。读取/写入沿用
+      `setting` 的 store 文件选择（debug 与生产隔离）；恢复时把几何夹紧到当前可见
+      屏幕（防止外接屏被拔出后窗口跑到屏幕外），无历史记录时保持 builder 默认的
+      1280×840（居中）。
+- [x] `src-tauri/src/config/constants.rs`：新增 `STORE_WINDOW_STATE_KEY`。
+- [x] `src-tauri/src/config/mod.rs`：导出 `window_state` 模块。
+- [x] `src-tauri/src/desktop/builder.rs`：
+  - `build_main_window` build() 成功后调用 `restore_main_window`（先设尺寸/位置，再
+    按需 `maximize()`）。
+  - `on_window_event` 处理 `Moved`/`Resized` 时调用 `save_geometry`。
+
+## 验证
+
+- 拖拽移动窗口 → 重启：位置还原。
+- 调整大小 → 重启：尺寸还原。
+- 最大化 → 重启：保持最大化。
+- 首次启动（无历史）：落在默认 1280×840（居中）。
+- 附带夹紧：保存的位置不可见时回落到主屏居中。

--- a/src-tauri/src/config/constants.rs
+++ b/src-tauri/src/config/constants.rs
@@ -69,6 +69,8 @@ pub const STORE_DAT_FILE: &str = ".store.dat";
 /// store 会让两边端口一路漂移并相互污染状态）。
 pub const STORE_DAT_DEV_FILE: &str = ".store.dev.dat";
 pub const STORE_SETTING_KEY: &str = "setting";
+/// Store 中记录主窗口几何（位置/大小/最大化）的键
+pub const STORE_WINDOW_STATE_KEY: &str = "window_state";
 
 /// 健康检查超时
 pub const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -6,6 +6,7 @@ mod runtime;
 mod setting;
 mod theme;
 mod utils;
+mod window_state;
 
 pub use constants::*;
 pub use format::*;
@@ -14,3 +15,4 @@ pub use runtime::*;
 pub use setting::*;
 pub use theme::*;
 pub use utils::*;
+pub use window_state::*;

--- a/src-tauri/src/config/window_state.rs
+++ b/src-tauri/src/config/window_state.rs
@@ -1,0 +1,219 @@
+//! 主窗口几何持久化：记住窗口大小/位置/最大化状态，重启后恢复。
+//!
+//! 为什么不直接用官方的 tauri-plugin-window-state：本项目主窗口是程序化创建
+//! （见 `desktop::builder::build_main_window`）、无标题栏 `decorations(false)`，
+//! 且关闭时是「隐藏到托盘」而非销毁（见 builder 的 on_window_event），并叠加
+//! release 的单例复用（二次启动 show/focus 同一窗口）。插件默认把状态写进独立的
+//! 配置文件、恢复时机与这套「隐藏 + 单例」流程存在耦合，且与本项目「所有应用数据
+//! 落进 store 文件（.store.dat/.store.dev.dat）」的约定不一致。因此这里基于已有的
+//! `tauri-plugin-store` 手动读写，几何记录的时机与恢复流程完全可控。
+
+use serde::{Deserialize, Serialize};
+use tauri::{
+    AppHandle, Manager, PhysicalPosition, PhysicalSize, Position, Runtime, Size, WebviewWindow, Window,
+};
+use tauri_plugin_store::StoreExt;
+
+use super::constants::{STORE_DAT_DEV_FILE, STORE_DAT_FILE, STORE_WINDOW_STATE_KEY};
+
+/// 主窗口默认尺寸（逻辑像素，首次启动/无历史时由 builder 采用）
+pub const DEFAULT_WINDOW_WIDTH: f64 = 1280.0;
+pub const DEFAULT_WINDOW_HEIGHT: f64 = 840.0;
+/// 主窗口最小尺寸（与 build_main_window 的 min_inner_size 对齐）
+pub const MIN_WINDOW_WIDTH: f64 = 860.0;
+pub const MIN_WINDOW_HEIGHT: f64 = 620.0;
+
+/// 记录一帧主窗口几何。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WindowState {
+    /// 上次是否为最大化状态
+    pub maximized: bool,
+    /// 非最大化时的物理位置（outer_position，屏幕左上角为原点）
+    pub x: Option<i32>,
+    pub y: Option<i32>,
+    /// 物理尺寸（outer_size）
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Default for WindowState {
+    fn default() -> Self {
+        Self {
+            maximized: false,
+            x: None,
+            y: None,
+            width: DEFAULT_WINDOW_WIDTH as u32,
+            height: DEFAULT_WINDOW_HEIGHT as u32,
+        }
+    }
+}
+
+/// Store 持久化文件名：debug 构建与生产隔离（各自独立文件），语义同
+/// `config::setting` 的 store 文件选择，保证开发版与发布版窗口几何不互相污染。
+fn store_dat_file_name() -> &'static str {
+    if cfg!(debug_assertions) {
+        STORE_DAT_DEV_FILE
+    } else {
+        STORE_DAT_FILE
+    }
+}
+
+/// 读取上次保存的窗口状态；无记录时返回默认值（首次启动）。
+pub fn get_window_state<R: Runtime>(app_handle: &AppHandle<R>) -> WindowState {
+    let store = app_handle
+        .store(store_dat_file_name())
+        .expect("Failed to load store for window state");
+    let raw = store.get(STORE_WINDOW_STATE_KEY);
+    raw.and_then(|v| {
+        v.as_str()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .or_else(|| Some(v.clone()))
+    })
+    .and_then(|v| serde_json::from_value(v).ok())
+    .unwrap_or_default()
+}
+
+/// 把窗口状态写回 store 并落盘（store 基于 AppData，不随窗口生命周期丢失）。
+fn save_window_state<R: Runtime>(app_handle: &AppHandle<R>, state: &WindowState) {
+    let store = app_handle
+        .store(store_dat_file_name())
+        .expect("Failed to load store for window state");
+    let serialized = serde_json::to_value(state).expect("Failed to serialize window state");
+    store.set(STORE_WINDOW_STATE_KEY, serialized);
+    store.save().expect("Failed to save window state");
+}
+
+/// 采样当前窗口并保存（主窗口移动/缩放时由 builder 调用）。
+pub fn save_geometry<R: Runtime>(window: &Window<R>) {
+    let pos = window.outer_position().ok();
+    let size = window.outer_size().ok();
+    let state = WindowState {
+        maximized: window.is_maximized().unwrap_or(false),
+        x: pos.map(|p| p.x),
+        y: pos.map(|p| p.y),
+        width: size.map(|s| s.width).unwrap_or(DEFAULT_WINDOW_WIDTH as u32),
+        height: size.map(|s| s.height).unwrap_or(DEFAULT_WINDOW_HEIGHT as u32),
+    };
+    save_window_state(window.app_handle(), &state);
+}
+
+/// 把保存的几何解析成「实际可用的矩形」，并夹紧到当前可见屏幕。
+///
+/// 返回 `(物理尺寸, 物理坐标)`：
+/// - 无位置记录（首次启动）→ `None`，调用方保持 builder 的默认尺寸（1280×840，
+///   由 Tauri 自动居中）。
+/// - 保存的位置完全不可见（例如保存时的外接屏已被拔出）→ 回落到主屏居中，
+///   尺寸仍按可见屏幕夹紧，避免窗口被放到屏幕外「找不到」。
+fn resolve_geometry<R: Runtime>(
+    app: &AppHandle<R>,
+    saved: &WindowState,
+) -> Option<(PhysicalSize<u32>, PhysicalPosition<i32>)> {
+    // 取当前所有监视器，计算可见屏幕的并集矩形
+    let monitors = app.available_monitors().ok()?;
+    if monitors.is_empty() {
+        return None;
+    }
+    let min_x = monitors.iter().map(|m| m.position().x).min()?;
+    let min_y = monitors.iter().map(|m| m.position().y).min()?;
+    let max_x = monitors
+        .iter()
+        .map(|m| m.position().x + m.size().width as i32)
+        .max()?;
+    let max_y = monitors
+        .iter()
+        .map(|m| m.position().y + m.size().height as i32)
+        .max()?;
+
+    // 尺寸：不小于最小尺寸，且不超过可见屏幕并集（防止拔掉外接大屏后窗口过大）
+    let mut w = saved.width.max(MIN_WINDOW_WIDTH as u32);
+    let mut h = saved.height.max(MIN_WINDOW_HEIGHT as u32);
+    let union_w = (max_x - min_x) as u32;
+    let union_h = (max_y - min_y) as u32;
+    w = w.min(union_w.max(MIN_WINDOW_WIDTH as u32));
+    h = h.min(union_h.max(MIN_WINDOW_HEIGHT as u32));
+
+    let (x, y) = match (saved.x, saved.y) {
+        (Some(sx), Some(sy)) => {
+            // 窗口矩形是否与可见屏幕并集有交集
+            let intersects = sx < max_x && sx + w as i32 > min_x
+                && sy < max_y && sy + h as i32 > min_y;
+            if intersects {
+                // 夹紧坐标到并集内，保证窗口至少部分可见
+                let nx = (sx as i64).clamp(min_x as i64, (max_x as i64 - w as i64).max(min_x as i64));
+                let ny = (sy as i64).clamp(min_y as i64, (max_y as i64 - h as i64).max(min_y as i64));
+                (nx as i32, ny as i32)
+            } else {
+                // 保存的位置不可见：回落到主屏居中
+                match app.primary_monitor().ok().flatten() {
+                    Some(m) => (
+                        m.position().x + (m.size().width as i32 - w as i32) / 2,
+                        m.position().y + (m.size().height as i32 - h as i32) / 2,
+                    ),
+                    None => return None,
+                }
+            }
+        }
+        _ => return None,
+    };
+
+    Some((PhysicalSize::new(w, h), PhysicalPosition::new(x, y)))
+}
+
+/// 恢复主窗口的大小与位置。在 `build_main_window` 成功 build() 之后调用。
+///
+/// 内部读取上次保存的 `WindowState`；顺序说明：先设置物理尺寸/位置，再按需
+/// `maximize()`——最大化会覆盖窗口当前尺寸，因此尺寸/位置要在最大化之前设置。
+/// 无历史状态时不改动窗口，由 builder 的默认 `inner_size(1280, 840)`
+/// （逻辑像素，居中）生效。
+pub fn restore_main_window<R: Runtime>(app: &AppHandle<R>, window: &WebviewWindow<R>) {
+    let saved = get_window_state(app);
+    let Some((size, pos)) = resolve_geometry(app, &saved) else {
+        return;
+    };
+    let _ = window.set_size(Size::Physical(size));
+    let _ = window.set_position(Position::Physical(pos));
+    if saved.maximized {
+        let _ = window.maximize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_state_default_matches_builder_default() {
+        let state = WindowState::default();
+        assert!(!state.maximized);
+        assert!(state.x.is_none());
+        assert!(state.y.is_none());
+        assert_eq!(state.width, DEFAULT_WINDOW_WIDTH as u32);
+        assert_eq!(state.height, DEFAULT_WINDOW_HEIGHT as u32);
+    }
+
+    #[test]
+    fn window_state_serde_roundtrip() {
+        let state = WindowState {
+            maximized: true,
+            x: Some(100),
+            y: Some(-200),
+            width: 1920,
+            height: 1080,
+        };
+        let json = serde_json::to_string(&state).expect("serialize");
+        let parsed: WindowState = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.maximized, state.maximized);
+        assert_eq!(parsed.x, state.x);
+        assert_eq!(parsed.y, state.y);
+        assert_eq!(parsed.width, state.width);
+        assert_eq!(parsed.height, state.height);
+    }
+
+    #[test]
+    fn window_state_ignores_missing_fields() {
+        // 老版本/缺失字段时也应能反序列化并回落到默认值
+        let parsed: WindowState = serde_json::from_str("{}").expect("deserialize");
+        assert_eq!(parsed, WindowState::default());
+    }
+}

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -162,6 +162,10 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
 
     let webview_window = webview_builder.build()?;
 
+    // 恢复上次的窗口大小/位置/最大化状态（无历史时保持 builder 默认的 1280×840，
+    // 由 Tauri 自动居中；见 config::window_state）。
+    crate::config::restore_main_window(app, &webview_window);
+
     #[cfg(windows)]
     {
         if !_notification_handlers_registered.swap(true, Ordering::SeqCst) {
@@ -251,11 +255,16 @@ pub fn builder() -> tauri::Builder<tauri::Wry> {
             Ok(())
         })
         // 点击关闭按钮时隐藏到托盘而不是退出程序
-        .on_window_event(|window, event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+        .on_window_event(|window, event| match event {
+            tauri::WindowEvent::CloseRequested { api, .. } => {
                 api.prevent_close();
                 let _ = window.hide();
             }
+            // 移动/缩放主窗口时记录几何，重启后据此恢复（见 config::window_state）
+            tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_) => {
+                crate::config::save_geometry(window);
+            }
+            _ => {}
         });
 
     // 单例模式：多次双击图标（或重复启动）时不会新开窗口，而是把


### PR DESCRIPTION
## 目标

处理 #63：调整窗口大小与位置后，重启应用保持窗口的大小、位置与最大化状态。

## 实现说明

本项目主窗口是程序化创建（`desktop::builder::build_main_window`）、无标题栏
（`decorations(false)`）、关闭时隐藏到托盘而非销毁，且 release 叠加单例复用
（二次启动 show/focus 同一窗口）。官方 `tauri-plugin-window-state` 默认把状态
写进独立配置文件，其恢复时机与这套「隐藏 + 单例」流程存在耦合。因此这里基于
项目已有的 `tauri-plugin-store` 手动读写，让几何数据落进与本项目一致的
`.store.dat` / `.store.dev.dat`（debug 与生产隔离），记录的时机与恢复流程完全可控，
并避免引入新依赖（符合仓库「优先复用/不加重依赖」的约定）。

## 改动

- `src-tauri/src/config/window_state.rs`（新增）：`WindowState` 几何结构体与
  `get_window_state` / `save_geometry` / `restore_main_window`。恢复时把几何夹紧到
  当前可见屏幕（保存位置不可见时回落到主屏居中，例如外接屏被拔出），无历史时保持
  builder 默认的 1280×840（居中）。
- `src-tauri/src/config/constants.rs`：新增存储键 `STORE_WINDOW_STATE_KEY`。
- `src-tauri/src/config/mod.rs`：导出 `window_state` 模块。
- `src-tauri/src/desktop/builder.rs`：
  - `build_main_window` build() 成功后调用 `restore_main_window`（先设尺寸/位置，再按需
    `maximize()`）。
  - `on_window_event` 处理 `Moved` / `Resized` 时调用 `save_geometry`。

## 验证

- `cargo check`（dev profile）通过。
- `cargo test --lib window_state`：3 个用例通过（默认值、serde roundtrip、缺失字段回落）。
- 行为：拖拽移窗/改大小后重启还原；最大化后重启保持；首次启动落在默认 1280×840。

Closes #63