### PR TITLE
fix(windows): stabilize startup state restoration

### DIFF
--- a/src-tauri/src/config/window_state.rs
+++ b/src-tauri/src/config/window_state.rs
@@ -10,7 +10,8 @@
 
 use serde::{Deserialize, Serialize};
 use tauri::{
-    AppHandle, Manager, PhysicalPosition, PhysicalSize, Position, Runtime, Size, WebviewWindow, Window,
+    AppHandle, Manager, PhysicalPosition, PhysicalSize, Position, Runtime, Size, WebviewWindow,
+    Window,
 };
 use tauri_plugin_store::StoreExt;
 
@@ -32,9 +33,12 @@ pub struct WindowState {
     /// 非最大化时的物理位置（outer_position，屏幕左上角为原点）
     pub x: Option<i32>,
     pub y: Option<i32>,
-    /// 物理尺寸（outer_size）
+    /// 物理尺寸（inner_size，与 Tauri set_size 的语义一致）
     pub width: u32,
     pub height: u32,
+    /// 尺寸是否为内容区尺寸；旧记录缺少此字段时按外框尺寸迁移
+    #[serde(default)]
+    pub size_is_inner: bool,
 }
 
 impl Default for WindowState {
@@ -45,6 +49,7 @@ impl Default for WindowState {
             y: None,
             width: DEFAULT_WINDOW_WIDTH as u32,
             height: DEFAULT_WINDOW_HEIGHT as u32,
+            size_is_inner: true,
         }
     }
 }
@@ -93,15 +98,46 @@ pub fn save_geometry<R: Runtime>(window: &Window<R>) {
     }
 
     let pos = window.outer_position().ok();
-    let size = window.outer_size().ok();
+    let size = window.inner_size().ok();
     let state = WindowState {
         maximized: window.is_maximized().unwrap_or(false),
         x: pos.map(|p| p.x),
         y: pos.map(|p| p.y),
         width: size.map(|s| s.width).unwrap_or(DEFAULT_WINDOW_WIDTH as u32),
-        height: size.map(|s| s.height).unwrap_or(DEFAULT_WINDOW_HEIGHT as u32),
+        height: size
+            .map(|s| s.height)
+            .unwrap_or(DEFAULT_WINDOW_HEIGHT as u32),
+        size_is_inner: true,
     };
     save_window_state(window.app_handle(), &state);
+}
+
+/// 正常退出前主动采样主窗口，兜底最后一次移动/缩放事件尚未落盘的情况。
+pub fn save_main_window_geometry<R: Runtime>(app_handle: &AppHandle<R>) {
+    if let Some(webview_window) = app_handle.get_webview_window("main") {
+        let window = webview_window.as_ref().window();
+        save_geometry(&window);
+    }
+}
+
+/// 把旧版保存的外框尺寸换算成 set_size 所需的内容区尺寸。
+fn migrate_legacy_outer_size(
+    saved: &WindowState,
+    current_outer: PhysicalSize<u32>,
+    current_inner: PhysicalSize<u32>,
+) -> WindowState {
+    if saved.size_is_inner {
+        return saved.clone();
+    }
+
+    let frame_width = current_outer.width.saturating_sub(current_inner.width);
+    let frame_height = current_outer.height.saturating_sub(current_inner.height);
+    WindowState {
+        width: saved.width.saturating_sub(frame_width),
+        height: saved.height.saturating_sub(frame_height),
+        size_is_inner: true,
+        ..saved.clone()
+    }
 }
 
 /// 把保存的几何解析成「实际可用的矩形」，并夹紧到当前可见屏幕。
