### PR TITLE
fix: resolve main-flow crashes on startup/install paths

### DIFF
--- a/src-tauri/src/bridge/lifecycle.rs
+++ b/src-tauri/src/bridge/lifecycle.rs
@@ -282,3 +282,21 @@ pub fn runtime_ready(app_handle: AppHandle) -> bool {
         && download::Dsh.check_installed(&app_handle)
         && download::Pnpm.check_installed(&app_handle)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::install_lock;
+
+    #[test]
+    fn install_lock_is_exclusive_while_held() {
+        let lock = install_lock();
+        // 首持获得锁
+        let guard = lock.try_lock();
+        assert!(guard.is_ok());
+        // 未释放前再次 try_lock 应失败，排除并发/重入（这正是替换 Status::Installing 守卫的目的）
+        assert!(lock.try_lock().is_err());
+        // 释放后可重新获取
+        drop(guard);
+        assert!(lock.try_lock().is_ok());
+    }
+}

--- a/src-tauri/src/bridge/lifecycle.rs
+++ b/src-tauri/src/bridge/lifecycle.rs
@@ -3,11 +3,30 @@
 //! 覆盖三块：依赖（Node.js / 打包 Harness / pnpm）的安装与「记录滞后」自愈、
 //! Harness 服务进程的启停与状态查询，以及运行时三件套的就绪判断。
 
+use std::sync::OnceLock;
+
 use crate::config;
 use crate::service::cli;
 use crate::service::download::{self, Installable};
 use crate::service::workflow;
 use tauri::AppHandle;
+
+/// 并发安装互斥：状态位守卫进程的“是否正在安装”判断
+/// （status::Status::Installing 会被失败路径/其它流程改写，不能作为互斥依据），
+/// 改用独立的进程内互斥锁覆盖完整安装生命周期，避免两路并发 install 的
+/// TOCTOU 与安装失败后状态卡死导致后续请求被静默跳过。
+static INSTALL_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
+fn install_lock() -> &'static tokio::sync::Mutex<()> {
+    INSTALL_LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+/// 安装失败后把状态从 Installing 复位，避免后续调用被“正在安装”卡死。
+/// 仅在失败路径调用；成功路径保持原有状态语义（由前端随后 launch 续接）。
+fn reset_install_status(app_handle: &AppHandle) {
+    workflow::status::set_status(workflow::status::Status::Stopped);
+    workflow::status::emit_status(app_handle);
+}
 
 /// 按当前设置同步命令行集成（shim + PATH 注册）。
 ///
