### PR TITLE
fix(cli): handle dangling symlink at shim write target (fix #96)

### DIFF
--- a/src-tauri/src/service/cli/shim.rs
+++ b/src-tauri/src/service/cli/shim.rs
@@ -482,6 +482,20 @@ fn is_foreign_file(path: &Path) -> bool {
     !is_generated_shim(path)
 }
 
+/// 路径是否为悬空符号链接（链接本身存在，但指向的目标不存在）。
+///
+/// 官方 dsh 安装器会在 `~/.local/bin/dsh -> ~/.dsh/source/current/bin/dsh` 留下
+/// 符号链接；当 `current` 指向的目录被移动/删除后链接即悬空。此时
+/// `Path::exists()` 跟随链接返回 `false`，但直接 `fs::write` 会沿链接打开目标
+/// 并在其父目录缺失时报 `No such file or directory (os error 2)`——必须先把
+/// 已失效的链接本身移除，才能按"文件不存在"正常写入。
+fn is_dangling_symlink(path: &Path) -> bool {
+    match path.symlink_metadata() {
+        Ok(meta) => meta.file_type().is_symlink() && !path.exists(),
+        Err(_) => false,
+    }
+}
+
 /// 判断路径是否为本应用生成的 shim（内容含生成标记）。
 ///
 /// 用于在本地 dsh 探测中区分"本应用 shim"与"用户自行放置的同名文件"：
@@ -491,6 +505,34 @@ pub fn is_generated_shim(path: &Path) -> bool {
         Ok(content) => content.contains(GENERATED_MARKER),
         Err(_) => false,
     }
+}
+
+/// 写入单个 shim 文件，处理目标已存在时的三种情形：
+///
+/// 1. 悬空符号链接（用户/官方安装器残留、目标已失效）→ 移除链接后正常写入；
+/// 2. 已存在且非本应用生成（用户手动放置的 `dsh`/`pnpm`）→ 跳过，保留用户文件；
+/// 3. 其余（不存在，或本应用生成的 shim）→ 直接写入/覆盖。
+fn write_shim_file(target: &Path, content: &str) -> Result<(), String> {
+    if is_dangling_symlink(target) {
+        log::warn!(
+            "Removing dangling symlink {:?} before writing shim (its target is gone)",
+            target
+        );
+        fs::remove_file(target).map_err(|e| {
+            format!(
+                "remove dangling symlink {} failed: {e}",
+                target.display()
+            )
+        })?;
+    }
+    if target.exists() && is_foreign_file(target) {
+        log::warn!(
+            "Skipping shim write to {:?}: an existing user file is preserved",
+            target
+        );
+        return Ok(());
+    }
+    fs::write(target, content).map_err(|e| format!("write {} failed: {e}", target.display()))
 }
 
 /// 主 `dsh` shim 路径下是否保留了用户自行安装的同名文件（用于状态展示）。
@@ -509,6 +551,8 @@ pub fn user_dsh_preserved(bin_dir: &Path) -> bool {
 }
 
 /// 将 shim 文件写入 bin 目录；目标已存在但非本应用生成的同名文件时跳过（保留）。
+/// 目标为悬空符号链接时先移除链接再写入（链接目标已失效，保留只会让写入
+/// 报 ENOENT）。
 ///
 /// 覆盖式仅针对本应用生成的 shim（自愈时内容与当前安装一致）；用户手动放置的
 /// 同名 `dsh`/`pnpm` 一律保留不动，避免覆盖用户自己的安装与配置。
@@ -520,15 +564,7 @@ pub fn write_shims(app_handle: &AppHandle, bin_dir: &Path) -> Result<(), String>
     macro_rules! write_if_ours {
         ($path:expr, $content:expr) => {{
             let target = bin_dir.join($path);
-            if target.exists() && is_foreign_file(&target) {
-                log::warn!(
-                    "Skipping shim write to {:?}: an existing user file is preserved",
-                    target
-                );
-            } else {
-                fs::write(&target, $content)
-                    .map_err(|e| format!("write {} failed: {e}", target.display()))?;
-            }
+            write_shim_file(&target, &$content)?;
             target
         }};
     }
