### PR TITLE
fix(workflow): harden process state machine and cross-platform cancel

### DIFF
--- a/src-tauri/src/service/cli/shim.rs
+++ b/src-tauri/src/service/cli/shim.rs
@@ -596,6 +596,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
     fn cmd_shim_contains_baked_paths() {
         let content = build_cmd_shim(&sample_app_dir(), &sample_dsh_home());
         assert!(content.contains(r"C:\Users\test\AppData\Roaming"));
@@ -653,6 +654,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
     fn ps1_shim_escapes_quotes() {
         let dir = PathBuf::from(r"C:\Users\o'brien\AppData\Roaming\io.github.hairyf.deepseek-harness-desktop");
         let content = build_ps1_shim(&dir, &sample_dsh_home());

--- a/src-tauri/src/service/download/core.rs
+++ b/src-tauri/src/service/download/core.rs
@@ -135,6 +135,16 @@ async fn download_with_retry<'a, R: Runtime>(
     ))
 }
 
+/// 下载进度百分比（0.0–100.0）；总长未知（0）时返回 -1 表示「不确定进度」，
+/// 避免除零产生 +inf/NaN 污染前端进度条。
+fn download_progress_percent(received_total: u64, total_size: u64) -> f64 {
+    if total_size > 0 {
+        (received_total as f64 / total_size as f64) * 100.0
+    } else {
+        -1.0
+    }
+}
+
 /// 单次下载尝试：发起 GET 请求并把响应体流式读入 `buffer`。
 ///
 /// 已有部分数据时自动带 `Range: bytes=<已有>-` 续传；服务端返回 200（不支持
@@ -204,7 +214,9 @@ async fn download_attempt<'a, R: Runtime>(
         buffer.extend_from_slice(&chunk);
         downloaded += chunk.len() as u64;
         let received_total = resume_from + downloaded;
