### PR TITLE
fix(workflow): bypass proxy for loopback health checks

### DIFF
--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -878,10 +878,9 @@ pub async fn proxy_health_check(port: u16) -> Result<String, String> {
     if !has_owned_process() {
         return Err("HARNESS_NOT_OWNED: no Harness process is owned by this app".to_string());
     }
-    let client = reqwest::Client::builder()
-        .timeout(config::HEALTH_CHECK_TIMEOUT)
-        .build()
-        .map_err(|e| e.to_string())?;
+    let client = utils::loopback_http_client(config::HEALTH_CHECK_TIMEOUT)
+        .map_err(|e| format!("HARNESS_HEALTH_CLIENT_FAILED: {e}"))?;
+    let mut failures = Vec::with_capacity(2);
 
     for endpoint in [
         format!("http://127.0.0.1:{port}/"),
@@ -897,13 +896,20 @@ pub async fn proxy_health_check(port: u16) -> Result<String, String> {
                         body.chars().take(80).collect::<String>()
                     ));
                 }
+                let failure = format!("{endpoint} returned {status}");
+                log::debug!("Health check failed: {failure}");
+                failures.push(failure);
             }
             Err(err) => {
                 log::debug!("Health check {endpoint}: {err}");
+                failures.push(format!("{endpoint}: {err}"));
             }
         }
     }
-    Err("HARNESS_NOT_READY: Harness service is not ready".to_string())
+    Err(format!(
+        "HARNESS_NOT_READY: Harness service is not ready ({})",
+        failures.join("; ")
+    ))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/service/workflow/utils.rs
+++ b/src-tauri/src/service/workflow/utils.rs
@@ -12,12 +12,21 @@ fn dsh_log_lock() -> &'static Mutex<()> {
     DSH_LOG_LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// 构造仅用于回环地址探测的 HTTP 客户端。
+///
+/// 生命周期探测访问的是本机 dsh，不能继承 `HTTP_PROXY` / `ALL_PROXY`：部分代理
+/// 不尊重回环地址直连，或应用进程没有 `NO_PROXY`，会把健康检查转发到外部代理，
+/// 造成端口已经监听但持续误报未就绪。
+pub(super) fn loopback_http_client(timeout: Duration) -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .no_proxy()
+        .timeout(timeout)
+        .build()
+}
+
 /// 检查 Harness 是否真正在运行（探测指定端口，随配置端口联动）
 pub async fn is_dsh_running(port: u16) -> bool {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-        .ok(); // 将 Result 转为 Option
+    let client = loopback_http_client(Duration::from_secs(2)).ok(); // 将 Result 转为 Option
 
     // 如果 client 创建失败，直接返回 false
     let client = match client {


### PR DESCRIPTION
可能和 #42 是相同的原因

### 问题表现

环境：

- Desktop App：0.7.3
- dsh：0.1.1-rc.2
- Node.js：26.0.0
- macOS arm64

dsh 进程成功启动并输出：

```text
dsh web: http://127.0.0.1:3080
```

但桌面端连续多次健康检查失败：

```text
HARNESS_NOT_READY: Harness service is not ready
```

最终界面提示 Harness 启动超时。期间 dsh 进程没有崩溃；关闭并重新启动应用后，同一套安装可以正常通过健康检查。

### 原因分析

桌面端通过 Rust `reqwest` 请求本机 `127.0.0.1` 检查服务状态，但原实现沿用了 reqwest 默认代理策略。

当应用进程存在 `HTTP_PROXY`、`ALL_PROXY` 等代理配置，而未正确配置 `NO_PROXY` 时，本应直连本机的健康检查可能被转发至代理服务器，导致 dsh 已经监听端口，桌面端却持续误判为未就绪。

此外，原错误统一返回 `HARNESS_NOT_READY`，没有记录具体端点、HTTP 状态码或连接错误，难以判断是代理、连接超时还是服务返回非 2xx。

补充说明：

- dsh 0.1.1-rc.2 的 `/` 正常返回 200。
- `/healthz` 返回 404，但健康检查同时探测 `/` 和 `/healthz`，任一成功即可，因此 `/healthz` 的 404 本身不是故障原因。
- 原始日志不足以百分之百证明当时一定经过了代理，因此本次修复同时属于代理规避和诊断增强。

### 解决方案

1. 新增专用于回环地址的 HTTP 客户端，调用 `reqwest::ClientBuilder::no_proxy()`，明确禁止本机生命周期探测使用任何系统或环境代理。
2. 启动健康检查和后台服务状态轮询统一使用该客户端。
3. 健康检查失败时同时保留 `/` 与 `/healthz` 的实际结果，包括 HTTP 状态码或连接错误，不再只返回笼统的“服务未就绪”。

### 修复效果

- `127.0.0.1` 健康检查始终直连本机 dsh。
- 避免代理环境造成“进程已启动、端口已监听，但桌面端误报超时”。
- 如果后续仍然失败，前台日志会包含两个探测端点的真实错误，方便进一步定位。
- 不影响依赖下载、更新检查等需要使用代理的外部网络请求。

<img width="2560" height="1680" alt="image" src="https://github.com/user-attachments/assets/e91972f1-eff3-4843-a18b-fd7885a3a9bf" />