@@ -34,10 +53,13 @@ fn sync_cli_link(app_handle: &AppHandle) {
 /// 启动逻辑由前端显式调用 `launch_harness` 完成，避免重复拉起进程。
 #[tauri::command]
 pub async fn install_dependencies(app_handle: AppHandle) -> Result<bool, String> {
-    if workflow::status::get_status() == workflow::status::Status::Installing {
+    // 并发/重入防护：使用独立互斥锁而非依赖 Status::Installing——
+    // 失败路径会复位状态，若用状态判断则一次失败后所有后续调用都会被
+    // “Installation process already running” 静默跳过直到重启应用。
+    let Ok(_install_guard) = install_lock().try_lock() else {
         log::info!("Installation process already running, skipping");
         return Ok(false);
-    }
+    };
 
     // 以实际安装状态为准：本地安装与 GitHub 最新 release 的 commit hash
     // 不一致时，说明上游 pkg 有更新/修复，需要自动重新下载。
@@ -154,7 +176,16 @@ pub async fn install_dependencies(app_handle: AppHandle) -> Result<bool, String>
     workflow::status::emit_status(&app_handle);
     // 返回 dsh 是否真正落盘更新：仅重装 Node/pnpm 或全部任务被跳过（例如
     // 版本相同仅记录滞后）时为 false，前端据此决定是否重启页面/保留更新提示
-    let updated = workflow::install(&app_handle, dsh_latest.ok()).await?;
+    let updated = match workflow::install(&app_handle, dsh_latest.ok()).await {
+        Ok(updated) => updated,
+        Err(e) => {
+            // 安装失败把状态复位，避免后续 install_dependencies 命中
+            // “正在安装”被静默跳过（否则必须重启应用才能重试）
+            log::error!("Installation failed, resetting status: {e}");
+            reset_install_status(&app_handle);
+            return Err(e);
+        }
+    };
     log::debug!("Installation completed, marked as installed");
     let mut setting = config::get_store_dat_setting(&app_handle);
     setting.installed = true;

--- a/src-tauri/src/bridge/system_os.rs
+++ b/src-tauri/src/bridge/system_os.rs
@@ -93,6 +93,20 @@ pub fn log_frontend(level: String, target: String, message: String) {
     logger::log_frontend(lvl, &target, &message);
 }
 
+/// 按字节上限取 `s` 的尾部，并在裁剪起点回退到 UTF-8 字符边界。
+///
+/// 日志必然包含中文/ANSI 等多字节字符，直接用
+/// `&s[s.len() - max_bytes..]` 在起点落在字符中间时会 panic
+/// （`byte index ... is not a char boundary`），此实现保证安全。
+fn tail_bytes(s: &str, max_bytes: usize) -> &str {
+    let start = s.len().saturating_sub(max_bytes);
+    let mut i = start;
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    &s[i..]
+}
+
 /// 读取 dsh 服务日志
 #[tauri::command]
 pub async fn read_service_logs(
@@ -109,7 +123,7 @@ pub async fn read_service_logs(
     if content.len() <= max_bytes {
         Ok(content)
     } else {
-        Ok(content[content.len() - max_bytes..].to_string())
+        Ok(tail_bytes(&content, max_bytes).to_string())
     }
 }
 

--- a/src-tauri/src/bridge/system_os.rs
+++ b/src-tauri/src/bridge/system_os.rs
@@ -238,6 +238,7 @@ pub async fn open_external_url(app_handle: AppHandle, url: String) -> Result<(),
 #[cfg(test)]
 mod tests {
     use super::is_frontend_log_line;
+    use super::tail_bytes;
 
     #[test]
     fn frontend_line_detected() {
@@ -260,5 +261,28 @@ mod tests {
     fn frontend_level_padding_and_extra_spaces() {
         // 级别可能带前导空格（`{:>5}` 或 tracing 层多空格），frontend 目标仍应命中
         assert!(is_frontend_log_line("2024-06-01 12:00:00.123Z  INFO frontend: padded"));
+    }
+
+    #[test]
+    fn tail_bytes_keeps_ascii_within_limit() {
+        assert_eq!(tail_bytes("hello world", 5), "world");
+        // 起点已落在字符边界时原样截取
+        assert_eq!(tail_bytes("abc", 2), "bc");
+    }
+
+    #[test]
+    fn tail_bytes_advances_to_char_boundary() {
+        // 截取起点落在 3 字节中文中间 → 回退到字符边界，不 panic 且结果 ≤ max_bytes
+        assert_eq!(tail_bytes("中a", 2), "a");
+        // 4 字节 emoji 同理（非边界前缀字节会连续回退）
+        assert_eq!(tail_bytes("😀x", 3), "x");
+        // 多字节 + 超限，回退后长度仍不超过 max_bytes
+        assert_eq!(tail_bytes("中文abc", 3), "abc");
+    }
+
+    #[test]
+    fn tail_bytes_shorter_than_limit_returns_whole() {
+        assert_eq!(tail_bytes("中文", 10), "中文");
+        assert_eq!(tail_bytes("", 10), "");
     }
 }

--- a/src-tauri/src/service/cli/shim.rs
+++ b/src-tauri/src/service/cli/shim.rs
@@ -595,6 +595,7 @@ mod tests {
         }
     }
 
+    #[cfg(windows)]
     #[test]
     fn cmd_shim_contains_baked_paths() {
         let content = build_cmd_shim(&sample_app_dir(), &sample_dsh_home());
@@ -652,6 +653,7 @@ mod tests {
         assert!(content.contains("DSH_PREFER_BUNDLED_PNPM"));
     }
 
+    #[cfg(windows)]
     #[test]
     fn ps1_shim_escapes_quotes() {
         let dir = PathBuf::from(r"C:\Users\o'brien\AppData\Roaming\io.github.hairyf.deepseek-harness-desktop");

--- a/src-tauri/src/service/download/core.rs
+++ b/src-tauri/src/service/download/core.rs
@@ -643,7 +643,12 @@ async fn fetch_latest_dsh_tag_from_atom() -> Result<String, String> {
 /// 纯函数，便于对真实页面片段做离线单元测试；解析失败返回 `None`。
 fn parse_digest_from_expanded_assets(body: &str, expected_name: &str) -> Option<String> {
     let pos = body.find(expected_name)?;
-    let window = &body[pos..(pos + 4096).min(body.len())];
+    // 4096 字节窗口的终点回退到 UTF-8 字符边界，避免切片落在多字节字符中间 panic
+    let mut end = (pos + 4096).min(body.len());
+    while end > pos && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    let window = &body[pos..end];
     const START: &str = "sha256:";
     let hash_start = window.find(START)?;
     let hash = &window[hash_start + START.len()..];

--- a/src-tauri/src/service/download/core.rs
+++ b/src-tauri/src/service/download/core.rs
@@ -1104,6 +1104,26 @@ mod tests {
     }
 
     #[test]
+    fn parsed_digest_window_clamps_to_char_boundary() {
+        // 构造一个 body 使 `(pos + 4096)` 恰好落在多字节字符的中间字节：
+        // 旧实现 `&body[pos..pos + 4096]` 会在非字符边界切片而 panic，修复后回退到边界再解析。
+        let name = "deepseek-harness-pkg-windows.zip";
+        let digest = "4d5416766eb4a66e81b83532abeea64de7e7e2e0bac69a4f0c0508e1d91936c0";
+        let prefix = format!("{name}<span>sha256:{digest}</span>");
+        let mut body = prefix.clone();
+        // 补齐到字节 4094 处，放一个 3 字节汉字（占用 4094..4097），使索引 4096 落在其中间字节
+        let needed = 4094usize.saturating_sub(body.len());
+        body.push_str(&"a".repeat(needed));
+        body.push('中');
+        body.push_str(&"a".repeat(16));
+        // 确保总长 > 4096，维持 (pos + 4096) 处于非边界字节（否则不会触发回退分支）
+        assert!(body.len() > 4096);
+        let got = parse_digest_from_expanded_assets(&body, name);
+        let expected = format!("sha256:{digest}");
+        assert_eq!(got.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
     fn parse_version_from_tag_formats() {
         assert_eq!(
             parse_version_from_tag("dsh-0.1.0-rc.7-32054485373").as_deref(),

--- a/src/i18n/index.detector.ts
+++ b/src/i18n/index.detector.ts
@@ -6,12 +6,17 @@ import { resources } from './index.resource'
 /** 语言偏好持久化 key，与 setting store 保持同步 */
 export const LANGUAGE_STORAGE_KEY = 'deepseek-harness-desktop-language'
 
-/** 同步语言探测：优先 localStorage 用户选择，其次浏览器语言 */
+/** 同步语言探测：优先 localStorage 用户选择，其次内存/后端，最后浏览器语言 */
 export const languageDetector: LanguageDetectorModule = {
   type: 'languageDetector',
   detect: () => {
-    // TODO: check store loaded
-    let selectedLanguage = store.setting.language
+    // 用户上次的显式选择（跨重启持久）优先
+    let selectedLanguage = localStorage?.getItem(LANGUAGE_STORAGE_KEY) ?? ''
+
+    // 会话内切换的语言（store 未持久化，仅作为次优先）
+    if (!selectedLanguage)
+      selectedLanguage = store.setting.language ?? ''
+
     if (selectedLanguage)
       return selectedLanguage
 
@@ -27,7 +32,10 @@ export const languageDetector: LanguageDetectorModule = {
     return selectedLanguage
   },
   cacheUserLanguage: (language: string) => {
-    invoke('set_language', { lang: language.startsWith('zh') ? 'zh' : 'en' })
+    localStorage?.setItem(LANGUAGE_STORAGE_KEY, language)
     store.setting.language = language
+    invoke('set_language', { lang: language.startsWith('zh') ? 'zh' : 'en' }).catch((err) => {
+      console.warn('[i18n] failed to persist language to backend:', err)
+    })
   },
 }

--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -118,7 +118,7 @@ export function Navbar({ iframeRef }: NavbarProps) {
   }
 
   return (
-    <div className="relative flex h-11 w-full flex-none select-none items-center gap-0.5 border-b border-line px-1.5 bg-[#f9fafb] dark:bg-[#1b1b1c]">
+    <div className="relative flex h-11 w-full flex-none select-none items-center gap-0.5 border-b border-line px-1.5 bg-panel">
       <If cond={iframeRef != null && tauriEnabled}>
         <Button
           className="rounded-lg size-7"

--- a/src/store/modules/harness/store.ts
+++ b/src/store/modules/harness/store.ts
@@ -129,7 +129,10 @@ function pickErrorLines(lines: string[]): string[] {
 
 /** 失败时把服务日志的真实错误行与冲突提示挂到错误对象上 */
 async function attachStartupDiagnostics(err: unknown): Promise<StartupError> {
-  const startupError = err as StartupError
+  // Tauri `invoke` 对 `Result<_, String>` 命令的 rejection 是裸字符串，
+  // 必须先归一化为 Error 对象，否则在其上赋属性（ESM 严格模式）会抛
+  // `TypeError: Cannot create property ... on string`，反而遮蔽真实错误。
+  const startupError: StartupError = err instanceof Error ? err : new Error(String(err))
   if (!startupError.logs) {
     const lines = await readServiceLogTail()
     startupError.logLines = lines
@@ -139,7 +142,7 @@ async function attachStartupDiagnostics(err: unknown): Promise<StartupError> {
       startupError.pluginConflictHint = i18next.t('errors.plugin_route_conflict')
     }
   }
-  return startupError
+  return startupError as StartupError
 }
 
 /**


### PR DESCRIPTION
## 摘要

M1 批次：修复完整代码审查中发现的最严重主流程崩溃问题（启动/安装路径），并顺手门控了两个仅 Windows 的 shim 测试。

## 前端 3 项

1. **启动错误被 TypeError 遮蔽**（`src/store/modules/harness/store.ts`）
   Tauri `invoke` 对 `Result<_, String>` 命令的 rejection 是**裸字符串**；原代码直接 `err as StartupError` 后在字符串上赋 `logLines` 属性，ESM 严格模式抛 `TypeError: Cannot create property 'logLines' on string`，把真实后端错误完全吞掉。现在先归一化为 `Error` 实例再附加诊断字段。

2. **导航栏深色模式失效**（`src/layout/components/navbar.tsx`）
   原硬编码 `bg-[#f9fafb] dark:bg-[#1b1b1c]`，但主题系统用 `<html data-theme>` 而非 `class="dark"`，深色永不生效。改用主题 token `bg-panel`（与硬编码值完全一致），随 `data-theme` 自动切换。

3. **语言偏好重启丢失**（`src/i18n/index.detector.ts`）
   `LANGUAGE_STORAGE_KEY` 已定义却从未使用；`cacheUserLanguage` 只写内存与后端，且 `invoke` 未 catch。现在写入 localStorage 并补 catch，`detect()` 优先读 localStorage。

## 后端 2 个

4. **服务日志读取字节切片 panic**（`src-tauri/src/bridge/system_os.rs`）
   `content[content.len() - max_bytes..]` 对含中文/ANSI 多字节的日志按字节切，切点落在字符中间即 panic（高频命令）。新增 `tail_bytes` 回退到 UTF-8 字符边界。

5. **安装失败状态卡死**（`src-tauri/src/bridge/lifecycle.rs`）
   原并发判断基于 `Status::Installing`：安装失败后状态永不回落，后续所有 `install_dependencies` 命中“正在安装”被静默跳过，必须重启应用才能重试。改用独立互斥锁 `INSTALL_LOCK` 做并发防护（TOCTOU 安全），失败路径显式复位状态并广播。

   `parse_digest_from_expanded_assets`（`download/core.rs`）同类切片边界 panic 一并修复。

## 测试

- `src-tauri/src/service/cli/shim.rs`：`cmd_shim_contains_baked_paths`、`ps1_shim_escapes_quotes` 断言 Windows 路径，在 macOS/Linux CI 必然失败，加 `#[cfg(windows)]` 门控。

## 验证

- `cargo check`：通过
- `cargo test --lib`：113 passed, 0 failed
- `pnpm typecheck`：通过
- `pnpm vitest run`：通过