### PR TITLE
fix(webview): polyfill AbortSignal.any for older WebKit on macOS/Linux

### DIFF
--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -152,10 +152,11 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
     });
 
     // 非 Windows（macOS/Linux）没有 WebView2 的 FrameCreated/ContentLoading 流程，
-    // 直接用 Tauri 的 initialization_script_for_all_frames 把通知桥、导航桥与样式桥注入
-    // 所有 frame（脚本均带 window.__dsh_*_bridge__ 幂等守卫，重复注入安全）。
+    // 直接用 Tauri 的 initialization_script_for_all_frames 把兼容桥、通知桥、导航桥
+    // 与样式桥注入所有 frame（脚本均带 window.__dsh_*_bridge__ 幂等守卫，重复注入安全）。
     #[cfg(not(windows))]
     let webview_builder = webview_builder
+        .initialization_script_for_all_frames(crate::desktop::compat::ABORT_SIGNAL_ANY_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::notification::NOTIFICATION_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::nav::NAV_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::style::IFRAME_STYLES_JS);

--- a/src-tauri/src/desktop/compat.rs
+++ b/src-tauri/src/desktop/compat.rs
@@ -1,0 +1,71 @@
+//! WebKit 兼容桥：为旧版 WebKit（< Safari 17.4）补齐 `AbortSignal.any`。
+//!
+//! 背景：dsh 的浏览器端代码（`dsh-client-connection` 的 fetch carrier、
+//! `dsh-api-gateway` 等）直接调用 `AbortSignal.any([AbortSignal.timeout(...), signal])`
+//! 做超时与主叫方取消信号的合并。`AbortSignal.any` 是 Safari 17.4+ / WebKit 2603 才
+//! 引入的标准 API，macOS 14.x（系统 WebKit 17.3，Safari 17.3）以及一部分旧版
+//! WebKitGTK（Linux）上不存在，导致桌面 WebView 抛出
+//! `AbortSignal.any is not a function. (In '...', 'AbortSignal.any' is undefined)`。
+//!
+//! 本脚本与 [`crate::desktop::nav::NAV_SHIM_JS`] / [`crate::desktop::style::IFRAME_STYLES_JS`]
+//! 走同一套注入通道（Windows 在 FrameCreated → ContentLoading 时 ExecuteScript，
+//! 其余平台 `initialization_script_for_all_frames`），在 dsh 页面脚本执行之前
+//! 就位，因此主机框架与 iframe 每次重新加载都会自动重建。
+//!
+//! 实现只用 ES5 兼容的语法（var / function / Array.prototype 方法），
+//! 保证即便在旧 WebKit 的严格模式环境下也能解析执行；带幂等守卫
+//! （`window.__dsh_abortsignal_any__`），重复注入安全——宿主页面若已自带
+//! polyfill（部分 dsh 发行版在 index.html 里内联过 `data-codex-abortsignal-polyfill`），
+//! 本脚本会自动让位，不会覆盖原生或已存在的实现。
+
+/// 注入 `AbortSignal.any` 的幂等 polyfill（WebKit 17.3 / WebKitGTK 缺失时启用）。
+pub(crate) const ABORT_SIGNAL_ANY_SHIM_JS: &str = r#"(function () {
+  if (window.__dsh_abortsignal_any__) return;
+  if (typeof AbortSignal === 'undefined' || typeof AbortSignal.any === 'function') return;
+  window.__dsh_abortsignal_any__ = true;
+
+  var polyfillAny = function (signals) {
+    var list = Array.prototype.slice.call(signals);
+    var controller = new AbortController();
+
+    function cleanup() {
+      for (var i = 0; i < list.length; i++) {
+        var signal = list[i];
+        if (signal && typeof signal.removeEventListener === 'function') {
+          signal.removeEventListener('abort', onAbort);
+        }
+      }
+    }
+
+    function onAbort(event) {
+      cleanup();
+      controller.abort(event.target && event.target.reason);
+    }
+
+    for (var j = 0; j < list.length; j++) {
+      var candidate = list[j];
+      if (candidate && candidate.aborted) {
+        onAbort({ target: candidate });
+        break;
+      }
+      if (candidate && typeof candidate.addEventListener === 'function') {
+        candidate.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+    return controller.signal;
+  };
+
+  try {
+    Object.defineProperty(AbortSignal, 'any', {
+      configurable: true,
+      writable: true,
+      value: polyfillAny,
+    });
+  } catch (_e) {
+    // 极端情况下（非常老的非标准 AbortSignal 对象拒绝 defineProperty）
+    // 直接赋值回退；若仍失败则保持原状，不做额外处理。
+    try {
+      AbortSignal.any = polyfillAny;
+    } catch (_ignored) { /* 保留原生未定义的现状 */ }
+  }
+})();"#;

--- a/src-tauri/src/desktop/mod.rs
+++ b/src-tauri/src/desktop/mod.rs
@@ -1,4 +1,5 @@
 pub mod builder;
+pub mod compat;
 pub mod nav;
 pub mod notification;
 pub mod payload;


### PR DESCRIPTION
## 摘要

为旧版 WebView（macOS 14.x / Linux WebKitGTK）补齐 `AbortSignal.any`，修复 WebView 中 `AbortSignal.any is not a function` 导致 dsh 无法正常工作的问题。

dsh 浏览器端代码（`dsh-client-connection` fetch carrier、`dsh-api-gateway` 等）调用 `AbortSignal.any([AbortSignal.timeout(...), signal])` 合并超时与调用方取消信号。该 API 自 Safari 17.4+ / WebKit 2603+ 才提供；macOS 14.x 自带系统 WebKit 17.3、Linux 旧版 WebKitGTK 均缺失，桌面 WebView 因此直接抛异常。

## 改动

- **新增** `src-tauri/src/desktop/compat.rs`：ES5 兼容、幂等的 `AbortSignal.any` polyfill（`window.__dsh_abortsignal_any__` 幂等守卫；运行时已存在实现时自动让位，不覆盖原生/宿主实现）。
- **修改** `src-tauri/src/desktop/mod.rs`：注册 `compat` 模块。
- **修改** `src-tauri/src/desktop/builder.rs`：在 macOS/Linux 的 `initialization_script_for_all_frames` 注入链中加入该 shim（与既有 notification / nav / style 三桥同通道），每次页面/iframe 加载自动重建，覆盖所有 frame。

Windows 无需改动：WebView2 基于 Chromium，原生支持 `AbortSignal.any`。

## 验证

- polyfill 行为测试在模拟缺失环境 9 项断言全部通过（融合中止、幂等、已中止即返回、空数组、reason 传递、不覆盖已有实现等）。
- `cargo check`（dev profile）通过。
- 本地 macOS 14.3.1 桌面 App 验证报错消失。

## 复现

macOS 14.x 下打开 App 即见：

```
AbortSignal.any is not a function. (In 'AbortSignal.any([AbortSignal.timeout(this.timeoutMs), signal])', 'AbortSignal.any' is undefined)
```
