### PR TITLE
fix(plugin): precise plugin update detection & route harness pnpm through desktop shim

### DIFF
--- a/src-tauri/src/bridge/plugin.rs
+++ b/src-tauri/src/bridge/plugin.rs
@@ -72,9 +72,22 @@ pub async fn open_preinstall_repo(app_handle: AppHandle, id: String) -> Result<(
 
 /// 当前 profile 已安装插件列表（含解析后的元信息），`use-dsh-plugins` 首次加载用；
 /// 之后 Rust 侧监控插件文件，变化时通过 `dsh-plugins-updated` 事件实时推送。
+/// 这里会并入 `updates` 模块的已知更新判定缓存（未判定时 `update_available=false`）。
 #[tauri::command]
 pub fn get_dsh_plugins(app_handle: AppHandle) -> Vec<plugin::DshPlugin> {
-    plugin::watch::list(&app_handle)
+    let mut plugins = plugin::watch::list(&app_handle);
+    plugin::updates::apply_cache(&app_handle, &mut plugins);
+    plugins
+}
+
+/// 重新探测已安装插件的更新可用性（网络 + 30min 缓存），返回带最新判定结果的列表。
+///
+/// 与 `get_dsh_plugins` 不同，此处会发起 registry / GitHub 请求（并行、失败静默按
+/// 「无更新」处理）。前端在插件面板挂载后调用一次以补齐 `updateAvailable`，使升级
+/// 按钮只在确有更新（或异常修复）时出现，而不是常驻。
+#[tauri::command]
+pub async fn refresh_plugin_updates(app_handle: AppHandle) -> Result<Vec<plugin::DshPlugin>, String> {
+    plugin::updates::refresh(&app_handle).await
 }
 
 /// 升级单个已安装插件：`dsh plugin --profile <当前档案> update <id>`，

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -353,6 +353,7 @@ pub fn handler() -> impl Fn(Invoke<Wry>) -> bool + Send + Sync + 'static {
         crate::bridge::skip_preinstall_plugins,
         crate::bridge::open_preinstall_repo,
         crate::bridge::get_dsh_plugins,
+        crate::bridge::refresh_plugin_updates,
         crate::bridge::update_dsh_plugin,
         crate::bridge::remove_dsh_plugin,
         crate::bridge::report_plugin_error,

--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -816,8 +816,7 @@ fn normalize_git_spec(spec: &str) -> String {
 /// 从 pnpm 失败输出里识别 git 传输层错误（区别于 allowBuilds 构建门禁），命中时
 /// 返回一句可读的成因/指引。pnpm 在这些场景下已经退到 git+ssh，再去补 allowBuilds
 /// 白名单是无效且误导的。
-fn git_transport_hint(output: &str) -> Option<&'static str> {
-    const SIGNALS: &[(&str, &str)] = &[
+fn git_transport_hint(output: &str) -> Option<&'static str> {    const SIGNALS: &[(&str, &str)] = &[
         (
             "host key verification failed",
             "git fell back to SSH and could not verify GitHub's host key (no known_hosts entry; the process ran non-interactively). Make sure GitHub is reachable over HTTPS.",
@@ -840,6 +839,33 @@ fn git_transport_hint(output: &str) -> Option<&'static str> {
         .iter()
         .find(|(sig, _)| lower.contains(sig))
         .map(|(_, hint)| *hint)
+}
+
+/// 决定 Harness 服务进程启动时是否应注入 `DSH_PREFER_BUNDLED_PNPM=1`
+/// （轻量缓解，issue #69 系列：让 dsh-market 子进程的 pnpm 走与桌面端插件安装
+/// 同一套受控策略，而非落到系统 pnpm 引发 store 不兼容 / 无 TTY / allowBuilds 门禁）。
+///
+/// 与 [`ensure_pnpm`] 的版本感知保持一致，但**启动阶段绝不触发下载**：捆绑版尚未
+/// 安装时返回 false（交由用户 pnpm，shim 默认用户优先）。仅当捆绑版已安装且满足
+/// 下列任一条件才强制捆绑版：
+/// - 档案 store 主版本已知且 == 捆绑版主版本，且用户 pnpm 主版本 != store
+///   （否则用户版会 `ERR_PNPM_UNEXPECTED_STORE`）；
+/// - store 未知（全新档案）且用户 pnpm 缺失或过旧（< `MIN_TRUSTED_PNPM_MAJOR`）。
+pub(crate) fn harness_prefer_bundled_pnpm(app_handle: &AppHandle) -> bool {
+    let store_major = profile_store_major(app_handle);
+    let user_major = user_pnpm_major_version(app_handle);
+    let bundled_major = bundled_pnpm_major(app_handle);
+    // 捆绑版未安装 → 无法强制，交还用户 pnpm（shim 默认用户优先）
+    if !config::get_pnpm_binary_path(app_handle).exists() {
+        return false;
+    }
+    match store_major {
+        Some(store) => bundled_major == Some(store) && user_major != Some(store),
+        None => match user_major {
+            Some(major) if major >= MIN_TRUSTED_PNPM_MAJOR => false,
+            _ => true,
+        },
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/service/plugin/mod.rs
+++ b/src-tauri/src/service/plugin/mod.rs
@@ -30,10 +30,12 @@ mod installed;
 mod preset;
 mod process;
 pub mod recovery;
+pub mod updates;
 pub mod watch;
 
 pub use cancel::cancel;
 pub use install::{install, remove, update};
+pub(crate) use install::harness_prefer_bundled_pnpm;
 pub use installed::{list, PreinstallPlugin};
 pub(crate) use installed::ensure_profile_npmrc;
 pub use preset::repo_url_of;

--- a/src-tauri/src/service/plugin/updates.rs
+++ b/src-tauri/src/service/plugin/updates.rs
@@ -1,0 +1,398 @@
+//! 插件更新可用性检测（参考 dsh-market 的 `updates.ts`，但去掉「桌面端」耦合）。
+//!
+//! 每个已安装插件按其在 profile `package.json` 中的依赖 spec 判断：
+//! - `link:` / `file:` 本地依赖 → 永不视为有更新；
+//! - git 类型（`github:` / `git+https://github.com/…` / `https://codeload.github.com/…`）
+//!   → 用 pnpm-lock.yaml 里记录的 codeload 提交 SHA 对比 GitHub 仓库 HEAD SHA，
+//!     不相同即视为有更新（与 market 的「按提交比较」一致）；
+//! - 其余（registry）→ 用 npm registry 的 `latest` dist-tag 与已装版本做语义化比较，
+//!   `latest > installed` 才视为有更新（避免把 `latest` 指向更旧版本误判为可升级）。
+//!
+//! 与 market 相同的兜底：任何一次判定失败都报告「无更新」，绝不因一次网络抖动或
+//! 404 让整个插件管理器不可用；结果按 (id, spec, 版本) 缓存 30 分钟（TTL），期间
+//! 重复调用直接命中缓存、不重复打网络。缓存缺失/未判定时 `update_available=false`，
+//! 前端由 `refresh_plugin_updates` 在挂载后补齐，因此首次展示短暂无按钮、随后自动
+//! 出现——这正好保证「不是常驻按钮」，只有确有更新（或异常修复）时才展示升级入口。
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use semver::Version as Semver;
+use serde_json::Value;
+use tauri::AppHandle;
+
+use super::installed::profile_dir;
+use super::watch::DshPlugin;
+
+/// 更新判定结果的缓存 TTL（与 dsh-market 一致：30 分钟）
+const UPDATES_TTL: Duration = Duration::from_secs(30 * 60);
+
+/// 单条更新判定结果
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    /// 是否确有更新（`true` = 有可升级的新版本/新提交）
+    pub update_available: bool,
+    /// 语义化判定得到的「最新版本」（npm 分支为 registry latest，git 分支为 HEAD SHA）
+    pub latest: Option<String>,
+}
+
+struct CacheEntry {
+    info: UpdateInfo,
+    at: Instant,
+}
+
+static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
+
+fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// 缓存键：同一插件换了 spec 或升级了版本后，旧的判定结果自动失效（key 变化即 miss）。
+fn cache_key(id: &str, spec: &str, version: &str) -> String {
+    format!("{id}\u{0}{spec}\u{0}{version}")
+}
+
+// ---------------------------------------------------------------------------
+// 读取安装态（spec / 版本 / 锁定提交）
+// ---------------------------------------------------------------------------
+
+/// 当前档案的直接依赖（id → spec）。读取失败返回空表（不阻断整体判定）。
+fn read_specs(app_handle: &AppHandle) -> HashMap<String, String> {
+    let dir = profile_dir(app_handle);
+    let Ok(content) = std::fs::read_to_string(dir.join("package.json")) else {
+        return HashMap::new();
+    };
+    let Ok(manifest) = serde_json::from_str::<Value>(&content) else {
+        return HashMap::new();
+    };
+    let mut out = HashMap::new();
+    if let Some(deps) = manifest.get("dependencies").and_then(Value::as_object) {
+        for (name, spec) in deps {
+            if let Some(s) = spec.as_str() {
+                out.insert(name.clone(), s.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// 从 pnpm-lock.yaml 的 codeload tarball URL 中提取「owner/repo → 提交 SHA」映射
+/// （与 dsh-market `readLockCommits` 的取法一致：pnpm 把 git 依赖的锁采用
+/// `https://codeload.github.com/<owner>/<repo>/tar.gz/<sha>` 形式记录）。
+fn read_locked_commits(profile: &Path) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let Ok(text) = std::fs::read_to_string(profile.join("pnpm-lock.yaml")) else {
+        return out;
+    };
+    let re = regex::Regex::new(r"codeload\.github\.com/([^/\s]+)/([^/\s]+)/tar\.gz/([0-9a-fA-F]{7,40})")
+        .expect("static codeload regex");
+    for cap in re.captures_iter(&text) {
+        let repo = format!("{}/{}", &cap[1], &cap[2]).to_lowercase();
+        out.insert(repo, cap[3].to_string());
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// spec 解析
+// ---------------------------------------------------------------------------
+
+/// 从依赖 spec 中提取 GitHub `owner/repo`（用于 git 类依赖的 HEAD 对比）。
+/// 支持 `github:owner/repo`、`git+https://github.com/owner/repo.git`、
+/// `git+ssh://git@github.com/owner/repo.git`、`https://codeload.github.com/owner/repo/…`。
+/// 非 git 形态返回 None。
+fn extract_github_repo(spec: &str) -> Option<String> {
+    if let Some(rest) = spec.strip_prefix("github:") {
+        let path = rest.split('#').next().unwrap_or(rest).trim_end_matches('/');
+        let path = path.strip_suffix(".git").unwrap_or(path).trim_end_matches('/');
+        return (is_owner_repo(path)).then(|| path.to_string());
+    }
+    let after = spec.split_once("github.com/").map(|(_, r)| r)?;
+    let path = after.split(['#', '?']).next().unwrap_or(after).trim_end_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path).trim_end_matches('/');
+    let mut parts = path.split('/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    (is_owner_repo(&format!("{owner}/{repo}"))).then(|| format!("{owner}/{repo}"))
+}
+
+/// `owner/repo` 形态校验（owner/repo 各仅允许字母数字 `._-`，避免误吞 URL 首位）。
+fn is_owner_repo(value: &str) -> bool {
+    let Some((owner, repo)) = value.split_once('/') else {
+        return false;
+    };
+    !owner.is_empty()
+        && !repo.is_empty()
+        && !value.contains('@')
+        && owner
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+        && repo
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+/// 语义化「latest 确实高于 installed」才判定为升级（避免把 dist-tag 指向旧版误判）。
+fn is_upgrade(installed: &str, latest: &str) -> bool {
+    match (Semver::parse(installed), Semver::parse(latest)) {
+        (Ok(i), Ok(l)) => l > i,
+        _ => false,
+    }
+}
+
+/// 把 npm 包名编码为 registry 路径（`@scope/name` → `@scope%2Fname`）。
+fn encode_registry_name(name: &str) -> String {
+    name.replace('@', "%40").replace('/', "%2F")
+}
+
+// ---------------------------------------------------------------------------
+// 网络判定
+// ---------------------------------------------------------------------------
+
+async fn fetch_json(client: &reqwest::Client, url: &str) -> Option<Value> {
+    let res = client
+        .get(url)
+        .header("accept", "application/json")
+        .header("user-agent", "deepseek-harness-desktop")
+        .send()
+        .await
+        .ok()?;
+    if !res.status().is_success() {
+        return None;
+    }
+    res.json::<Value>().await.ok()
+}
+
+/// GitHub 仓库 HEAD 提交 SHA（API 限流/429/网络错误均返回 None，视为无法判定）。
+async fn fetch_head_sha(client: &reqwest::Client, repo: &str) -> Option<String> {
+    let url = format!("https://api.github.com/repos/{repo}/commits/HEAD");
+    let v = fetch_json(client, &url).await?;
+    v.get("sha")?.as_str().map(String::from)
+}
+
+/// npm registry `latest` dist-tag 版本（404/网络错误返回 None）。
+async fn fetch_npm_latest(client: &reqwest::Client, name: &str) -> Option<String> {
+    let url = format!("https://registry.npmjs.org/{}/latest", encode_registry_name(name));
+    let v = fetch_json(client, &url).await?;
+    v.get("version")?.as_str().map(String::from)
+}
+
+/// 计算单个插件的更新判定。任何不确定性都返回「无更新」，绝不因失败报升级。
+async fn compute_update(
+    client: &reqwest::Client,
+    id: &str,
+    spec: &str,
+    installed_version: Option<&str>,
+    locked: &HashMap<String, String>,
+) -> UpdateInfo {
+    if spec.starts_with("link:") || spec.starts_with("file:") {
+        return UpdateInfo { update_available: false, latest: None };
+    }
+
+    if let Some(repo) = extract_github_repo(spec) {
+        let current = locked.get(&repo.to_lowercase()).cloned();
+        let latest = fetch_head_sha(client, &repo).await;
+        return UpdateInfo {
+            update_available: current.is_some() && latest.is_some() && current != latest,
+            latest,
+        };
+    }
+
+    let latest = fetch_npm_latest(client, id).await;
+    let update_available = match (installed_version, latest.as_deref()) {
+        (Some(i), Some(l)) => is_upgrade(i, l),
+        _ => false,
+    };
+    UpdateInfo { update_available, latest }
+}
+
+// ---------------------------------------------------------------------------
+// 对外接口
+// ---------------------------------------------------------------------------
+
+/// 把缓存里的已知判定合并进插件列表（`get_dsh_plugins` 用）。缓存缺失时保持
+/// `update_available=false`（未判定，由前端随后 `refresh_plugin_updates` 补齐）。
+pub fn apply_cache(app_handle: &AppHandle, plugins: &mut [DshPlugin]) {
+    let specs = read_specs(app_handle);
+    let cache = cache().lock().unwrap();
+    let now = Instant::now();
+    for p in plugins.iter_mut() {
+        let spec = specs.get(&p.id).cloned().unwrap_or_default();
+        let key = cache_key(&p.id, &spec, &p.version);
+        if let Some(entry) = cache.get(&key) {
+            if now.duration_since(entry.at) < UPDATES_TTL {
+                p.update_available = entry.info.update_available;
+                p.latest_version = entry.info.latest.clone();
+            }
+        }
+    }
+}
+
+/// 重新探测所有已安装插件的更新可用性（网络 + 缓存），返回带最新判定结果的完整列表。
+///
+/// 对已缓存且未过期的条目复用缓存；其余条目并行发请求；判定失败统一按「无更新」
+/// 处理，因此即使 registry/GitHub 不可达，插件管理流程也照常可用。
+pub async fn refresh(app_handle: &AppHandle) -> Result<Vec<DshPlugin>, String> {
+    let mut plugins = super::watch::list(app_handle);
+    let specs = read_specs(app_handle);
+    let locked = read_locked_commits(&profile_dir(app_handle));
+    let client = reqwest::Client::builder()
+        .user_agent("deepseek-harness-desktop")
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("UPDATES_CLIENT: {e}"))?;
+
+    struct Task {
+        idx: usize,
+        key: String,
+        id: String,
+        spec: String,
+        version: Option<String>,
+    }
+
+    let now = Instant::now();
+    let mut tasks: Vec<Task> = Vec::new();
+    {
+        let cache = cache().lock().unwrap();
+        for (idx, p) in plugins.iter_mut().enumerate() {
+            let spec = specs.get(&p.id).cloned().unwrap_or_default();
+            let key = cache_key(&p.id, &spec, &p.version);
+            if let Some(entry) = cache.get(&key) {
+                if now.duration_since(entry.at) < UPDATES_TTL {
+                    p.update_available = entry.info.update_available;
+                    p.latest_version = entry.info.latest.clone();
+                    continue;
+                }
+            }
+            tasks.push(Task {
+                idx,
+                key,
+                id: p.id.clone(),
+                spec,
+                version: (!p.version.is_empty()).then(|| p.version.clone()),
+            });
+        }
+    }
+
+    // 并行发起更新判定。`client`/`locked` 只在 `join_all` 期间存活，用引用而非 move
+    // 捕获（否则 FnMut 的 map 无法多次消费非 Copy 的它们）；`t` 是闭包参数、按 move
+    // 进每个异步块（每个任务独立持有自己的键/下标）。
+    let results = futures_util::future::join_all(tasks.into_iter().map(|t| {
+        let c = &client;
+        let lock = &locked;
+        async move {
+            let info = compute_update(c, &t.id, &t.spec, t.version.as_deref(), lock).await;
+            (t.idx, t.key, info)
+        }
+    }))
+    .await;
+
+    let mut cache = cache().lock().unwrap();
+    for (idx, key, info) in results {
+        if let Some(p) = plugins.get_mut(idx) {
+            p.update_available = info.update_available;
+            p.latest_version = info.latest.clone();
+        }
+        cache.insert(key, CacheEntry { info, at: Instant::now() });
+    }
+
+    Ok(plugins)
+}
+
+// ---------------------------------------------------------------------------
+// 单元测试
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upgrade_requires_strictly_newer() {
+        assert!(is_upgrade("1.0.0", "1.0.1"));
+        assert!(is_upgrade("1.0.0", "2.0.0"));
+        // latest 不是更高（回退/降级/相同）→ 不算升级
+        assert!(!is_upgrade("1.0.1", "1.0.0"));
+        assert!(!is_upgrade("1.0.0", "1.0.0"));
+        // 非语义化版本不可判 → 不算升级
+        assert!(!is_upgrade("1.0.0", "canary"));
+        assert!(!is_upgrade("0.0.0", "0.0.0"));
+    }
+
+    #[test]
+    fn upgrade_handles_prerelease() {
+        assert!(is_upgrade("1.0.0", "1.0.1-rc.1"));
+        // 同 base，release 高于 prerelease
+        assert!(is_upgrade("1.0.0-rc.1", "1.0.0"));
+        assert!(!is_upgrade("1.0.0", "1.0.0-rc.1"));
+    }
+
+    #[test]
+    fn extract_repo_from_github_shorthand() {
+        assert_eq!(
+            extract_github_repo("github:omdsh-dev/DSH-better-sidebar"),
+            Some("omdsh-dev/DSH-better-sidebar".into())
+        );
+        assert_eq!(
+            extract_github_repo("github:baihejiangnan/dsh-session-context-menu#next"),
+            Some("baihejiangnan/dsh-session-context-menu".into())
+        );
+    }
+
+    #[test]
+    fn extract_repo_from_git_https_and_codeload() {
+        assert_eq!(
+            extract_github_repo("git+https://github.com/omdsh-dev/DSH-better-sidebar.git"),
+            Some("omdsh-dev/DSH-better-sidebar".into())
+        );
+        assert_eq!(
+            extract_github_repo("git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git"),
+            Some("omdsh-dev/DSH-better-sidebar".into())
+        );
+        assert_eq!(
+            extract_github_repo("https://codeload.github.com/omdsh-dev/DSH-better-sidebar/tar.gz/7dbd9b75e2fd65758d4e55f750319399b91255a2"),
+            Some("omdsh-dev/DSH-better-sidebar".into())
+        );
+    }
+
+    #[test]
+    fn extract_repo_for_plain_npm_is_none() {
+        assert_eq!(extract_github_repo("dshmarket"), None);
+        assert_eq!(extract_github_repo("link:../plugin"), None);
+        assert_eq!(extract_github_repo("file:./local"), None);
+        assert_eq!(extract_github_repo("npm:dshmarket@^1.0"), None);
+    }
+
+    #[test]
+    fn lock_commits_parsed_from_codeload_urls() {
+        let lock = "\
+importers:\n  .:\n    dependencies:\n      dsh-better-sidebar:\n        specifier: https://codeload.github.com/omdsh-dev/DSH-better-sidebar/tar.gz/7dbd9b75e2fd65758d4e55f750319399b91255a2\n";
+        let dir = std::env::temp_dir().join(format!("dsh-updates-lock-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("pnpm-lock.yaml"), lock).unwrap();
+        let commits = read_locked_commits(&dir);
+        assert_eq!(
+            commits.get("omdsh-dev/dsh-better-sidebar"),
+            Some(&"7dbd9b75e2fd65758d4e55f750319399b91255a2".to_string())
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn cache_key_changes_with_version() {
+        let a = cache_key("p", "spec", "1.0.0");
+        let b = cache_key("p", "spec", "1.0.1");
+        assert_ne!(a, b);
+        let c = cache_key("p", "spec2", "1.0.0");
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn registry_name_encoded() {
+        assert_eq!(encode_registry_name("@scope/name"), "%40scope%2Fname");
+        assert_eq!(encode_registry_name("dshmarket"), "dshmarket");
+    }
+}

--- a/src-tauri/src/service/plugin/watch.rs
+++ b/src-tauri/src/service/plugin/watch.rs
@@ -48,6 +48,13 @@ pub struct DshPlugin {
     pub recommended: bool,
     /// 预设清单中的「修复」标记（黄色 chip）
     pub fix: bool,
+    /// 是否有可用更新（由 `service::plugin::updates` 探测；尚未判定时为 false，
+    /// 前端在挂载后经 `refresh_plugin_updates` 补齐——因此有更新时才显示升级按钮，
+    /// 不会「常驻」）
+    pub update_available: bool,
+    /// 判定得到的「最新版本」（registry latest / git HEAD SHA）；未判定或不可判定时缺省
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_version: Option<String>,
     /// 异常信息（安装/升级/卸载失败或页面运行期上报）；`None` = 正常
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<PluginError>,
@@ -167,6 +174,8 @@ fn parse_plugins(profile: &Path, presets: &[PreinstallPluginInfo]) -> Vec<DshPlu
                 bundled: bundled.contains(id.as_str()),
                 recommended: preset.map(|p| p.recommended).unwrap_or(false),
                 fix: preset.map(|p| p.fix).unwrap_or(false),
+                update_available: false,
+                latest_version: None,
                 error: None,
             })
         })

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -592,6 +592,9 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     // bin 目录：persistent bash（--noprofile --norc）不执行 profile 脚本、PATH
     // 完全继承服务进程，若不含 Git 的 usr/bin，ls/sed/find 等 coreutils 全会
     // `command not found`（MSYS 运行时在部分环境下不会自动补 /usr/bin）。
+    // 前置应用自身的 shim 目录，使市场（dsh-market）及其子进程通过名字解析的
+    // `pnpm`/`dsh` 都命中桌面端 shim，从而受桌面端 pnpm 选版策略管辖
+    // （轻量缓解，issue #69 系列）。
     if let Some(node_dir) = node_binary_path.parent() {
         if let Some(existing_path) = std::env::var_os("PATH") {
             let git_dirs = win_inspector::git_bash_bin_dirs();
@@ -599,13 +602,22 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
             for dir in &git_dirs {
                 log::debug!("harness service PATH prepend: {}", dir.to_string_lossy());
             }
-            let mut paths = vec![node_dir.to_path_buf()];
+            let mut paths = vec![crate::service::cli::get_bin_dir(&app_handle)];
+            paths.push(node_dir.to_path_buf());
             paths.extend(git_dirs);
             paths.extend(std::env::split_paths(&existing_path));
             if let Ok(new_path) = std::env::join_paths(paths) {
                 envs.insert("PATH".to_string(), new_path.to_string_lossy().into_owned());
             }
         }
+    }
+
+    // 让市场子进程的 pnpm 与桌面端同一套受控策略（store 主版本感知、避免落到系统
+    // homebrew pnpm）。与插件安装路径的 ensure_pnpm 版本感知一致，但启动阶段绝不
+    // 触发下载；捆绑版未安装或与 store 不匹配时不注入（交由用户 pnpm）。
+    // 最佳努力：失败只告警，不阻断启动。
+    if crate::service::plugin::harness_prefer_bundled_pnpm(&app_handle) {
+        envs.insert("DSH_PREFER_BUNDLED_PNPM".to_string(), "1".to_string());
     }
 
     // 日志文件（前端日志面板读取）。

--- a/src/components/config-plugin.tsx
+++ b/src/components/config-plugin.tsx
@@ -177,8 +177,9 @@ export function ConfigPlugin() {
                 )}
                 right={(
                   <>
-                    {/* 更新入口仅在插件异常时显示（需求 2：异常插件的修复入口） */}
-                    <If cond={plugin.error != null}>
+                    {/* 升级入口仅在确有更新（updateAvailable）或插件异常（error，修复入口）时显示；
+                        与文档 P1「对 dshmarket 点击升级」一致，且不会常驻——up-to-date 插件不显示升级按钮 */}
+                    <If cond={plugin.updateAvailable || plugin.error != null}>
                       <Chip
                         className={`rounded-md${busy ? ' cursor-not-allowed opacity-50' : ' cursor-pointer'}`}
                         variant="primary"
@@ -189,6 +190,9 @@ export function ConfigPlugin() {
                         <span className="flex items-center gap-1">
                           <If cond={busy?.id === plugin.id && busy.action === 'update'} then={<Spinner size="sm" color="current" />} />
                           {t('plugins.upgrade')}
+                          <If cond={plugin.latestVersion != null && plugin.error == null}>
+                            <span className="font-mono text-[10px] opacity-80">{plugin.latestVersion}</span>
+                          </If>
                         </span>
                       </Chip>
                     </If>

--- a/src/hooks/use-dsh-plugins.ts
+++ b/src/hooks/use-dsh-plugins.ts
@@ -31,6 +31,10 @@ export interface DshPlugin {
   recommended: boolean
   /** 预设清单中的「修复」标记 */
   fix: boolean
+  /** 是否有可用更新（由 `service::plugin::updates` 探测；未判定时为 false） */
+  updateAvailable: boolean
+  /** 判定得到的「最新版本」（registry latest / git HEAD SHA）；未判定时缺省 */
+  latestVersion?: string
   /** 异常信息（安装/升级/卸载失败或页面运行期上报）；undefined = 正常 */
   error?: PluginErrorInfo | null
 }
@@ -62,6 +66,20 @@ export function useDshPlugins(): UseDshPluginsResult {
     queryFn: () => invoke<DshPlugin[]>('get_dsh_plugins'),
   })
 
+  // 重新探测更新可用性并写回缓存（Rust 侧 30min 缓存；失败静默按「无更新」处理，
+  // 插件管理器仍可用）。返回的列表会经 `dsh-plugins-updated` 事件写入同一缓存，
+  // 前端据此在仅有更新（或异常修复）时才显示升级按钮，而不是常驻。
+  function refreshUpdates() {
+    void invoke<DshPlugin[]>('refresh_plugin_updates')
+      .then(list => queryClient.setQueryData(['plugins'], list))
+      .catch(err => console.error('[useDshPlugins] refresh_plugin_updates failed:', err))
+  }
+
+  // 首次加载后补齐更新可用性
+  useEffect(() => {
+    refreshUpdates()
+  }, [queryClient])
+
   // 订阅后端实时推送：事件载荷即完整列表，直接写入缓存避免多余的往返拉取
   useEffect(() => {
     let unlisten: UnlistenFn | null = null
@@ -71,6 +89,8 @@ export function useDshPlugins(): UseDshPluginsResult {
       if (disposed)
         return
       queryClient.setQueryData(['plugins'], event.payload)
+      // 文件变化（安装/升级/卸载）会改写版本与 spec → 缓存键变化，需重新探测更新
+      refreshUpdates()
     })
       .then((fn) => {
         if (disposed)


### PR DESCRIPTION
## 问题

「设置 → 插件」面板的升级按钮此前只在插件异常（`error != null`）时显示，导致「明明有更新却看不到升级按钮」（如 `dsh-auto-collapse`、`dsh-better-sidebar`，见 #69）。

同时，dsh-market 的安装/更新走的是它自己内部 `spawnSync("pnpm")`——在 macOS 上固定落到系统 homebrew pnpm，绕开了桌面端对 pnpm 选版与 `allowBuilds` 自愈的控制，成为插件市场无法更新/安装的根因之一。

## 改动

### 1. 精确判断是否有更新（替换「常驻按钮」）
新增 `src-tauri/src/service/plugin/updates.rs`，参考 dsh-market 的判定逻辑，按依赖 spec 分类：
- **git 类**（`github:` / `git+https://github.com/…` / codeload 链接）：用 `pnpm-lock.yaml` 里记录的 codeload 提交 SHA 对比 GitHub `commits/HEAD`，不同即视为有更新。
- **npm 类**：查 `registry.npmjs.org/<pkg>/latest`，`semver` 判定 `latest > installed` 才算更新。
- **`link:` / `file:`**：永不判更新。
- **任何失败 → 按「无更新」处理**，30 分钟 TTL 缓存，插件管理器保持可用（即使市场不可更新）。

数据流：
- `DshPlugin` 新增 `updateAvailable` / `latestVersion`。
- `get_dsh_plugins` 并入缓存判定；新增 `refresh_plugin_updates` 命令真正做网络探测。
- `useDshPlugins` 在挂载后与收到 `dsh-plugins-updated` 时刷新；`config-plugin` 的「升级」按钮改为仅在 `updateAvailable`（或插件异常修复）时显示，并附目标版本徽标——不再常驻。

### 2. harness 进程注入 pnpm 策略
- 新增 `harness_prefer_bundled_pnpm`（store 主版本感知、启动阶段不触发下载）。
- `workflow/mod.rs` 启动 harness 时前置应用 shim 目录到 PATH，并在捆绑版与 store 匹配时注入 `DSH_PREFER_BUNDLED_PNPM=1`，使市场子进程的 pnpm 走桌面端受控策略而非系统 pnpm。

## 验证
- `cargo check` 通过（仅 1 个既有警告）。
- `cargo test --lib plugin::` 47 项全绿（含 8 个新增 `updates` 单测）。
- 前端 `pnpm typecheck`（`tsc --noEmit`）通过。

关联 #69。