-        let progress_pct = (received_total as f64 / total_size as f64) * 100.0;
+        // 未知总长（服务器未给 Content-Length/分块传输）时进度取 -1，
+        // 避免 `received / 0 = +inf` 或 NaN 进度传给前端
+        let progress_pct = download_progress_percent(received_total, total_size);
         tracker.update(
             progress_pct,
             format!(
@@ -994,6 +1006,21 @@ pub async fn fetch_dsh_pkg_tags() -> Result<Vec<(String, String)>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn progress_percent_never_emits_nan_or_inf() {
+        // 总长已知：常规百分比
+        assert_eq!(download_progress_percent(50, 100), 50.0);
+        assert_eq!(download_progress_percent(0, 100), 0.0);
+        // 总长未知（0）：返回 -1 而非 inf/NaN（除零保护）
+        assert_eq!(download_progress_percent(50, 0), -1.0);
+        // 尚未开始且总长未知也不产生 NaN
+        assert_eq!(download_progress_percent(0, 0), -1.0);
+        // 数值绝对不出现非有限值
+        for pct in [download_progress_percent(50, 0), download_progress_percent(0, 0)] {
+            assert!(pct.is_finite(), "progress must be finite, got {pct}");
+        }
+    }
 
     #[test]
     fn sha256_verification_accepts_only_matching_digest() {

--- a/src-tauri/src/service/plugin/cancel.rs
+++ b/src-tauri/src/service/plugin/cancel.rs
@@ -1,8 +1,11 @@
 //! 取消正在进行的预装插件安装。
 //!
-//! Windows 下按命令行特征（`plugin --profile web add`）查找由本应用安装目录下
-//! node 拉起的进程树并强制结束（`taskkill /T /F`），随后向前端推送
-//! `preinstall-cancelled` 事件；非 Windows 平台没有隐藏控制台争用问题，直接忽略。
+//! 跨平台结束由本应用拉起的 `dsh plugin` 安装进程树：
+//! - Unix（macOS/Linux）：进程以独立进程组启动（`process_group(0)`，见
+//!   `process.rs`），此处对注册的 PID 发 `kill -<pid> SIGTERM` 一次结束整组
+//!   （含 pnpm / git 等子进程）；随后向前端推送 `preinstall-cancelled` 事件；
+//! - Windows：按命令行特征（`plugin --profile <档案> add`）查找由本应用安装
+//!   目录下 node 拉起的进程树并强制结束（`taskkill /T /F`）。
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
@@ -23,23 +26,49 @@ pub struct PreinstallCancelPayload {}
 
 /// 取消正在进行的预装插件安装
 pub async fn cancel(app_handle: &AppHandle) {
-    if !cfg!(windows) {
-        return;
+    // Unix：结束注册 PID 对应的安装进程组；Windows：按命令行特征 taskkill。
+    #[cfg(not(windows))]
+    {
+        if let Some(pid) = super::process::active_plugin_pid() {
+            log::info!("Cancelling dsh plugin install process group led by pid {pid}");
+            // 负 PID 语义：对整个进程组发 SIGTERM（子进程 pnpm/git 一并结束）。
+            // 注意 `--` 之后的负数才被 kill 当进程组号，直接 `kill -<pid>` 会被
+            // 误解析为信号编号。
+            let ok = std::process::Command::new("kill")
+                .args(["-TERM", "--", &format!("-{pid}")])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+            if !ok {
+                // 兜底：kill 命令不可用/失败时，至少结束直接子进程
+                let _ = std::process::Command::new("pkill")
+                    .arg("-TERM")
+                    .arg("-P")
+                    .arg(pid.to_string())
+                    .status();
+            }
+            log::warn!("preinstall cancel: kill(-{pid}) success={ok}");
+        } else {
+            log::debug!("preinstall cancel: no active install process");
+        }
     }
-
-    let Some(window) = app_handle.get_webview_window("main") else {
-        return;
-    };
 
     #[cfg(windows)]
     {
+        let Some(window) = app_handle.get_webview_window("main") else {
+            return;
+        };
+
         // 按当前档案匹配命令行：`dsh plugin --profile <当前档案> add`（不再写死 web）
         let profile = crate::service::profile::active_profile(app_handle);
         let base = config::get_dsh_install_path(app_handle)
             .to_string_lossy()
             .replace('\\', "\\\\");
+        // PowerShell 单引号转义：`'` → `''`（防断串/注入）
+        let profile_escaped = profile.replace('\'', "''");
+        let base_escaped = base.replace('\'', "''");
         let ps_cmd = format!(
-            "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\" | Where-Object {{ ($_.CommandLine -like '*plugin*--profile*{profile}*add*') -and ($_.ExecutablePath -like '{base}\\*') }} | ForEach-Object {{ taskkill /PID $_.ProcessId /T /F 2>$null }}"
+            "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\" | Where-Object {{ ($_.CommandLine -like '*plugin*--profile*{profile_escaped}*add*') -and ($_.ExecutablePath -like '{base_escaped}\\*') }} | ForEach-Object {{ taskkill /PID $_.ProcessId /T /F 2>$null }}"
         );
 
         let mut cmd = Command::new("powershell");
@@ -61,5 +90,7 @@ pub async fn cancel(app_handle: &AppHandle) {
         }
     }
 
-    let _ = window.emit(PREINSTALL_CANCEL_EVENT, PreinstallCancelPayload {});
+    if let Some(window) = app_handle.get_webview_window("main") {
+        let _ = window.emit(PREINSTALL_CANCEL_EVENT, PreinstallCancelPayload {});
+    }
 }

--- a/src-tauri/src/service/plugin/cancel.rs
+++ b/src-tauri/src/service/plugin/cancel.rs
@@ -55,7 +55,8 @@ pub async fn cancel(app_handle: &AppHandle) {
 
     #[cfg(windows)]
     {
-        let Some(window) = app_handle.get_webview_window("main") else {
+        // window 仅作「存在 main 窗口」的借位判定；实际 emit 在函数末尾统一做。
+        let Some(_window) = app_handle.get_webview_window("main") else {
             return;
         };
 

--- a/src-tauri/src/service/plugin/process.rs
+++ b/src-tauri/src/service/plugin/process.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{Emitter, WebviewWindow};
 
 #[cfg(windows)]
@@ -26,6 +26,36 @@ pub(crate) const PREINSTALL_LOG_EVENT: &str = "preinstall-log";
 #[serde(rename_all = "camelCase")]
 pub struct PreinstallLogPayload {
     pub line: String,
+}
+
+/// 当前正在运行的 `dsh plugin` 子进程 PID（无进行中安装时为 None）。
+///
+/// `cancel`（跨平台）用它结束安装进程树；安装结束/失败后必须复位，
+/// 防止把「下一个安装」或无关进程误杀。
+static ACTIVE_PLUGIN_PID: OnceLock<Mutex<Option<u32>>> = OnceLock::new();
+
+fn active_pid_lock() -> &'static Mutex<Option<u32>> {
+    ACTIVE_PLUGIN_PID.get_or_init(|| Mutex::new(None))
+}
+
+/// 当前进行中安装的根进程 PID（取消安装用）。
+pub(crate) fn active_plugin_pid() -> Option<u32> {
+    *active_pid_lock().lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// 记录/清除当前安装进程 PID（guard-drop 模式，作用域结束自动复位）。
+struct PidGuard;
+
+impl PidGuard {
+    fn set(pid: u32) {
+        *active_pid_lock().lock().unwrap_or_else(|e| e.into_inner()) = Some(pid);
+    }
+}
+
+impl Drop for PidGuard {
+    fn drop(&mut self) {
+        *active_pid_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
+    }
 }
 
 /// Windows 进程句柄包装：原始句柄是 `*mut c_void`（非 Send），
@@ -87,6 +117,7 @@ pub(crate) async fn run_plugin_process(
 
     #[cfg(not(windows))]
     {
+        use std::os::unix::process::CommandExt;
         let mut child = Command::new(node)
             .args(args)
             .envs(envs)
@@ -94,8 +125,14 @@ pub(crate) async fn run_plugin_process(
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            // 独立进程组：取消时可用 `kill(-pid, ...)` 一次结束整棵安装进程树
+            .process_group(0)
             .spawn()
             .map_err(|e| format!("PREINSTALL_SPAWN: {e}"))?;
+
+        let pid = child.id();
+        PidGuard::set(pid);
+        log::info!("dsh plugin install started, pid {pid}");
 
         if let Some(stdout) = child.stdout.take() {
             spawn_line_emitter(stdout, window.clone(), captured.clone());

--- a/src-tauri/src/service/plugin/process.rs
+++ b/src-tauri/src/service/plugin/process.rs
@@ -32,26 +32,35 @@ pub struct PreinstallLogPayload {
 ///
 /// `cancel`（跨平台）用它结束安装进程树；安装结束/失败后必须复位，
 /// 防止把「下一个安装」或无关进程误杀。
+///
+/// 仅在 Unix 被 `cancel` 使用（Windows 取消安装走 taskkill 按命令行匹配），
+/// 故 Windows 下按项目约定允许 dead_code。
+#[cfg_attr(windows, allow(dead_code))]
 static ACTIVE_PLUGIN_PID: OnceLock<Mutex<Option<u32>>> = OnceLock::new();
 
+#[cfg_attr(windows, allow(dead_code))]
 fn active_pid_lock() -> &'static Mutex<Option<u32>> {
     ACTIVE_PLUGIN_PID.get_or_init(|| Mutex::new(None))
 }
 
 /// 当前进行中安装的根进程 PID（取消安装用）。
+#[cfg_attr(windows, allow(dead_code))]
 pub(crate) fn active_plugin_pid() -> Option<u32> {
     *active_pid_lock().lock().unwrap_or_else(|e| e.into_inner())
 }
 
 /// 记录/清除当前安装进程 PID（guard-drop 模式，作用域结束自动复位）。
+#[cfg_attr(windows, allow(dead_code))]
 struct PidGuard;
 
+#[cfg_attr(windows, allow(dead_code))]
 impl PidGuard {
     fn set(pid: u32) {
         *active_pid_lock().lock().unwrap_or_else(|e| e.into_inner()) = Some(pid);
     }
 }
 
+#[cfg_attr(windows, allow(dead_code))]
 impl Drop for PidGuard {
     fn drop(&mut self) {
         *active_pid_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
@@ -132,6 +141,10 @@ pub(crate) async fn run_plugin_process(
 
         let pid = child.id();
         PidGuard::set(pid);
+        // 绑定守卫实例：本 cfg 块作用域结束时自动把共享 PID 槽复位为 None，
+        // 避免把「这一次安装」的 PID 泄漏给之后的取消/下一次安装（误杀无关进程）。
+        // 若 spawn_blocking 因错误提前 `?` 返回，守卫同样会 Drop 复位。
+        let _pid_guard = PidGuard;
         log::info!("dsh plugin install started, pid {pid}");
 
         if let Some(stdout) = child.stdout.take() {

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -55,12 +55,34 @@ fn set_owned_process_with_handle(pid: u32, handle: usize) {
 }
 
 /// 原子取出持有的进程（PID+句柄一起）。Whoever takes it is responsible for
-/// closing the Windows handle.
+/// closing the Windows handle. 无条件取出（停止/退出路径）。
 fn take_owned_process() -> Option<OwnedProcess> {
     owned_process_lock()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .take()
+}
+
+/// 仅当当前持有进程的 PID 与 `pid` 匹配时才取出（成对 PID+句柄）。
+///
+/// 保留 base 代码 `compare_exchange(pid, 0)` 的防护语义：退出监视线程只能清掉
+/// 属于自己那一条登记，绝不误取/误清「刚启动的新进程」的登记——否则会把它
+/// 当作已退出而错误回落 Status，并把新进程的句柄误关（WARN-6 合并引入的回退）。
+fn take_owned_process_if(pid: u32) -> Option<OwnedProcess> {
+    let mut guard = owned_process_lock().lock().unwrap_or_else(|e| e.into_inner());
+    take_owned_process_if_matching(&mut guard, pid)
+}
+
+/// 纯函数部分：便于单测，不触碰全局状态。
+fn take_owned_process_if_matching(
+    owned: &mut Option<OwnedProcess>,
+    pid: u32,
+) -> Option<OwnedProcess> {
+    if owned.as_ref().map(|p| p.pid) == Some(pid) {
+        owned.take()
+    } else {
+        None
+    }
 }
 
 struct LaunchGuard;
@@ -188,16 +210,17 @@ pub fn has_owned_process() -> bool {
 
 /// 处理「持有的 dsh 进程退出」这一事实（由退出监视线程与健康检查 tick 共用）：
 ///
-/// - 清空持有的 PID/句柄（`take` 保证只会被清一次，PID/句柄作为整体成对
-///   取出，PID 复用窗口最小化）；
+/// - 仅当退出的 PID 仍是当前登记的那个进程时才清空持有（`take_owned_process_if`
+///   按 pid 匹配），PID/句柄作为整体成对取出——杜绝「读 PID」与「清句柄」
+///   之间的跨原子竞态（WARN-6），也杜绝旧监视线程误清新启动进程的登记；
 /// - 若当前状态仍是 Running，回落到 Stopped——否则进程已经没了、状态却永远
 ///   显示「运行中」，前端按钮/横幅会长期处于错误语义（WARN-5）。
 ///
 /// 返回被取出的进程记录（含 Windows 句柄），取到者负责 `CloseHandle`——保证
 /// 「取走进程」与「关闭句柄」同属一个调用者，杜绝重复 close。幂等：多次调用
 /// （tick 与监视线程并发）只会生效一次，后续调用返回 None。
-fn on_owned_process_exit() -> Option<OwnedProcess> {
-    let owned = take_owned_process()?;
+fn on_owned_process_exit(pid: u32) -> Option<OwnedProcess> {
+    let owned = take_owned_process_if(pid)?;
 
     log::warn!(
         "Owned Harness process {} exited; resetting status to Stopped",
@@ -645,10 +668,11 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                     }
                     // 进程确已退出：清空持有 PID 并把 Status 从 Running 回落为
                     // Stopped（原有实现只清 PID、状态永远停留在 Running）。
+                    // 仅当该 PID 仍是当前登记才取出——旧监视线程不会误清新进程。
                     // take 返回值里的句柄由本线程负责关闭（不会与
                     // terminate_owned_process 重复 close——进程已 exit，
                     // 通常是本线程取走）。
-                    let owned = on_owned_process_exit();
+                    let owned = on_owned_process_exit(pid);
                     if let Some(owned) = owned {
                         let h = owned.handle as windows_sys::Win32::Foundation::HANDLE;
                         CloseHandle(h);
@@ -694,8 +718,9 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                         log::warn!("Owned Harness process {pid} exited (no exit code)");
                     }
                     // 进程确已退出：清空持有 PID 并把 Status 从 Running 回落为 Stopped
-                    // （Unix 无进程句柄可关闭，忽略返回的进程记录）
-                    let _ = on_owned_process_exit();
+                    // （Unix 无进程句柄可关闭，忽略返回的进程记录）。
+                    // 仅当该 PID 仍是当前登记才取出——旧监视线程不会误清新进程。
+                    let _ = on_owned_process_exit(pid);
                 });
                 (stdout, stderr, pid)
             })
@@ -1009,5 +1034,36 @@ mod tests {
         assert!(!version_supports_no_open("0.1"));
         assert!(!version_supports_no_open("v0.1.0"));
         assert!(!version_supports_no_open("not-a-version"));
+    }
+
+    /// 构造一个测试用 `OwnedProcess`（跨平台处理 Windows 句柄字段）。
+    #[cfg(windows)]
+    fn test_owned(pid: u32) -> OwnedProcess {
+        OwnedProcess { pid, handle: 0 }
+    }
+    #[cfg(not(windows))]
+    fn test_owned(pid: u32) -> OwnedProcess {
+        OwnedProcess { pid }
+    }
+
+    /// 退出监视线程只能清掉「与自己 PID 匹配」的登记，不许误清刚启动的新进程，
+    /// 也不许重复取出（幂等）。回归 WARN-6 合并引入的回退。
+    #[test]
+    fn owned_process_take_if_only_matches_pid() {
+        // 匹配的 PID 才可取出，且取走后槽清空
+        let mut slot = Some(test_owned(42));
+        let taken = take_owned_process_if_matching(&mut slot, 42);
+        assert_eq!(taken.map(|p| p.pid), Some(42));
+        assert!(slot.is_none());
+
+        // PID 不匹配（旧进程 41 退出）时禁止取出/清空新进程（新进程 42）
+        let mut slot = Some(test_owned(42));
+        let taken = take_owned_process_if_matching(&mut slot, 41);
+        assert!(taken.is_none());
+        assert_eq!(slot.as_ref().map(|p| p.pid), Some(42));
+
+        // 幂等：已清空后再次取出返回 None
+        let mut slot: Option<OwnedProcess> = None;
+        assert!(take_owned_process_if_matching(&mut slot, 42).is_none());
     }
 }

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -13,18 +13,55 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
 use std::process::{Command, Stdio};
-#[cfg(windows)]
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 use tauri::Manager;
 
 /// 启动守卫：并发调用 `launch` 时只允许一个真正拉起 dsh 进程
 static LAUNCH_GUARD: AtomicBool = AtomicBool::new(false);
-/// 当前进程内由桌面端创建的 Harness 根进程 PID；0 表示没有持有的实例。
-static OWNED_PROCESS_ID: AtomicU32 = AtomicU32::new(0);
-/// Windows 进程句柄用于确认 PID 仍指向原进程，消除 PID 复用误杀窗口。
+
+/// 当前进程内由桌面端创建的 Harness 根进程（PID + Windows 句柄）。
+///
+/// PID 与句柄装在同一把锁的可选值里：`take()` 一次性成对取出，保证
+/// 「PID 清空」与「句柄关闭」之间不存在跨原子竞态（WARN-6）。历史上 PID/句柄
+/// 分两个 `Atomic*` 存储，`stop` 读 PID 与监视线程清句柄之间有微窗口可能导致
+/// 漏杀或重复 close。
+#[derive(Clone, Copy)]
+struct OwnedProcess {
+    pid: u32,
+    /// Windows 进程句柄（原始 HANDLE 转 usize 存储，避免 `*mut c_void` 非 Send）。
+    /// 只在 Windows 存在；Unix 无句柄概念。
+    #[cfg(windows)]
+    handle: usize,
+}
+
+fn owned_process_lock() -> &'static Mutex<Option<OwnedProcess>> {
+    static OWNED_PROCESS: OnceLock<Mutex<Option<OwnedProcess>>> = OnceLock::new();
+    OWNED_PROCESS.get_or_init(|| Mutex::new(None))
+}
+
+/// 记录新持有的 Harness 根进程（Unix，启动成功后调用）。
+#[cfg(not(windows))]
+fn set_owned_process(pid: u32) {
+    let mut guard = owned_process_lock().lock().unwrap_or_else(|e| e.into_inner());
+    *guard = Some(OwnedProcess { pid });
+}
+
+/// 若调用方 owns 该进程（Windows 额外存句柄），记录之。
 #[cfg(windows)]
-static OWNED_PROCESS_HANDLE: AtomicUsize = AtomicUsize::new(0);
+fn set_owned_process_with_handle(pid: u32, handle: usize) {
+    let mut guard = owned_process_lock().lock().unwrap_or_else(|e| e.into_inner());
+    *guard = Some(OwnedProcess { pid, handle });
+}
+
+/// 原子取出持有的进程（PID+句柄一起）。Whoever takes it is responsible for
+/// closing the Windows handle.
+fn take_owned_process() -> Option<OwnedProcess> {
+    owned_process_lock()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .take()
+}
 
 struct LaunchGuard;
 
@@ -84,27 +121,26 @@ fn web_supports_no_open_flag(app_handle: &tauri::AppHandle) -> bool {
 
 /// 只结束本应用当前进程创建并仍持有的 Harness 进程树。
 fn terminate_owned_process() {
-    let pid = OWNED_PROCESS_ID.swap(0, Ordering::SeqCst);
-    if pid == 0 {
+    // 一次性取出 PID+句柄（成对），杜绝「PID 已清空/句柄未清」的漏杀窗口
+    let Some(owned) = take_owned_process() else {
         return;
-    }
+    };
 
     #[cfg(windows)]
     {
         use windows_sys::Win32::Foundation::CloseHandle;
         use windows_sys::Win32::System::Threading::WaitForSingleObject;
         const WAIT_TIMEOUT_CODE: u32 = 0x0000_0102;
-        let handle_value = OWNED_PROCESS_HANDLE.swap(0, Ordering::SeqCst);
-        if handle_value == 0 {
+        let handle = owned.handle as windows_sys::Win32::Foundation::HANDLE;
+        if handle.is_null() {
             return;
         }
-        let handle = handle_value as windows_sys::Win32::Foundation::HANDLE;
         // 真实句柄已结束说明 PID 可能已复用，此时绝不调用 taskkill。
         if unsafe { WaitForSingleObject(handle, 0) } != WAIT_TIMEOUT_CODE {
             unsafe { CloseHandle(handle) };
             return;
         }
-        kill_pid_tree(pid);
+        kill_pid_tree(owned.pid);
         unsafe {
             WaitForSingleObject(handle, 5_000);
             CloseHandle(handle);
@@ -113,7 +149,7 @@ fn terminate_owned_process() {
 
     #[cfg(unix)]
     {
-        kill_pid_tree(pid);
+        kill_pid_tree(owned.pid);
     }
 }
 
@@ -144,7 +180,34 @@ fn kill_pid_tree(pid: u32) {
 }
 
 pub fn has_owned_process() -> bool {
-    OWNED_PROCESS_ID.load(Ordering::SeqCst) != 0
+    owned_process_lock()
+        .lock()
+        .map(|g| g.is_some())
+        .unwrap_or(false)
+}
+
+/// 处理「持有的 dsh 进程退出」这一事实（由退出监视线程与健康检查 tick 共用）：
+///
+/// - 清空持有的 PID/句柄（`take` 保证只会被清一次，PID/句柄作为整体成对
+///   取出，PID 复用窗口最小化）；
+/// - 若当前状态仍是 Running，回落到 Stopped——否则进程已经没了、状态却永远
+///   显示「运行中」，前端按钮/横幅会长期处于错误语义（WARN-5）。
+///
+/// 返回被取出的进程记录（含 Windows 句柄），取到者负责 `CloseHandle`——保证
+/// 「取走进程」与「关闭句柄」同属一个调用者，杜绝重复 close。幂等：多次调用
+/// （tick 与监视线程并发）只会生效一次，后续调用返回 None。
+fn on_owned_process_exit() -> Option<OwnedProcess> {
+    let owned = take_owned_process()?;
+
+    log::warn!(
+        "Owned Harness process {} exited; resetting status to Stopped",
+        owned.pid
+    );
+
+    if status::get_status() == status::Status::Running {
+        status::set_status(status::Status::Stopped);
+    }
+    Some(owned)
 }
 
 /// 结束所有从本应用 dsh 安装目录启动的 Harness 服务进程（含历史崩溃残留的孤儿实例）。
@@ -562,10 +625,9 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                 &envs,
             )
             .map(|(stdout, stderr, pid, handle)| {
-                OWNED_PROCESS_ID.store(pid, Ordering::SeqCst);
-                // 持有真实进程句柄直到退出；退出后仅在 PID 仍匹配时清空，避免复用。
+                // PID 与句柄作为整体一次登记，与退出清理（take 一并取出）配对
                 let handle_value = handle as usize;
-                OWNED_PROCESS_HANDLE.store(handle_value, Ordering::SeqCst);
+                set_owned_process_with_handle(pid, handle_value);
                 std::thread::spawn(move || unsafe {
                     use windows_sys::Win32::Foundation::CloseHandle;
                     use windows_sys::Win32::System::Threading::{
@@ -581,17 +643,15 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                     } else {
                         log::warn!("Owned Harness process {pid} exited (exit code unavailable)");
                     }
-                    let _ = OWNED_PROCESS_ID.compare_exchange(
-                        pid,
-                        0,
-                        Ordering::SeqCst,
-                        Ordering::SeqCst,
-                    );
-                    let owns_handle = OWNED_PROCESS_HANDLE
-                        .compare_exchange(handle_value, 0, Ordering::SeqCst, Ordering::SeqCst)
-                        .is_ok();
-                    if owns_handle {
-                        CloseHandle(process_handle);
+                    // 进程确已退出：清空持有 PID 并把 Status 从 Running 回落为
+                    // Stopped（原有实现只清 PID、状态永远停留在 Running）。
+                    // take 返回值里的句柄由本线程负责关闭（不会与
+                    // terminate_owned_process 重复 close——进程已 exit，
+                    // 通常是本线程取走）。
+                    let owned = on_owned_process_exit();
+                    if let Some(owned) = owned {
+                        let h = owned.handle as windows_sys::Win32::Foundation::HANDLE;
+                        CloseHandle(h);
                     }
                 });
                 (Some(stdout), Some(stderr), pid)
@@ -624,7 +684,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                 let pid = child.id();
                 let stdout = child.stdout.take();
                 let stderr = child.stderr.take();
-                OWNED_PROCESS_ID.store(pid, Ordering::SeqCst);
+                set_owned_process(pid);
                 std::thread::spawn(move || {
                     let code = child.wait().ok().and_then(|status| status.code());
                     // 记录退出码：启动即崩溃（插件冲突等）时前端据此快速失败
@@ -633,12 +693,9 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                     } else {
                         log::warn!("Owned Harness process {pid} exited (no exit code)");
                     }
-                    let _ = OWNED_PROCESS_ID.compare_exchange(
-                        pid,
-                        0,
-                        Ordering::SeqCst,
-                        Ordering::SeqCst,
-                    );
+                    // 进程确已退出：清空持有 PID 并把 Status 从 Running 回落为 Stopped
+                    // （Unix 无进程句柄可关闭，忽略返回的进程记录）
+                    let _ = on_owned_process_exit();
                 });
                 (stdout, stderr, pid)
             })

--- a/src-tauri/src/service/workflow/win_inspector.rs
+++ b/src-tauri/src/service/workflow/win_inspector.rs
@@ -120,11 +120,22 @@ mod imp {
             serde_yaml::Value::Sequence(seq) => seq,
             _ => unreachable!("parse_patch_list only returns a sequence"),
         };
-        // 已挂载则跳过（幂等）。
-        if seq.iter().any(block_is_ours) {
-            return Ok(());
+        // 迁移 + 幂等：已有本插件块时只需把旧的「裸包名」写法改写为相对路径写法；
+        // 完全没有才追加新块。避免把旧写法当作「已挂载」直接跳过，导致修复对
+        // 存量安装用户不生效（它们是注释-实现矛盾的历史受害者）。
+        let mut has_ours = false;
+        for el in seq.iter_mut() {
+            if block_is_ours(el) {
+                has_ours = true;
+                if block_uses_bare_name(el) {
+                    // 整块替换为规范写法（仅 id + name，其余字段不涉及本插件）。
+                    *el = plugin_insert_entry();
+                }
+            }
         }
-        seq.push(plugin_insert_entry());
+        if !has_ours {
+            seq.push(plugin_insert_entry());
+        }
 
         let out = serde_yaml::to_string(&doc)
             .map_err(|e| format!("PATCH_RENDER_FAILED: {e}"))?;
@@ -215,6 +226,17 @@ mod imp {
     fn block_is_ours(el: &serde_yaml::Value) -> bool {
         serde_yaml::to_string(el)
             .map(|s| s.contains(PATCH_MARKER))
+            .unwrap_or(false)
+    }
+
+    /// 挂载块是否仍使用「裸包名」旧写法（`name: dsh-win-terminal-inspector`）。
+    ///
+    /// 与相对路径写法（`name: ./node_modules/dsh-win-terminal-inspector`）区分：
+    /// 裸包名无法被 dsh loader 按 harness baseUrl 可靠解析，是历史注释-实现矛盾处。
+    fn block_uses_bare_name(el: &serde_yaml::Value) -> bool {
+        serde_yaml::to_string(el)
+            .map(|s| s.contains("name: dsh-win-terminal-inspector")
+                && !s.contains("name: ./node_modules/dsh-win-terminal-inspector"))
             .unwrap_or(false)
     }
 
@@ -569,6 +591,35 @@ mod imp {
                 !out.contains("name: dsh-win-terminal-inspector\n"),
                 "patch must not use bare package name, got:\n{out}"
             );
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn ensure_patch_upgrades_existing_bare_name_entry() {
+            let dir = temp_dir("m");
+            std::fs::create_dir_all(&dir).unwrap();
+            let patch = dir.join("cordis.patch.yml");
+            // 旧写法（历史注释-实现矛盾处）：裸包名无法被 loader 按 baseUrl 解析
+            std::fs::write(
+                &patch,
+                "- insert:\n    - id: win-terminal-inspector\n      name: dsh-win-terminal-inspector\n",
+            )
+            .unwrap();
+            ensure_patch(&dir).unwrap();
+            let out = std::fs::read_to_string(&patch).unwrap();
+            // 存量旧条目必须被改写为相对 profile 路径，而不是当作「已挂载」跳过
+            assert!(
+                out.contains("name: ./node_modules/dsh-win-terminal-inspector"),
+                "bare-name entry must be migrated to profile-relative path, got:\n{out}"
+            );
+            assert!(
+                !out.contains("name: dsh-win-terminal-inspector\n"),
+                "bare-name form must be gone after migration, got:\n{out}"
+            );
+            // 幂等：再次运行不改写、不产生重复块
+            ensure_patch(&dir).unwrap();
+            let out2 = std::fs::read_to_string(&patch).unwrap();
+            assert_eq!(out, out2);
             std::fs::remove_dir_all(&dir).ok();
         }
 

--- a/src-tauri/src/service/workflow/win_inspector.rs
+++ b/src-tauri/src/service/workflow/win_inspector.rs
@@ -45,14 +45,14 @@ mod imp {
 
     /// cordis.patch.yml 追加的挂载行（顶层数组的一个 `- insert:` 元素）。
     ///
-    /// name 必须用相对 profile 目录的路径（`./node_modules/...`），不能用裸包名：
+    /// name 用相对 profile 目录的路径（`./node_modules/...`），不用裸包名：
     /// dsh loader 对 profile patch 条目的模块解析以 harness 安装为 baseUrl，
     /// 裸插件名无法可靠解析；而相对路径经 `new URL(name, baseUrl)` 基于 profile
     /// 目录解析，稳定指向 `dsh plugin add` 装入的 node_modules。
     const PATCH_ENTRY: &str = concat!(
         "- insert:\n",
         "    - id: win-terminal-inspector\n",
-        "      name: dsh-win-terminal-inspector\n",
+        "      name: ./node_modules/dsh-win-terminal-inspector\n",
     );
 
     /// 注入判定标记：patch 中出现该字符串即视为已挂载。
@@ -557,7 +557,18 @@ mod imp {
             std::fs::create_dir_all(&dir).unwrap();
             ensure_patch(&dir).unwrap();
             let out = std::fs::read_to_string(dir.join("cordis.patch.yml")).unwrap();
-            assert!(out.contains("dsh-win-terminal-inspector"));
+            // 必须是 `name: ./node_modules/dsh-win-terminal-inspector`（相对 profile
+            // 目录路径）。裸包名（`name: dsh-win-terminal-inspector`）无法被 dsh
+            // loader 按 harness baseUrl 可靠解析，是历史实现的注释-实现矛盾处。
+            assert!(
+                out.contains("name: ./node_modules/dsh-win-terminal-inspector"),
+                "patch must mount via profile-relative path, got:\n{out}"
+            );
+            // 单独断言不含裸包名写法（`name: dsh-win-terminal-inspector` 后直接换行）
+            assert!(
+                !out.contains("name: dsh-win-terminal-inspector\n"),
+                "patch must not use bare package name, got:\n{out}"
+            );
             std::fs::remove_dir_all(&dir).ok();
         }
 

--- a/src-tauri/src/task/tick_check_dsh_process/mod.rs
+++ b/src-tauri/src/task/tick_check_dsh_process/mod.rs
@@ -23,5 +23,13 @@ pub async fn trigger(app_handle: AppHandle) -> Result<(), Box<dyn std::error::Er
         status::emit_status(&app_handle);
     }
 
+    // 反向回收：不再持有 dsh 进程（退出监视线程可能因崩溃等未复位）而状态仍
+    // 停在 Running 时兜底回落 Stopped，避免前端长期显示错误的「运行中」。
+    if !crate::service::workflow::has_owned_process() && current_status == Status::Running {
+        log::warn!("DSH status check: no owned process yet status Running; resetting to Stopped");
+        status::set_status(Status::Stopped);
+        status::emit_status(&app_handle);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## 摘要

P1 批次：状态机 / 进程健壮性（fix 方案第 10–15 项；第 9 项并发安装互斥已在 M1 以 `INSTALL_LOCK` 交付，随 #67 合并，此处不重复）。

## #10+11 · 跨平台取消安装（WARN-3 / WARN-4）

**`service/plugin/process.rs`**
- 安装根进程登记到共享 PID 槽（`active_plugin_pid`，RAII guard 自动复位，不会误杀后续安装）；
- Unix 以 `process_group(0)` 建立独立进程组。

**`service/plugin/cancel.rs`**
- **Unix 不再空实现**：对注册 PID 的进程组发 `kill -TERM -- -<pid>`（一次结束 pnpm/git 等整棵子进程树，误写信号号的坑已规避），kill 失败时 `pkill` 兜底直接子进程；
- Windows PowerShell 命令对 `profile`/`base` 做单引号转义（`'`→`''`），杜绝注入与断串。

## #12 · 等待 / 进程退出后 Status 不回落（WARN-5）

- `service/workflow/mod.rs`：新增 `on_owned_process_exit()`，监视线程检测到进程退出时清空持有并将 Status 从 Running 回落为 Stopped（幂等）；
- `task/tick_check_dsh_process/mod.rs`：反向兜底——无持有进程时状态仍 Running 则回落并 emit，防监视线程自身异常退出导致状态永远卡运行。

## #13 · OWNED_PROCESS_ID/HANDLE 双原子合并（WARN-6）

- PID 与 Windows 句柄合并为单把 `Mutex<Option<OwnedProcess>>`，`take()` 一次性成对取出；
- 消除 stop 与监视线程并行时「PID 已清 / 句柄未清」的漏杀或重复 close 窗口。

## #14 · win_inspector 注释-实现矛盾（WARN-7）

- 挂载行改为注释声称的 `name: ./node_modules/dsh-win-terminal-inspector`（相对 profile 目录路径；裸包名无法按 harness baseUrl 可靠解析）；
- 强化断言测试区分两种写法。

## #15 · 下载进度除零（LOW-1）

- `service/download/core.rs` 抽出 `download_progress_percent()`：总长未知（0）返回 -1（前端 `Math.max` 兜底不显示），杜绝 +inf/NaN；
- 新增有限性单测。

## 验证

- `cargo check` 通过
- `cargo test --lib`：**114 passed, 0 failed**（Windows 专属 shim 测试按平台 `#[cfg(windows)]` 隔离，本分支基于 main 自带该修复）