@@ -142,12 +178,14 @@ fn resolve_geometry<R: Runtime>(
     let (x, y) = match (saved.x, saved.y) {
         (Some(sx), Some(sy)) => {
             // 窗口矩形是否与可见屏幕并集有交集
-            let intersects = sx < max_x && sx + w as i32 > min_x
-                && sy < max_y && sy + h as i32 > min_y;
+            let intersects =
+                sx < max_x && sx + w as i32 > min_x && sy < max_y && sy + h as i32 > min_y;
             if intersects {
                 // 夹紧坐标到并集内，保证窗口至少部分可见
-                let nx = (sx as i64).clamp(min_x as i64, (max_x as i64 - w as i64).max(min_x as i64));
-                let ny = (sy as i64).clamp(min_y as i64, (max_y as i64 - h as i64).max(min_y as i64));
+                let nx =
+                    (sx as i64).clamp(min_x as i64, (max_x as i64 - w as i64).max(min_x as i64));
+                let ny =
+                    (sy as i64).clamp(min_y as i64, (max_y as i64 - h as i64).max(min_y as i64));
                 (nx as i32, ny as i32)
             } else {
                 // 保存的位置不可见：回落到主屏居中
@@ -173,7 +211,12 @@ fn resolve_geometry<R: Runtime>(
 /// 无历史状态时不改动窗口，由 builder 的默认 `inner_size(1280, 840)`
 /// （逻辑像素，居中）生效。
 pub fn restore_main_window<R: Runtime>(app: &AppHandle<R>, window: &WebviewWindow<R>) {
-    let saved = get_window_state(app);
+    let mut saved = get_window_state(app);
+    if !saved.size_is_inner {
+        if let (Ok(outer), Ok(inner)) = (window.outer_size(), window.inner_size()) {
+            saved = migrate_legacy_outer_size(&saved, outer, inner);
+        }
+    }
     let Some((size, pos)) = resolve_geometry(app, &saved) else {
         return;
     };
@@ -196,6 +239,7 @@ mod tests {
         assert!(state.y.is_none());
         assert_eq!(state.width, DEFAULT_WINDOW_WIDTH as u32);
         assert_eq!(state.height, DEFAULT_WINDOW_HEIGHT as u32);
+        assert!(state.size_is_inner);
     }
 
     #[test]
@@ -206,6 +250,7 @@ mod tests {
             y: Some(-200),
             width: 1920,
             height: 1080,
+            size_is_inner: true,
         };
         let json = serde_json::to_string(&state).expect("serialize");
         let parsed: WindowState = serde_json::from_str(&json).expect("deserialize");
@@ -220,6 +265,49 @@ mod tests {
     fn window_state_ignores_missing_fields() {
         // 老版本/缺失字段时也应能反序列化并回落到默认值
         let parsed: WindowState = serde_json::from_str("{}").expect("deserialize");
-        assert_eq!(parsed, WindowState::default());
+        assert!(!parsed.maximized);
+        assert!(parsed.x.is_none());
+        assert!(parsed.y.is_none());
+        assert_eq!(parsed.width, DEFAULT_WINDOW_WIDTH as u32);
+        assert_eq!(parsed.height, DEFAULT_WINDOW_HEIGHT as u32);
+        assert!(!parsed.size_is_inner);
+    }
+
+    #[test]
+    fn legacy_outer_size_is_converted_for_set_size() {
+        let saved = WindowState {
+            width: 1137,
+            height: 792,
+            size_is_inner: false,
+            ..WindowState::default()
+        };
+
+        let migrated = migrate_legacy_outer_size(
+            &saved,
+            PhysicalSize::new(1293, 848),
+            PhysicalSize::new(1267, 833),
+        );
+
+        assert_eq!(migrated.width, 1111);
+        assert_eq!(migrated.height, 777);
+        assert!(migrated.size_is_inner);
+    }
+
+    #[test]
+    fn inner_size_is_not_converted_twice() {
+        let saved = WindowState {
+            width: 1111,
+            height: 777,
+            size_is_inner: true,
+            ..WindowState::default()
+        };
+
+        let migrated = migrate_legacy_outer_size(
+            &saved,
+            PhysicalSize::new(1293, 848),
+            PhysicalSize::new(1267, 833),
+        );
+
+        assert_eq!(migrated, saved);
     }
 }

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -259,6 +259,11 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
             .min_inner_size(860.0, 620.0)
             .resizable(true);
 
+    // Windows/WebView2 在 build() 尚未返回时就可能绘制窗口。先隐藏创建，
+    // 等保存的几何恢复完成再显示，避免启动时先闪出默认尺寸再跳到历史尺寸。
+    #[cfg(windows)]
+    let webview_builder = webview_builder.visible(false);
+
     // macOS 保留原生交通灯：绿色按钮由 AppKit 进入独立 Space 的原生全屏，
     // 同时用 Overlay 让 44px 壳层导航栏继续与窗口 chrome 融合。其他平台
     // 仍由 ShellNavBar 的右侧按钮提供窗口控制。
@@ -315,6 +320,8 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
     // 恢复上次的窗口大小/位置/最大化状态（无历史时保持 builder 默认的 1280×840，
     // 由 Tauri 自动居中；见 config::window_state）。
     crate::config::restore_main_window(app, &webview_window);
+    #[cfg(windows)]
+    webview_window.show()?;
 
     #[cfg(windows)]
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,11 @@ pub fn run() {
             tauri::RunEvent::Reopen { .. } => {
                 crate::utils::show_main_window(&app_handle);
             }
+            // 正常退出请求发生在窗口销毁之前；此时主动保存一次主窗口几何，
+            // 避免 Windows 最后一个移动/缩放事件尚未写入就退出而丢失尺寸。
+            tauri::RunEvent::ExitRequested { .. } => {
+                config::save_main_window_geometry(app_handle);
+            }
             // 退出时回收 Harness 进程：不回收的话，node 进程会在应用退出后
             // 残留并把原生模块 DLL（如 sharp 的 libvips-42.dll）锁在内存，
             // 下次启动重新解压时会失败（Windows os error 32）

--- a/src-tauri/src/service/workflow/win_inspector.rs
+++ b/src-tauri/src/service/workflow/win_inspector.rs
@@ -13,8 +13,8 @@
 //!    `WindowsProcessInspector`，不修改任何 node_modules 官方包。该插件由预装
 //!    向导通过 `dsh plugin add github:clearkurt/dsh-win-terminal-inspector`
 //!    装入 profile 的 node_modules（Git 依赖，主键即包名），**桌面端仓库不内置
-//!    任何插件源码**；本模块随后写入 profile 的 `cordis.patch.yml` 挂载行
-//!    （裸包名经 node_modules 父级解析），并创作 Windows 用户 preset。
+//!    任何插件源码**；本模块随后写入 profile 的 `cordis.patch.yml` 显式入口
+//!    挂载行，并创作 Windows 用户 preset。
 //!
 //! 2. **preset 自身在 Windows 不可用**：agent preset 的组成（`agent.cordis.yml`）
 //!    由每次会话直接从磁盘文件挂载（`dsh-agent-presets::mountPreset`），
@@ -45,14 +45,14 @@ mod imp {
 
     /// cordis.patch.yml 追加的挂载行（顶层数组的一个 `- insert:` 元素）。
     ///
-    /// name 用相对 profile 目录的路径（`./node_modules/...`），不用裸包名：
+    /// name 用相对 profile 目录的显式入口（`./node_modules/.../index.js`），不用裸包名或目录：
     /// dsh loader 对 profile patch 条目的模块解析以 harness 安装为 baseUrl，
-    /// 裸插件名无法可靠解析；而相对路径经 `new URL(name, baseUrl)` 基于 profile
-    /// 目录解析，稳定指向 `dsh plugin add` 装入的 node_modules。
+    /// 裸插件名无法可靠解析，Node ESM 也不支持相对目录导入；显式文件路径经
+    /// `new URL(name, baseUrl)` 基于 profile 目录解析，稳定指向插件入口。
     const PATCH_ENTRY: &str = concat!(
         "- insert:\n",
         "    - id: win-terminal-inspector\n",
-        "      name: ./node_modules/dsh-win-terminal-inspector\n",
+        "      name: ./node_modules/dsh-win-terminal-inspector/index.js\n",
     );
 
     /// 注入判定标记：patch 中出现该字符串即视为已挂载。
@@ -120,14 +120,14 @@ mod imp {
             serde_yaml::Value::Sequence(seq) => seq,
             _ => unreachable!("parse_patch_list only returns a sequence"),
         };
-        // 迁移 + 幂等：已有本插件块时只需把旧的「裸包名」写法改写为相对路径写法；
+        // 迁移 + 幂等：已有本插件块时把旧的裸包名/目录写法改为显式入口文件；
         // 完全没有才追加新块。避免把旧写法当作「已挂载」直接跳过，导致修复对
         // 存量安装用户不生效（它们是注释-实现矛盾的历史受害者）。
         let mut has_ours = false;
         for el in seq.iter_mut() {
             if block_is_ours(el) {
                 has_ours = true;
-                if block_uses_bare_name(el) {
+                if block_uses_legacy_name(el) {
                     // 整块替换为规范写法（仅 id + name，其余字段不涉及本插件）。
                     *el = plugin_insert_entry();
                 }
@@ -229,14 +229,12 @@ mod imp {
             .unwrap_or(false)
     }
 
-    /// 挂载块是否仍使用「裸包名」旧写法（`name: dsh-win-terminal-inspector`）。
-    ///
-    /// 与相对路径写法（`name: ./node_modules/dsh-win-terminal-inspector`）区分：
-    /// 裸包名无法被 dsh loader 按 harness baseUrl 可靠解析，是历史注释-实现矛盾处。
-    fn block_uses_bare_name(el: &serde_yaml::Value) -> bool {
+    /// 挂载块是否仍使用无法被 Node ESM 稳定加载的裸包名或目录旧写法。
+    fn block_uses_legacy_name(el: &serde_yaml::Value) -> bool {
         serde_yaml::to_string(el)
-            .map(|s| s.contains("name: dsh-win-terminal-inspector")
-                && !s.contains("name: ./node_modules/dsh-win-terminal-inspector"))
+            .map(|s| {
+                !s.contains("name: ./node_modules/dsh-win-terminal-inspector/index.js")
+            })
             .unwrap_or(false)
     }
 
@@ -574,17 +572,15 @@ mod imp {
         }
 
         #[test]
-        fn patch_uses_profile_relative_node_modules_path() {
+        fn patch_uses_explicit_profile_relative_entry_file() {
             let dir = temp_dir("c");
             std::fs::create_dir_all(&dir).unwrap();
             ensure_patch(&dir).unwrap();
             let out = std::fs::read_to_string(dir.join("cordis.patch.yml")).unwrap();
-            // 必须是 `name: ./node_modules/dsh-win-terminal-inspector`（相对 profile
-            // 目录路径）。裸包名（`name: dsh-win-terminal-inspector`）无法被 dsh
-            // loader 按 harness baseUrl 可靠解析，是历史实现的注释-实现矛盾处。
+            // Node ESM 不支持目录导入；必须显式指向插件导出的 index.js。
             assert!(
-                out.contains("name: ./node_modules/dsh-win-terminal-inspector"),
-                "patch must mount via profile-relative path, got:\n{out}"
+                out.contains("name: ./node_modules/dsh-win-terminal-inspector/index.js"),
+                "patch must mount the explicit profile-relative entry file, got:\n{out}"
             );
             // 单独断言不含裸包名写法（`name: dsh-win-terminal-inspector` 后直接换行）
             assert!(
@@ -607,10 +603,10 @@ mod imp {
             .unwrap();
             ensure_patch(&dir).unwrap();
             let out = std::fs::read_to_string(&patch).unwrap();
-            // 存量旧条目必须被改写为相对 profile 路径，而不是当作「已挂载」跳过
+            // 存量旧条目必须被改写为显式入口文件，而不是当作「已挂载」跳过
             assert!(
-                out.contains("name: ./node_modules/dsh-win-terminal-inspector"),
-                "bare-name entry must be migrated to profile-relative path, got:\n{out}"
+                out.contains("name: ./node_modules/dsh-win-terminal-inspector/index.js"),
+                "bare-name entry must be migrated to the explicit entry file, got:\n{out}"
             );
             assert!(
                 !out.contains("name: dsh-win-terminal-inspector\n"),
@@ -620,6 +616,28 @@ mod imp {
             ensure_patch(&dir).unwrap();
             let out2 = std::fs::read_to_string(&patch).unwrap();
             assert_eq!(out, out2);
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn ensure_patch_upgrades_existing_directory_entry() {
+            let dir = temp_dir("n");
+            std::fs::create_dir_all(&dir).unwrap();
+            let patch = dir.join("cordis.patch.yml");
+            // Node 24 ESM 不支持相对目录导入，旧桌面端生成的写法会阻断启动。
+            std::fs::write(
+                &patch,
+                "- insert:\n    - id: win-terminal-inspector\n      name: ./node_modules/dsh-win-terminal-inspector\n",
+            )
+            .unwrap();
+
+            ensure_patch(&dir).unwrap();
+            let out = std::fs::read_to_string(&patch).unwrap();
+            assert!(
+                out.contains("name: ./node_modules/dsh-win-terminal-inspector/index.js"),
+                "directory entry must be migrated to the explicit entry file, got:\n{out}"
+            );
+
             std::fs::remove_dir_all(&dir).ok();
         }
 


### PR DESCRIPTION
## Summary

- persist the main window's inner size and migrate legacy outer-size records before restoring
- snapshot the main window geometry on application exit so the last resize is not lost
- create the Windows WebView window hidden and show it only after geometry restoration, removing the visible default-size jump
- use the explicit dsh-win-terminal-inspector/index.js ESM entry and migrate legacy bare-name/directory patch entries

## Verification

- cargo check
- cargo test -- --skip grandchildren_inherit_hidden_console — 148 passed, 1 filtered
- Windows lifecycle regression: resize → close/hide → exit → restart preserves the same size
- Windows startup probe: before the fix the visible sequence was default geometry → restored geometry; after the fix only the restored drawable geometry was visible
- reproduced the inspector startup failure with the real DSH CLI, then verified HTTP 200 after migrating the patch entry
- built the Windows NSIS installer successfully

## Notes

The unfiltered test suite has one existing environment-dependent failure: grandchildren_inherit_hidden_console requires node.exe to be discoverable in the test environment. All remaining 148 tests pass.