### PR TITLE
feat: 适配 macOS 原生全屏与系统菜单栏交互

### DIFF
--- a/src-tauri/src/bridge/app_config.rs
+++ b/src-tauri/src/bridge/app_config.rs
@@ -61,6 +61,10 @@ pub fn set_language(app_handle: AppHandle, lang: String) {
         "en" | "en-US" => config::i18n::Lang::En,
         _ => config::i18n::Lang::Zh,
     });
+    #[cfg(target_os = "macos")]
+    if let Err(error) = crate::desktop::builder::install_macos_menu(&app_handle) {
+        log::warn!("[menu] failed to refresh macOS menu language: {error}");
+    }
 }
 
 /// 切换侧边栏（布局状态保存在前端，保留该命令以对齐参考实现）

--- a/src-tauri/src/config/i18n.rs
+++ b/src-tauri/src/config/i18n.rs
@@ -50,6 +50,14 @@ pub fn t(key: &str) -> String {
         "install.extracting" => ("正在解压", "Extracting"),
         "install.downloaded" => ("已下载", "Downloaded"),
         "install.done" => ("依赖已安装完毕", "Dependencies installed"),
+        "menu.application" => ("应用", "Application"),
+        "menu.help" => ("帮助", "Help"),
+        "menu.settings" => ("设置…", "Settings…"),
+        "menu.enter_fullscreen" => ("进入全屏幕", "Enter Full Screen"),
+        "menu.exit_fullscreen" => ("退出全屏幕", "Exit Full Screen"),
+        "menu.about" => ("关于 Desktop", "About Desktop"),
+        "menu.run_logs" => ("运行日志", "Run Logs"),
+        "menu.check_update" => ("检查更新", "Check for Updates"),
         _ => (key, key),
     };
     match lang() {

--- a/src-tauri/src/config/window_state.rs
+++ b/src-tauri/src/config/window_state.rs
@@ -1,7 +1,7 @@
 //! 主窗口几何持久化：记住窗口大小/位置/最大化状态，重启后恢复。
 //!
 //! 为什么不直接用官方的 tauri-plugin-window-state：本项目主窗口是程序化创建
-//! （见 `desktop::builder::build_main_window`）、无标题栏 `decorations(false)`，
+//! （见 `desktop::builder::build_main_window`）、自定义壳层标题栏（macOS 上保留原生交通灯），
 //! 且关闭时是「隐藏到托盘」而非销毁（见 builder 的 on_window_event），并叠加
 //! release 的单例复用（二次启动 show/focus 同一窗口）。插件默认把状态写进独立的
 //! 配置文件、恢复时机与这套「隐藏 + 单例」流程存在耦合，且与本项目「所有应用数据
@@ -86,6 +86,12 @@ fn save_window_state<R: Runtime>(app_handle: &AppHandle<R>, state: &WindowState)
 
 /// 采样当前窗口并保存（主窗口移动/缩放时由 builder 调用）。
 pub fn save_geometry<R: Runtime>(window: &Window<R>) {
+    // 原生全屏切换会触发 Resized，但此时的屏幕尺寸不是可恢复的
+    // 普通窗口几何；保留进入全屏前的最后一帧，退出全屏后会再次正常采样。
+    if window.is_fullscreen().unwrap_or(false) {
+        return;
+    }
+
     let pos = window.outer_position().ok();
     let size = window.outer_size().ok();
     let state = WindowState {

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -2,18 +2,30 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(windows)]
 use std::sync::Arc;
+#[cfg(target_os = "macos")]
+use std::sync::{Mutex, OnceLock};
 
 use tauri::{
     ipc::Invoke,
     menu::{Menu, MenuEvent, MenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
-    Runtime, WebviewUrl, WebviewWindowBuilder, Wry,
+    Emitter, Runtime, WebviewUrl, WebviewWindowBuilder, Wry,
 };
 
-use crate::utils::show_main_window;
-use crate::desktop::window::{on_download, on_new_window};
+#[cfg(target_os = "macos")]
+use tauri::{
+    menu::{PredefinedMenuItem, Submenu},
+    Manager,
+};
+
+#[cfg(target_os = "macos")]
+static MACOS_FULLSCREEN_MENU_ITEM: OnceLock<Mutex<Option<PredefinedMenuItem<Wry>>>> =
+    OnceLock::new();
+
 #[cfg(windows)]
 use crate::desktop::window::on_page_load;
+use crate::desktop::window::{on_download, on_new_window};
+use crate::utils::show_main_window;
 
 /// setup app
 pub fn setup(app_handle: tauri::AppHandle) {
@@ -103,6 +115,128 @@ pub fn tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
         .build(app)?;
 
     Ok(())
+}
+
+/// 安装 macOS 全局菜单栏操作。
+///
+/// 菜单由原生层在窗口启动前后始终持有，避免 WebView 重载或进入独立全屏 Space
+/// 时丢失；点击后只发送动作 id，由前端复用现有对话框和更新流程。
+#[cfg(target_os = "macos")]
+pub fn install_macos_menu(app: &tauri::AppHandle<Wry>) -> tauri::Result<()> {
+    let setting = crate::config::get_store_dat_setting(app);
+    crate::config::i18n::set_language(match setting.language.as_str() {
+        "en" | "en-US" => crate::config::i18n::Lang::En,
+        _ => crate::config::i18n::Lang::Zh,
+    });
+
+    let config = MenuItem::with_id(
+        app,
+        "desktop-config",
+        crate::config::i18n::t("menu.settings"),
+        true,
+        Some("CmdOrCtrl+,"),
+    )?;
+    let application_separator = PredefinedMenuItem::separator(app)?;
+    let is_fullscreen = app
+        .get_webview_window("main")
+        .and_then(|window| window.is_fullscreen().ok())
+        .unwrap_or(false);
+    let fullscreen_label = crate::config::i18n::t(if is_fullscreen {
+        "menu.exit_fullscreen"
+    } else {
+        "menu.enter_fullscreen"
+    });
+    let fullscreen = PredefinedMenuItem::fullscreen(app, Some(&fullscreen_label))?;
+    let application_menu = Submenu::with_id_and_items(
+        app,
+        "desktop-application-menu",
+        crate::config::i18n::t("menu.application"),
+        true,
+        &[&config, &application_separator, &fullscreen],
+    )?;
+
+    let hide = PredefinedMenuItem::hide(app, None)?;
+    let hide_others = PredefinedMenuItem::hide_others(app, None)?;
+    let show_all = PredefinedMenuItem::show_all(app, None)?;
+    let quit_separator = PredefinedMenuItem::separator(app)?;
+    let quit = PredefinedMenuItem::quit(app, None)?;
+    // macOS 会把首个菜单标题强制显示为应用名称；这里只承载必要的系统动作，
+    // 真正可见的“应用”功能菜单放在其后，避免再次被系统改名。
+    let system_application_menu = Submenu::with_id_and_items(
+        app,
+        "desktop-system-application-menu",
+        app.package_info().name.clone(),
+        true,
+        &[&hide, &hide_others, &show_all, &quit_separator, &quit],
+    )?;
+
+    let run_logs = MenuItem::with_id(
+        app,
+        "desktop-copy-run-logs",
+        crate::config::i18n::t("menu.run_logs"),
+        true,
+        None::<&str>,
+    )?;
+    let check_update = MenuItem::with_id(
+        app,
+        "desktop-check-update",
+        crate::config::i18n::t("menu.check_update"),
+        true,
+        None::<&str>,
+    )?;
+    let help_separator = PredefinedMenuItem::separator(app)?;
+    let about = MenuItem::with_id(
+        app,
+        "desktop-about",
+        crate::config::i18n::t("menu.about"),
+        true,
+        None::<&str>,
+    )?;
+    let help_menu = Submenu::with_id_and_items(
+        app,
+        "desktop-help-menu",
+        crate::config::i18n::t("menu.help"),
+        true,
+        &[&run_logs, &check_update, &help_separator, &about],
+    )?;
+
+    let menu = Menu::with_items(
+        app,
+        &[&system_application_menu, &application_menu, &help_menu],
+    )?;
+    let _ = app.set_menu(menu)?;
+    *MACOS_FULLSCREEN_MENU_ITEM
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner()) = Some(fullscreen);
+    Ok(())
+}
+
+/// 原生全屏动画会连续触发 Resize；只在状态真正变化时刷新菜单文案。
+#[cfg(target_os = "macos")]
+fn sync_macos_fullscreen_menu(window: &tauri::Window<Wry>) {
+    let Ok(is_fullscreen) = window.is_fullscreen() else {
+        return;
+    };
+    let label = crate::config::i18n::t(if is_fullscreen {
+        "menu.exit_fullscreen"
+    } else {
+        "menu.enter_fullscreen"
+    });
+    let item = MACOS_FULLSCREEN_MENU_ITEM
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .clone();
+    let Some(item) = item else {
+        return;
+    };
+    if item.text().ok().as_deref() == Some(label.as_str()) {
+        return;
+    }
+    if let Err(error) = item.set_text(label) {
+        log::warn!("[menu] failed to update macOS fullscreen label: {error}");
+    }
 }
 
 /// 构建主窗口。
@@ -267,9 +401,22 @@ pub fn builder() -> tauri::Builder<tauri::Wry> {
         .setup(|app| {
             let app_handle = app.handle().clone();
             build_main_window(&app_handle)?;
+            #[cfg(target_os = "macos")]
+            install_macos_menu(&app_handle)?;
             tray(&app_handle)?;
             setup(app_handle.clone());
             Ok(())
+        })
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "desktop-config"
+            | "desktop-about"
+            | "desktop-copy-run-logs"
+            | "desktop-check-update" => {
+                if let Err(error) = app.emit("macos-menu-action", event.id().as_ref()) {
+                    log::warn!("[menu] failed to emit macOS menu action: {error}");
+                }
+            }
+            _ => {}
         })
         // 点击关闭按钮时隐藏到托盘而不是退出程序
         .on_window_event(|window, event| match event {
@@ -278,8 +425,13 @@ pub fn builder() -> tauri::Builder<tauri::Wry> {
                 let _ = window.hide();
             }
             // 移动/缩放主窗口时记录几何，重启后据此恢复（见 config::window_state）
-            tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_) => {
+            tauri::WindowEvent::Moved(_) => {
                 crate::config::save_geometry(window);
+            }
+            tauri::WindowEvent::Resized(_) => {
+                crate::config::save_geometry(window);
+                #[cfg(target_os = "macos")]
+                sync_macos_fullscreen_menu(window);
             }
             _ => {}
         });

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -123,24 +123,38 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
             .title("Deepseek Harness Desktop")
             .inner_size(1280.0, 840.0)
             .min_inner_size(860.0, 620.0)
-            .resizable(true)
-            // 无系统标题栏：窗口 chrome 由壳层 ShellNavBar 常驻提供
-            // （44px 顶部导航：左侧 iframe 导航控制 + 右侧窗口控制）
-            .decorations(false)
-            // 恢复 iframe 内 HTML5 拖拽（拖入图片/拖动元素）：
-            // Tauri 默认注册 wry drag_drop_handler → WebView2 SetAllowExternalDrop(false)
-            // 并注入 IDropTarget 接管拖放，iframe 内拖拽被禁用。
-            // 注意不能用 .drag_and_drop(false)：它只设置 tao 窗口层的拖放开关
-            // （tauri issue #13761），不影响 webview 层，拖拽依旧失效；
-            // disable_drag_drop_handler 才能关掉 wry 的接管（等价于旧配置 dragDropEnabled: false）。
-            .disable_drag_drop_handler()
-            // 接管内嵌 iframe 的 window.open() / target=_blank 新窗口请求：
-            // WebView2 里这类请求走 NewWindowRequested，wry 在没有 handler 时
-            // 直接 SetHandled(true) 吞掉（点了没反应）——dshmarket 等预设插件的
-            // “源码”按钮在桌面端因此无法跳转（浏览器里正常）。
-            // 这里把 http(s) 链接交给系统浏览器打开，其余协议一律拒绝。
-            .on_new_window(move |url, features| on_new_window(app_handle.clone(), url, features))
-            .on_download(|webview, event| on_download(webview, event));
+            .resizable(true);
+
+    // macOS 保留原生交通灯：绿色按钮由 AppKit 进入独立 Space 的原生全屏，
+    // 同时用 Overlay 让 44px 壳层导航栏继续与窗口 chrome 融合。其他平台
+    // 仍由 ShellNavBar 的右侧按钮提供窗口控制。
+    #[cfg(target_os = "macos")]
+    let webview_builder = webview_builder
+        .decorations(true)
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true)
+        // Wry 保留了 AppKit 原生按钮的纵向 frame 偏移；24px 在 44px
+        // 壳层导航栏内的实测视觉圆心为 22px，而非 API 直觉上的 24px。
+        .traffic_light_position(tauri::LogicalPosition::new(14.0, 24.0));
+
+    #[cfg(not(target_os = "macos"))]
+    let webview_builder = webview_builder.decorations(false);
+
+    let webview_builder = webview_builder
+        // 恢复 iframe 内 HTML5 拖拽（拖入图片/拖动元素）：
+        // Tauri 默认注册 wry drag_drop_handler → WebView2 SetAllowExternalDrop(false)
+        // 并注入 IDropTarget 接管拖放，iframe 内拖拽被禁用。
+        // 注意不能用 .drag_and_drop(false)：它只设置 tao 窗口层的拖放开关
+        // （tauri issue #13761），不影响 webview 层，拖拽依旧失效；
+        // disable_drag_drop_handler 才能关掉 wry 的接管（等价于旧配置 dragDropEnabled: false）。
+        .disable_drag_drop_handler()
+        // 接管内嵌 iframe 的 window.open() / target=_blank 新窗口请求：
+        // WebView2 里这类请求走 NewWindowRequested，wry 在没有 handler 时
+        // 直接 SetHandled(true) 吞掉（点了没反应）——dshmarket 等预设插件的
+        // “源码”按钮在桌面端因此无法跳转（浏览器里正常）。
+        // 这里把 http(s) 链接交给系统浏览器打开，其余协议一律拒绝。
+        .on_new_window(move |url, features| on_new_window(app_handle.clone(), url, features))
+        .on_download(|webview, event| on_download(webview, event));
 
     #[cfg(windows)]
     let webview_builder = webview_builder.on_page_load(move |webview_window, payload| {

--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -12,6 +12,7 @@ import { Button, Chip, Description, Dropdown, Label } from '@heroui/react'
 import { useOverlay } from '@overlastic/react'
 import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWindow } from '@tauri-apps/api/window'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { If } from 'react-if-lite'
 import { cn } from 'tailwind-variants'
@@ -23,6 +24,7 @@ import { useDshPlugins } from '@/hooks/use-dsh-plugins'
 import { useIframeTauri } from '@/hooks/use-iframe-tauri'
 import { store } from '@/store'
 import { toast } from '@/utils'
+import { useMacOSAppMenu } from './use-macos-app-menu'
 
 /**
  * 壳层窗口顶部导航栏（44px，常驻）：
@@ -39,7 +41,7 @@ import { toast } from '@/utils'
  * - 空白拖拽区：Tauri 原生 `data-tauri-drag-region`（顶层文档直接生效），
  *   Windows/Linux 上双击切换最大化，macOS 上交由系统标题栏偏好。
  * - macOS：使用原生交通灯，红键后台化、黄键最小化、绿键进入原生全屏；
- *   导航栏左侧留出交通灯区域。
+ *   普通窗口下导航栏左侧留出交通灯区域，原生全屏时整条导航栏收起。
  * - Windows/Linux：右侧窗口按钮直接调用 Tauri API；
  *   后台化 = 隐藏到托盘（服务保持运行）。
  *
@@ -60,6 +62,55 @@ function detectMacOS() {
 
 const IS_MACOS = detectMacOS()
 
+/** macOS 原生全屏时收起整条壳层导航栏。 */
+function useMacOSFullscreen() {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  useEffect(() => {
+    if (!IS_MACOS)
+      return
+
+    const appWindow = getCurrentWindow()
+    let mounted = true
+    let unlisten: (() => void) | undefined
+
+    async function syncFullscreen() {
+      try {
+        const fullscreen = await appWindow.isFullscreen()
+        if (mounted)
+          setIsFullscreen(fullscreen)
+      }
+      catch (error) {
+        console.error('[Navbar] failed to sync fullscreen state:', error)
+      }
+    }
+
+    async function setupListener() {
+      try {
+        await syncFullscreen()
+        const stopListening = await appWindow.onResized(() => {
+          void syncFullscreen()
+        })
+        if (mounted)
+          unlisten = stopListening
+        else
+          stopListening()
+      }
+      catch (error) {
+        console.error('[Navbar] failed to listen for fullscreen state:', error)
+      }
+    }
+
+    void setupListener()
+    return () => {
+      mounted = false
+      unlisten?.()
+    }
+  }, [])
+
+  return isFullscreen
+}
+
 export interface NavbarProps {
   /** 就绪态 iframe；传入时启用左侧导航控制 */
   iframeRef?: RefObject<HTMLIFrameElement | null>
@@ -67,6 +118,7 @@ export interface NavbarProps {
 
 export function Navbar({ iframeRef }: NavbarProps) {
   const { t } = useTranslation()
+  const isFullscreen = useMacOSFullscreen()
   const { plugins } = useDshPlugins()
   const { sidebarCollapsed, canGoBack, canGoForward, sendNav } = useIframeTauri(iframeRef)
   const { updateInfo } = useStore(store.desktopUpdater)
@@ -107,6 +159,14 @@ export function Navbar({ iframeRef }: NavbarProps) {
       void copyRunLogs()
   }
 
+  function handleOpenConfig() {
+    void openConfigDialog().catch(() => {})
+  }
+
+  function handleOpenAbout() {
+    void openAboutDialog().catch(() => {})
+  }
+
   /** 「检查更新」：先检查，有更新才弹框；检查失败提示错误而非「已是最新」 */
   async function handleCheckUpdate() {
     try {
@@ -134,13 +194,22 @@ export function Navbar({ iframeRef }: NavbarProps) {
     }
   }
 
+  useMacOSAppMenu({
+    enabled: IS_MACOS,
+    openConfig: handleOpenConfig,
+    openAbout: handleOpenAbout,
+    copyRunLogs: () => { void copyRunLogs() },
+    checkUpdate: () => { void handleCheckUpdate() },
+  })
+
   return (
     <div
       className={cn(
         'relative flex h-11 w-full flex-none select-none items-center gap-0.5 border-b border-line bg-panel',
         {
-          'pl-20 pr-1.5': IS_MACOS,
-          'px-1.5': !IS_MACOS,
+          'hidden': IS_MACOS && isFullscreen,
+          'pl-20 pr-1.5': IS_MACOS && !isFullscreen,
+          'px-1.5': !IS_MACOS || isFullscreen,
         },
       )}
     >
@@ -183,65 +252,66 @@ export function Navbar({ iframeRef }: NavbarProps) {
           <ArrowRight />
         </Button>
       </If>
-      <div className="ml-1">
-        <Button
-          className="rounded-lg h-6 text-xs px-1.5"
-          size="sm"
-          variant="ghost"
-          onPress={() => void openConfigDialog().catch(() => {})}
-        >
-          {t('app.config')}
-        </Button>
-        <Dropdown>
+      <If cond={!IS_MACOS || !isFullscreen}>
+        <div className="ml-1">
           <Button
             className="rounded-lg h-6 text-xs px-1.5"
             size="sm"
             variant="ghost"
-            aria-label={t('app.expand_sidebar')}
+            onPress={handleOpenConfig}
           >
-            {t('app.help')}
+            {t('app.config')}
           </Button>
-          <Dropdown.Popover className="rounded-md w-5!">
-            <Dropdown.Menu>
-              <Dropdown.Item
-                className="rounded-md"
-                id="copy-run-logs"
-                textValue={t('menu.run_logs')}
-                onAction={() => handleHelpAction('copy-run-logs')}
-              >
-                <Label>{t('menu.run_logs')}</Label>
-              </Dropdown.Item>
-              <Dropdown.Item
-                className="rounded-md"
-                id="check-update"
-                textValue={t('menu.check_update')}
-                onAction={() => handleHelpAction('check-update')}
-              >
-                <span className="flex w-full items-center justify-between gap-3">
-                  <Label>{t('menu.check_update')}</Label>
-                  <If cond={updateInfo != null}>
-                    <Description>{t('menu.new_version')}</Description>
-                  </If>
-                </span>
-              </Dropdown.Item>
-              <Dropdown.Item
-                className="rounded-md"
-                id="about"
-                textValue={t('menu.about')}
-                onAction={() => handleHelpAction('about')}
-              >
-                <Label>{t('menu.about')}</Label>
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown.Popover>
-        </Dropdown>
-        <If cond={import.meta.env.DEV}>
-          <Chip size="sm" variant="primary" color="warning" className="text-xs text-background ml-1">
-            {t('app.dev_env')}
-          </Chip>
-        </If>
-
-      </div>
+          <Dropdown>
+            <Button
+              className="rounded-lg h-6 text-xs px-1.5"
+              size="sm"
+              variant="ghost"
+              aria-label={t('app.expand_sidebar')}
+            >
+              {t('app.help')}
+            </Button>
+            <Dropdown.Popover className="rounded-md w-5!">
+              <Dropdown.Menu>
+                <Dropdown.Item
+                  className="rounded-md"
+                  id="copy-run-logs"
+                  textValue={t('menu.run_logs')}
+                  onAction={() => handleHelpAction('copy-run-logs')}
+                >
+                  <Label>{t('menu.run_logs')}</Label>
+                </Dropdown.Item>
+                <Dropdown.Item
+                  className="rounded-md"
+                  id="check-update"
+                  textValue={t('menu.check_update')}
+                  onAction={() => handleHelpAction('check-update')}
+                >
+                  <span className="flex w-full items-center justify-between gap-3">
+                    <Label>{t('menu.check_update')}</Label>
+                    <If cond={updateInfo != null}>
+                      <Description>{t('menu.new_version')}</Description>
+                    </If>
+                  </span>
+                </Dropdown.Item>
+                <Dropdown.Item
+                  className="rounded-md"
+                  id="about"
+                  textValue={t('menu.about')}
+                  onAction={() => handleHelpAction('about')}
+                >
+                  <Label>{t('menu.about')}</Label>
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown.Popover>
+          </Dropdown>
+        </div>
+      </If>
+      <If cond={import.meta.env.DEV}>
+        <Chip size="sm" variant="primary" color="warning" className="text-xs text-background ml-1">
+          {t('app.dev_env')}
+        </Chip>
+      </If>
 
       {/* 拖拽区：Tauri 原生拖拽（仅此元素带 data-tauri-drag-region，按钮不受影响） */}
       <div

--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -14,6 +14,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { useTranslation } from 'react-i18next'
 import { If } from 'react-if-lite'
+import { cn } from 'tailwind-variants'
 import { useStore } from 'valtio-define'
 import { ConfigDialog } from '@/components/config-dialog'
 import { DesktopAboutDialog } from '@/components/desktop-about-dialog'
@@ -36,8 +37,11 @@ import { toast } from '@/utils'
  *   左侧控件只在「dsh-tauri 插件已启用（已安装）」且存在 iframe 时渲染：
  *   原生桥缺席时控件没有可靠接收方，避免出现点了没反应的死按钮。
  * - 空白拖拽区：Tauri 原生 `data-tauri-drag-region`（顶层文档直接生效），
- *   双击切换最大化。
- * - 窗口按钮：直接调用 Tauri 窗口 API；后台化 = 隐藏到托盘（服务保持运行）。
+ *   Windows/Linux 上双击切换最大化，macOS 上交由系统标题栏偏好。
+ * - macOS：使用原生交通灯，红键后台化、黄键最小化、绿键进入原生全屏；
+ *   导航栏左侧留出交通灯区域。
+ * - Windows/Linux：右侧窗口按钮直接调用 Tauri API；
+ *   后台化 = 隐藏到托盘（服务保持运行）。
  *
  * 未传入 iframeRef（安装/错误/预装引导页，无 iframe 可操控）时
  * 只渲染窗口控制，不渲染左侧导航控制。
@@ -48,6 +52,13 @@ import { toast } from '@/utils'
  *  原生导航桥（`useDshPlugins` 实时同步其安装状态，插件增删即时生效）
  */
 const TAURI_PLUGIN_ID = 'dsh-tauri'
+
+/** WKWebView 的 macOS UA 稳定包含 Macintosh，用于切换平台原生窗口 chrome。 */
+function detectMacOS() {
+  return navigator.userAgent.includes('Macintosh')
+}
+
+const IS_MACOS = detectMacOS()
 
 export interface NavbarProps {
   /** 就绪态 iframe；传入时启用左侧导航控制 */
@@ -79,6 +90,12 @@ export function Navbar({ iframeRef }: NavbarProps) {
         void appWindow.hide()
         break
     }
+  }
+
+  function handleDragRegionDoubleClick() {
+    // macOS 的双击标题栏行为由系统偏好决定，不用网页强制覆盖。
+    if (!IS_MACOS)
+      void getCurrentWindow().toggleMaximize()
   }
 
   function handleHelpAction(key: string) {
@@ -118,7 +135,15 @@ export function Navbar({ iframeRef }: NavbarProps) {
   }
 
   return (
-    <div className="relative flex h-11 w-full flex-none select-none items-center gap-0.5 border-b border-line px-1.5 bg-panel">
+    <div
+      className={cn(
+        'relative flex h-11 w-full flex-none select-none items-center gap-0.5 border-b border-line bg-panel',
+        {
+          'pl-20 pr-1.5': IS_MACOS,
+          'px-1.5': !IS_MACOS,
+        },
+      )}
+    >
       <If cond={iframeRef != null && tauriEnabled}>
         <Button
           className="rounded-lg size-7"
@@ -222,41 +247,43 @@ export function Navbar({ iframeRef }: NavbarProps) {
       <div
         className="min-w-0 flex-1 self-stretch"
         data-tauri-drag-region
-        onDoubleClick={() => { void getCurrentWindow().toggleMaximize() }}
+        onDoubleClick={handleDragRegionDoubleClick}
       />
 
-      <Button
-        className="rounded-lg size-7"
-        isIconOnly
-        size="sm"
-        variant="ghost"
-        aria-label={t('nav.minimize')}
-        onPress={() => { handleWindowAction('minimize') }}
-      >
-        <Minus />
-      </Button>
+      <If cond={!IS_MACOS}>
+        <Button
+          className="rounded-lg size-7"
+          isIconOnly
+          size="sm"
+          variant="ghost"
+          aria-label={t('nav.minimize')}
+          onPress={() => { handleWindowAction('minimize') }}
+        >
+          <Minus />
+        </Button>
 
-      <Button
-        className="rounded-lg size-7"
-        isIconOnly
-        size="sm"
-        variant="ghost"
-        aria-label={t('nav.maximize')}
-        onPress={() => { handleWindowAction('maximize') }}
-      >
-        <Square style={{ width: 14, height: 14 }} />
-      </Button>
+        <Button
+          className="rounded-lg size-7"
+          isIconOnly
+          size="sm"
+          variant="ghost"
+          aria-label={t('nav.maximize')}
+          onPress={() => { handleWindowAction('maximize') }}
+        >
+          <Square style={{ width: 14, height: 14 }} />
+        </Button>
 
-      <Button
-        className="rounded-lg size-7 transition-colors enabled:hover:bg-danger/16 enabled:hover:text-danger"
-        isIconOnly
-        size="sm"
-        variant="ghost"
-        aria-label={t('nav.background')}
-        onPress={() => { handleWindowAction('background') }}
-      >
-        <Xmark />
-      </Button>
+        <Button
+          className="rounded-lg size-7 transition-colors enabled:hover:bg-danger/16 enabled:hover:text-danger"
+          isIconOnly
+          size="sm"
+          variant="ghost"
+          aria-label={t('nav.background')}
+          onPress={() => { handleWindowAction('background') }}
+        >
+          <Xmark />
+        </Button>
+      </If>
     </div>
   )
 }

--- a/src/layout/components/use-macos-app-menu.ts
+++ b/src/layout/components/use-macos-app-menu.ts
@@ -1,0 +1,75 @@
+import { listen } from '@tauri-apps/api/event'
+import { useEffect, useRef } from 'react'
+
+interface MacOSAppMenuActions {
+  openConfig: () => void
+  openAbout: () => void
+  copyRunLogs: () => void
+  checkUpdate: () => void
+}
+
+interface UseMacOSAppMenuOptions extends MacOSAppMenuActions {
+  enabled: boolean
+}
+
+/**
+ * 接收 macOS 原生菜单事件并复用壳层已有操作。
+ * 操作经 ref 转发，监听器无需因 React 渲染而反复注册。
+ */
+export function useMacOSAppMenu({
+  enabled,
+  openConfig,
+  openAbout,
+  copyRunLogs,
+  checkUpdate,
+}: UseMacOSAppMenuOptions) {
+  const actionsRef = useRef<MacOSAppMenuActions>({
+    openConfig,
+    openAbout,
+    copyRunLogs,
+    checkUpdate,
+  })
+  actionsRef.current = { openConfig, openAbout, copyRunLogs, checkUpdate }
+
+  useEffect(() => {
+    if (!enabled)
+      return
+
+    let mounted = true
+    let unlisten: (() => void) | undefined
+
+    async function setupListener() {
+      try {
+        const stopListening = await listen<string>('macos-menu-action', (event) => {
+          switch (event.payload) {
+            case 'desktop-config':
+              actionsRef.current.openConfig()
+              break
+            case 'desktop-about':
+              actionsRef.current.openAbout()
+              break
+            case 'desktop-copy-run-logs':
+              actionsRef.current.copyRunLogs()
+              break
+            case 'desktop-check-update':
+              actionsRef.current.checkUpdate()
+              break
+          }
+        })
+        if (mounted)
+          unlisten = stopListening
+        else
+          stopListening()
+      }
+      catch (error) {
+        console.error('[Navbar] failed to listen for macOS application menu:', error)
+      }
+    }
+
+    void setupListener()
+    return () => {
+      mounted = false
+      unlisten?.()
+    }
+  }, [enabled])
+}


### PR DESCRIPTION
## 背景

现有窗口交互在 macOS 上不够原生：

- 无法完整适配 macOS 原生全屏 Space
- 交通灯按钮与应用内顶栏存在对齐问题
- 全屏后应用内顶栏占用额外空间
- 默认的 File / Edit / View / Window 菜单没有实际用途

## 变更内容

- 保留 macOS 原生交通灯按钮，并调整其垂直位置
- 使用系统原生全屏交互
- 在全屏状态下隐藏应用内置顶栏
- 将“应用”和“帮助”功能放入 macOS 系统菜单栏
- 移除无实际用途的 File / Edit / View / Window 菜单
- “应用”菜单提供：
  - 设置
  - 进入/退出全屏幕
- “帮助”菜单提供：
  - 运行日志
  - 检查更新
  - 关于 Desktop
- 全屏菜单文案根据状态动态切换：
  - 普通窗口：`进入全屏幕`
  - 全屏状态：`退出全屏幕`
- 切换中英文时同步刷新原生菜单文案
- Windows 和 Linux 窗口交互保持不变

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/1227448c-1d6c-4b14-8a5b-ea8aa77d04a7" />
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/3cdc7ec4-205b-4d0e-8af9-342da3313d7d" />
<img width="2560" height="1680" alt="image" src="https://github.com/user-attachments/assets/f77c852c-b58f-479d-a2fa-5de96b0806d6" />
