### PR TITLE
fix(webview): wait for client plugin bundles before embedding dsh

### DIFF
--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -367,7 +367,8 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
         .initialization_script_for_all_frames(crate::desktop::notification::NOTIFICATION_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::nav::NAV_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::style::IFRAME_STYLES_JS)
-        .initialization_script_for_all_frames(crate::desktop::paste::PASTE_SHIM_JS);
+        .initialization_script_for_all_frames(crate::desktop::paste::PASTE_SHIM_JS)
+        .initialization_script_for_all_frames(crate::desktop::plugin_boot::PLUGIN_BOOT_RELOAD_JS);
 
     let webview_window = webview_builder.build()?;
 

--- a/src-tauri/src/desktop/mod.rs
+++ b/src-tauri/src/desktop/mod.rs
@@ -4,6 +4,7 @@ pub mod nav;
 pub mod notification;
 pub mod paste;
 pub mod payload;
+pub mod plugin_boot;
 pub mod style;
 pub mod window;
 

--- a/src-tauri/src/desktop/notification.rs
+++ b/src-tauri/src/desktop/notification.rs
@@ -277,6 +277,7 @@ pub fn enable_notification_permissions(
                     crate::desktop::nav::NAV_SHIM_JS,
                     crate::desktop::style::IFRAME_STYLES_JS,
                     crate::desktop::paste::PASTE_SHIM_JS,
+                    crate::desktop::plugin_boot::PLUGIN_BOOT_RELOAD_JS,
                 ] {
                     let script = HSTRING::from(script);
                     let _ = frame_for_injection.ExecuteScript(

--- a/src-tauri/src/desktop/plugin_boot.rs
+++ b/src-tauri/src/desktop/plugin_boot.rs
@@ -1,0 +1,47 @@
+//! 官方 dsh boot 页卡在 “Loading plugins…” 时的一次性自动刷新。
+//!
+//! 桌面端曾把 SPA `/` 的 200 当成就绪并立刻挂 iframe。连接桥尚未注册时，
+//! boot 页会无限转圈（[#36](https://github.com/dsh-tauri-desk/deepseek-harness-desktop/issues/36)、
+//! [#42](https://github.com/dsh-tauri-desk/deepseek-harness-desktop/issues/42)）；
+//! 手动刷新即可恢复。本脚本注入 iframe，若仍停在 boot 文案则只 reload 一次。
+//!
+//! 注入通道与 [`crate::desktop::nav::NAV_SHIM_JS`] 相同。
+
+/// iframe 内：boot 页卡住时自动 reload 一次（sessionStorage 防循环）。
+pub(crate) const PLUGIN_BOOT_RELOAD_JS: &str = r#"(function () {
+  if (window.__dsh_plugin_boot_reload__) return;
+  window.__dsh_plugin_boot_reload__ = true;
+  if (window === window.top) return;
+
+  var FLAG = '__dsh_plugin_boot_reloaded__';
+  try {
+    if (sessionStorage.getItem(FLAG) === '1') return;
+  } catch (_) {}
+
+  function isSplash() {
+    var text = (document.body && (document.body.innerText || document.body.textContent)) || '';
+    return text.indexOf('Loading plugins') !== -1;
+  }
+
+  function tick() {
+    if (!isSplash()) return;
+    try { sessionStorage.setItem(FLAG, '1'); } catch (_) {}
+    location.reload();
+  }
+
+  setTimeout(tick, 8000);
+})();"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boot_reload_script_is_one_shot_and_splash_scoped() {
+        assert!(PLUGIN_BOOT_RELOAD_JS.contains("__dsh_plugin_boot_reloaded__"));
+        assert!(PLUGIN_BOOT_RELOAD_JS.contains("Loading plugins"));
+        assert!(PLUGIN_BOOT_RELOAD_JS.contains("sessionStorage"));
+        assert!(PLUGIN_BOOT_RELOAD_JS.contains("window === window.top"));
+        assert!(PLUGIN_BOOT_RELOAD_JS.contains("location.reload"));
+    }
+}

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -1178,21 +1178,18 @@ pub async fn proxy_health_check(port: u16) -> Result<String, String> {
         .map_err(|e| format!("HARNESS_HEALTH_CLIENT_FAILED: {e}"))?;
     let mut failures = Vec::with_capacity(2);
 
-    for endpoint in [
-        format!("http://127.0.0.1:{port}/"),
-        format!("http://127.0.0.1:{port}/healthz"),
-    ] {
+    for endpoint in utils::health_probe_plugin_urls(port) {
         match client.get(&endpoint).send().await {
             Ok(response) => {
                 let status = response.status();
                 let body = response.text().await.unwrap_or_default();
-                if status.is_success() {
+                if utils::looks_like_plugin_bundle(status.is_success(), &body) {
                     return Ok(format!(
                         "healthy - {status} - {}",
                         body.chars().take(80).collect::<String>()
                     ));
                 }
-                let failure = format!("{endpoint} returned {status}");
+                let failure = format!("{endpoint} returned {status} (not a plugin bundle)");
                 log::debug!("Health check failed: {failure}");
                 failures.push(failure);
             }
@@ -1203,7 +1200,7 @@ pub async fn proxy_health_check(port: u16) -> Result<String, String> {
         }
     }
     Err(format!(
-        "HARNESS_NOT_READY: Harness service is not ready ({})",
+        "HARNESS_NOT_READY: Harness client plugins are not ready ({})",
         failures.join("; ")
     ))
 }

--- a/src-tauri/src/service/workflow/utils.rs
+++ b/src-tauri/src/service/workflow/utils.rs
@@ -24,6 +24,41 @@ pub(super) fn loopback_http_client(timeout: Duration) -> Result<reqwest::Client,
         .build()
 }
 
+/// 客户端插件 bundle 探测地址。
+///
+/// SPA `/` 在 webServer 绑定后立刻 200，此时连接桥与 Loader 图往往还没就绪；
+/// WebView 若在这个窗口加载，会永久停在官方 boot 页 “Loading plugins…”。
+/// 必须等到真实 JS bundle（而非 HTML fallback）可取，才视为可挂载 iframe。
+pub(super) fn health_probe_plugin_urls(port: u16) -> Vec<String> {
+    vec![
+        format!(
+            "http://127.0.0.1:{port}/plugins/@deepseek-ai/dsh-client-ui-layout/client.js"
+        ),
+        format!(
+            "http://127.0.0.1:{port}/plugins/@deepseek-ai/dsh-client-runtime/client.js"
+        ),
+    ]
+}
+
+/// 判断健康检查响应是不是可用的插件 bundle。
+///
+/// 未知 `/plugins/...` 路径会被 SPA fallback 成 `index.html`（仍是 200），
+/// 绝不能当成插件已就绪。
+pub(super) fn looks_like_plugin_bundle(ok_status: bool, body: &str) -> bool {
+    if !ok_status {
+        return false;
+    }
+    let trimmed = body.trim_start();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("<!doctype") || lower.starts_with("<html") {
+        return false;
+    }
+    true
+}
+
 /// 检查 Harness 是否真正在运行（探测指定端口，随配置端口联动）
 pub async fn is_dsh_running(port: u16) -> bool {
     let client = loopback_http_client(Duration::from_secs(2)).ok(); // 将 Result 转为 Option
@@ -222,6 +257,34 @@ mod tests {
         assert!(!dir.join("dsh-web.log.3").exists());
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn health_probe_plugin_urls_target_client_bundles_not_spa_root() {
+        let urls = health_probe_plugin_urls(3080);
+        assert!(urls.iter().all(|u| u.contains("/plugins/")));
+        assert!(urls
+            .iter()
+            .all(|u| !u.ends_with("3080/") && !u.ends_with("://127.0.0.1:3080")));
+        assert!(
+            urls.iter()
+                .any(|u| u.contains("dsh-client-ui-layout/client.js"))
+        );
+    }
+
+    #[test]
+    fn spa_html_fallback_is_not_a_plugin_bundle() {
+        assert!(!looks_like_plugin_bundle(
+            true,
+            "<!doctype html><html lang=\"en\"><body>HARNESS Loading plugins...</body></html>"
+        ));
+        assert!(!looks_like_plugin_bundle(true, "<html><head></head></html>"));
+        assert!(!looks_like_plugin_bundle(true, "   "));
+        assert!(!looks_like_plugin_bundle(false, "window.__ModuleLoader__={}"));
+        assert!(looks_like_plugin_bundle(
+            true,
+            "window.__ModuleLoader__.load({id:\"@deepseek-ai/dsh-client-ui-layout\"})"
+        ));
     }
 
     /// keep=0 时把当前日志也删掉。


### PR DESCRIPTION
## Summary
- Treat `/plugins/@deepseek-ai/dsh-client-*/client.js` as the ready signal instead of SPA `/` HTML 200. The latter is available before the connection bridge, so WebView2 stays on the official **Loading plugins…** splash ([#36](https://github.com/dsh-tauri-desk/deepseek-harness-desktop/issues/36), [#42](https://github.com/dsh-tauri-desk/deepseek-harness-desktop/issues/42); refresh recovers).
- Reject HTML fallback bodies so a 200 `index.html` on a missing plugin path is not counted as healthy.
- Inject a one-shot iframe reload if the splash is still visible after 8s (same workaround users already use: F12 then refresh).

## Test plan
- [x] `cargo test --lib` for `health_probe_plugin_urls`, `spa_html_fallback_is_not_a_plugin_bundle`, `boot_reload_script_is_one_shot_and_splash_scoped`
- [x] Cold start the desktop app and confirm it leaves Loading plugins without a manual refresh — verified on Windows with locally rebuilt release exe (`v0.8.0-beta.1` + this patch); cold start enters main UI, no manual refresh needed
- [x] With HTTP_PROXY set, loopback health still succeeds (`no_proxy` client unchanged) — unchanged from merged #74; `loopback_http_client()` still calls `.no_proxy()`; health probe only switches endpoints, not client construction