### PR TITLE
fix(macos): add Edit menu to restore Cmd+X/C/V input shortcuts

### DIFF
--- a/src-tauri/src/config/i18n.rs
+++ b/src-tauri/src/config/i18n.rs
@@ -58,6 +58,13 @@ pub fn t(key: &str) -> String {
         "menu.about" => ("关于 Desktop", "About Desktop"),
         "menu.run_logs" => ("运行日志", "Run Logs"),
         "menu.check_update" => ("检查更新", "Check for Updates"),
+        "menu.edit" => ("编辑", "Edit"),
+        "menu.undo" => ("撤销", "Undo"),
+        "menu.redo" => ("重做", "Redo"),
+        "menu.cut" => ("剪切", "Cut"),
+        "menu.copy" => ("复制", "Copy"),
+        "menu.paste" => ("粘贴", "Paste"),
+        "menu.select_all" => ("全选", "Select All"),
         _ => (key, key),
     };
     match lang() {

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -200,9 +200,44 @@ pub fn install_macos_menu(app: &tauri::AppHandle<Wry>) -> tauri::Result<()> {
         &[&run_logs, &check_update, &help_separator, &about],
     )?;
 
+    // 编辑菜单：macOS 设置了主菜单后，⌘X/⌘C/⌘V/⌘A 等组合键会先经菜单的
+    // key-equivalent 路由，若不挂载标准编辑项，WebView 的编辑快捷键会被吞掉，
+    // 输入框内无法剪切/复制/粘贴（#85）。这些预定义项绑定标准 NSMenu 选择器
+    // （cut:/copy:/paste:/selectAll:/undo:/redo:），由 AppKit 把命令转发给聚焦视图
+    // （WebView），同时保持菜单条上的撤销/重做/剪切/复制/粘贴/全选。
+    let undo = PredefinedMenuItem::undo(app, Some(&crate::config::i18n::t("menu.undo")))?;
+    let redo = PredefinedMenuItem::redo(app, Some(&crate::config::i18n::t("menu.redo")))?;
+    let cut = PredefinedMenuItem::cut(app, Some(&crate::config::i18n::t("menu.cut")))?;
+    let copy = PredefinedMenuItem::copy(app, Some(&crate::config::i18n::t("menu.copy")))?;
+    let paste = PredefinedMenuItem::paste(app, Some(&crate::config::i18n::t("menu.paste")))?;
+    let select_all = PredefinedMenuItem::select_all(app, Some(&crate::config::i18n::t("menu.select_all")))?;
+    let edit_separator_after_redo = PredefinedMenuItem::separator(app)?;
+    let edit_separator_before_select_all = PredefinedMenuItem::separator(app)?;
+    let edit_menu = Submenu::with_id_and_items(
+        app,
+        "desktop-edit-menu",
+        crate::config::i18n::t("menu.edit"),
+        true,
+        &[
+            &undo,
+            &redo,
+            &edit_separator_after_redo,
+            &cut,
+            &copy,
+            &paste,
+            &edit_separator_before_select_all,
+            &select_all,
+        ],
+    )?;
+
     let menu = Menu::with_items(
         app,
-        &[&system_application_menu, &application_menu, &help_menu],
+        &[
+            &system_application_menu,
+            &application_menu,
+            &edit_menu,
+            &help_menu,
+        ],
     )?;
     let _ = app.set_menu(menu)?;
     *MACOS_FULLSCREEN_MENU_ITEM


### PR DESCRIPTION
## Summary

Fixes #85 — on macOS, the session input box's Command+X/C/V (cut/copy/paste) shortcuts stopped working after v0.7.6 (regression; v0.7.5 was fine).

## Root cause

v0.7.6 introduced a native macOS menu (`install_macos_menu` in `src-tauri/src/desktop/builder.rs`) that only contains System / Application / Help submenus — there is no **Edit** menu, i.e. no ⌘X / ⌘C / ⌘V / ⌘A key-equivalent items. Once an app installs a main menu on macOS, Command shortcuts are routed through the menu's key-equivalent handling first, which swallows the WebView's native edit shortcuts.

## Changes

- `src-tauri/src/desktop/builder.rs`: add an **Edit** submenu (`desktop-edit-menu`) between the Application and Help menus, binding the standard predefined items — undo (⌘Z), redo (⇧⌘Z), cut (⌘X), copy (⌘C), paste (⌘V), select-all (⌘A). These use the standard NSMenu selectors (cut: / copy: / paste: / selectAll: / undo: / redo:) so AppKit forwards the commands to the focused WebView, restoring clipboard editing in the input box.
- `src-tauri/src/config/i18n.rs`: add flat backend i18n keys `menu.edit`, `menu.undo`, `menu.redo`, `menu.cut`, `menu.copy`, `menu.paste`, `menu.select_all` (zh/en) — no hardcoded strings.

## Verification

- `cargo check` passes
- `cargo test` passes (169/169)

Note: the macOS-only code path cannot be cross-compiled on this host (Windows) because a transitive dependency's build script needs the Apple C toolchain, but each API call mirrors existing working patterns in the same function and the vendored Tauri 2.11.5 signatures.
