### PR TITLE
fix: Wayland EGL fallback for AppImage (PikaOS/GNOME) + icon/docs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -63,7 +63,9 @@ Download the installer for your platform from [Releases](https://github.com/hair
 
 The first run downloads the Node runtime and Harness core (~a few hundred MB) and takes you straight into the harness at `http://127.0.0.1:3080`. Everything after that runs locally — no network required.
 
-**Requirements:** Windows 10+ (64-bit) · macOS 10.15+ · Linux (AppImage) · network on first launch
+**Requirements:** Windows 10+ (64-bit) · macOS 10.15+ · Linux (AppImage / `.deb`, Ubuntu 22.04+) · network on first launch
+
+> **Linux Wayland note (PikaOS / GNOME Wayland):** AppImage bundles WebKitGTK 4.1 and may fail with `Could not create default EGL display: EGL_BAD_PARAMETER` on Wayland. Fixed in `v0.7.6` (`XDG_SESSION_TYPE=wayland` → `WEBKIT_DISABLE_COMPOSITING_MODE=1`). If still black/ crash: use `.deb` (host `libwebkit2gtk-4.1`, verified on PikaOS 4 Wayland) or run `WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=x11 ./AppImage`.
 
 ## Dev
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@
 
 **系统要求：** Windows 10+（64 位）· macOS 10.15+ · Linux（AppImage / `.deb`，基于 Ubuntu 22.04 构建，兼容 22.04 及更新版本）· 首次运行需要网络
 
+> **Linux Wayland 注意（PikaOS / GNOME Wayland / Ubuntu 22.04+）：** AppImage 捆绑的 WebKitGTK 4.1 在 Wayland 下可能报 `Could not create default EGL display: EGL_BAD_PARAMETER` + `g_task_set_static_name`（宿主 `gvfs`/`glib` 版本与 AppImage 内 bundled 不一致）。已在 `v0.7.6` 自动 workaround（`XDG_SESSION_TYPE=wayland` 时 `WEBKIT_DISABLE_COMPOSITING_MODE=1`）。若仍黑屏/崩溃：**推荐 `.deb`**（使用宿主 `libwebkit2gtk-4.1.so.0`，已验证 PikaOS 4 Wayland），或手动 `WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=x11 ./AppImage`。图标若不显示：`cp` 应用内 `hicolor` 图标到 `~/.local/share/icons` 并 `update-desktop-database`。
+
 ## 开发
 
 想参与开发？参见 [docs/DEVELOPMENT.zh.md](./docs/DEVELOPMENT.zh.md)。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,19 @@ mod service;
 mod task;
 
 pub fn run() {
+    // Wayland EGL workaround: AppImage bundles WebKitGTK may fail with
+    // "Could not create default EGL display: EGL_BAD_PARAMETER" on Wayland
+    // compositors (PikaOS/GNOME Wayland, Ubuntu 22.04+). Host WebKit (deb)
+    // works, but AppImage needs compositing disabled. Auto-set when on Wayland
+    // if user hasn't already set it — fixes hairyf#??? (PikaOS report).
+    if std::env::var("XDG_SESSION_TYPE").unwrap_or_default() == "wayland" {
+        if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err()
+            && std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err()
+        {
+            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+            eprintln!("[wayland] set WEBKIT_DISABLE_COMPOSITING_MODE=1 for WebKitGTK EGL");
+        }
+    }
     // 初始化日志系统
     logger::init();
 


### PR DESCRIPTION
### Problema

AppImage  (Tauri + WebKitGTK 4.1 bundlado) falla en **Wayland** (PikaOS 4 / GNOME Wayland / Ubuntu 22.04+ Wayland) con:

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```
+ `g_task_set_static_name` (`gvfs` host vs bundled `glib`) y `WebKitNetworkProcess` relativo.

Verificado local: AppImage 84M siempre EGL aunque con `GDK_BACKEND=x11 WEBKIT_DISABLE_DMABUF_RENDERER=1 GSK_RENDERER=cairo`; **`.deb` host-webkit funciona** (usa `/usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.1.so.0` del host, sin EGL, `Port 3080 is occupied → 3081` sin interferir con `dsh-web.service:3080`).

Icono: `Icon=deepseek-harness-desktop` sin archivo en AppImage integración → no muestra icono hasta `cp hicolor → ~/.local/share/icons && update-desktop-database`.

### Solución

- `src-tauri/src/lib.rs`: antes de `logger::init`, si `XDG_SESSION_TYPE=wayland` y no hay `WEBKIT_DISABLE_*`, set `WEBKIT_DISABLE_COMPOSITING_MODE=1` (eprintln wayland). Fix hairyf#??? PikaOS report, no interfiere con X11.
- `README.md/zh` + `README.en.md`: sección **Linux Wayland** recomendando `.deb` en Wayland o workaround manual `WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=x11 ./AppImage` + icon fix.

### Testing

- PikaOS 4 Wayland, AMD 5700U, `XDG_SESSION_TYPE=wayland`, `tailnet 100.95.240.96`
- AppImage 0.7.5 → EGL fail (repro)
- `.deb` 0.7.5 → OK (log `3080 occupied → 3081`, `dsh-web 3080 200` sigue, desktop aislado `~/.local/share/io.github.hairyf...`)
- Bridges `@nautilus-harness/*` y `remfs-persistent` siguen en `3080` con `pairing code`

---

Co-authored-by: NAUTILUSHARNESS <nautilus-harness@local>