@@ -755,6 +791,103 @@ mod tests {
         std::fs::write(&user_dsh, generated).unwrap();
         assert!(!is_foreign_file(&user_dsh), "generated shim must not be foreign");
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ------------------------------------------------------------------
+    // write_shim_file 目标文件处理（悬空符号链接 / 用户文件保留 / 生成文件覆盖）
+    // ------------------------------------------------------------------
+
+    /// 独立的临时目录，避免测试间互相干扰
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "dsh-shim-write-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// 悬空符号链接（官方 dsh 安装器残留 `~/.local/bin/dsh -> ~/.dsh/source/current/bin/dsh`
+    /// 且目标已消失）时：先移除失效链接，再正常写入生成 shim——修复原报错
+    /// `write ... failed: No such file or directory (os error 2)`
+    #[test]
+    #[cfg(unix)]
+    fn write_shim_file_removes_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = temp_dir("dangling");
+        let target = dir.join("dsh");
+        symlink(dir.join("missing/source/current/bin/dsh"), &target).unwrap();
+        assert!(is_dangling_symlink(&target));
+
+        write_shim_file(&target, "#!/bin/sh\ngenerated shim\n").unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "#!/bin/sh\ngenerated shim\n"
+        );
+        assert!(
+            !std::fs::symlink_metadata(&target)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "dangling symlink must be replaced by a regular file"
+        );
+        assert!(!is_dangling_symlink(&target));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 指向真实用户 dsh 的符号链接（目标仍存在）→ 视为用户文件，保留不动
+    #[test]
+    #[cfg(unix)]
+    fn write_shim_file_preserves_valid_user_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = temp_dir("userlink");
+        let real = dir.join("real-dsh");
+        std::fs::write(&real, "#!/bin/sh\necho my real dsh\n").unwrap();
+        let target = dir.join("dsh");
+        symlink(&real, &target).unwrap();
+
+        write_shim_file(&target, "#!/bin/sh\ngenerated shim\n").unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&target)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "valid user symlink must be preserved"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&real).unwrap(),
+            "#!/bin/sh\necho my real dsh\n"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 本应用生成的 shim → 覆盖自愈内容
+    #[test]
+    fn write_shim_file_overwrites_generated_shim() {
+        let dir = temp_dir("overwrite");
+        let target = dir.join("dsh");
+        std::fs::write(
+            &target,
+            "#!/bin/sh\n# DeepSeek Harness Desktop - old shim\n",
+        )
+        .unwrap();
+
+        write_shim_file(&target, "#!/bin/sh\n# DeepSeek Harness Desktop - new shim\n").unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "#!/bin/sh\n# DeepSeek Harness Desktop - new shim\n"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## What & why

Fixes #96.

On Unix, `~/.local/bin/dsh` left behind by the official dsh installer is a symlink
(`~/.local/bin/dsh -> ~/.dsh/source/current/bin/dsh`). Once the link target is moved
or removed, the link becomes **dangling**. `write_shims` then:

1. `target.exists()` follows the symlink -> `false` -> treated as "missing, safe to write";
2. `fs::write()` follows the dangling link again and fails with
   `write ... failed: No such file or directory (os error 2)` because the target's
   parent directory does not exist.

`fs::create_dir_all(bin_dir)` only ensures `~/.local/bin` exists; it cannot help the
link target.

## Changes

- `shim.rs`: add `is_dangling_symlink()` and a new `write_shim_file()` helper used by
  `write_shims` for every shim (dsh/pnpm, cmd/ps1/sh):
  - dangling symlink -> remove the dead link, then write the generated shim normally;
  - existing non-generated file (regular user file **or valid symlink to user dsh**) ->
    still preserved, never overwritten;
  - generated shim -> overwritten as before.
- 3 new unit tests covering the dangling-symlink repair, valid-user-symlink preservation,
  and generated-shim overwrite.

## Verification

- `cargo test --lib` -> 185 passed, 0 failed.
- Reproduced the original ENOENT with a plain dangling symlink before the fix.
