### PR TITLE
feat: add per-session Git worktree support

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -62,6 +62,7 @@ First-party plugins bundled with the installer:
 
 - [DSH Tauri](https://github.com/dsh-tauri-desk/dsh-tauri) — provides a communication channel with the Tauri 2 shell
 - [DSH Tauri UI](https://github.com/dsh-tauri-desk/dsh-tauri-ui) — provides a custom settings sidebar for the Tauri 2 shell
+- [DSH Tauri Worktree](https://github.com/dsh-tauri-desk/dsh-tauri-worktree) — creates an isolated Git worktree per session, with checkout to a local branch or archive-and-abandon flows
 - More coming soon...
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 
 - [DSH Tauri](https://github.com/dsh-tauri-desk/dsh-tauri) — 提供与 Tauri 2 外壳的通信通道
 - [DSH Tauri UI](https://github.com/dsh-tauri-desk/dsh-tauri-ui) — 为 Tauri 2 外壳提供自定义设置侧边栏
+- [DSH Tauri Worktree](https://github.com/dsh-tauri-desk/dsh-tauri-worktree) — 为每个会话创建隔离的 Git Worktree，并支持检出到本地分支或归档放弃
 - 更多即将引入的插件...
 
 ## 快速开始

--- a/docs/WORKTREE.md
+++ b/docs/WORKTREE.md
@@ -1,0 +1,104 @@
+### 需求规格说明书：Tauri 客户端内置 Git Worktree 插件集成
+
+**项目名称**：`dsh-tauri-worktree` 插件集成
+
+**目标**：在 Tauri 桌面端集成 Git Worktree 能力，支持在独立隔离的环境中进行对话与代码变更，并提供一键合并带回本地或放弃更改的能力。
+
+---
+
+### 一、 UI / UX 交互需求
+
+#### 1. 模式选择下拉框扩展
+
+* **位置**：聊天框上方模式选择器（ DOM 节点 `._root_19372_1`）右侧。
+* **交互逻辑**：
+* 点击展开下拉菜单，新增 **工作树** 选项（默认项为 **本地**）。
+* 切换为 **工作树** 后，后续消息发送将在隔离的 Worktree 环境中处理。
+* 用户支持选择已有工作树或切换回本地工作区。
+
+
+
+#### 2. 会话处理状态与日志展示
+
+发送消息后，聊天界面需实时显示工作区创建进度：
+
+* **阶段 1（加载中）**：
+`[loadingIcon] 正在准备工作区` $\rightarrow$ `[loadingIcon] 正在检出文件`
+* **阶段 2（完成/可展开日志）**：
+`已创建工作区` > `点击可查看调用 logs`
+* **日志展开视图**：
+```text
+[info] Starting worktree creation
+Preparing worktree (detached HEAD 0689db7)
+HEAD is now at 0689db7 Merge pull request #106 ...
+Worktree created at ~/.dsh/worktrees/[hash]/[dirname]
+
+```
+
+
+* **阶段 3（模型响应）**：
+`正在思考...`（LLM 基于创建好的工作树环境进行回复）。
+
+#### 3. 顶部提示条 (Surface)
+
+会话处于 Worktree 模式时，聊天框上方需**常驻**顶部 Surface 提示条：
+
+$$\text{[ 该会话正在工作树进行 ]} \quad \text{---------------------- [ 空白区 ] ----------------------} \quad \text{[ 检出本地 ] \ \ [ 放弃 ]}$$
+
+#### 4. 模态框 (Dialog) 交互
+
+* **检出本地弹窗**：
+* **标题**：`将更改带回本地检出并继续`
+* **表单/信息**：
+* 本地检出分支名输入框：预填 `dsh/`（例：`dsh/feature-xyz`）
+* 显示当前关联路径：`[工作区 hash]/[dirname]`
+* 显示目标项目路径：`[项目路径]`
+
+
+* **操作按钮**：`确认检出并合并` / `取消`
+
+
+* **放弃更改弹窗**：
+* **标题**：`放弃工作树更改`
+* **提示文本**：`确认放弃吗？这将删除当前会话及对应的临时工作树。`
+* **操作按钮**：`确认放弃`（危险操作） / `取消`
+
+
+
+#### 5. 会话列表标识
+
+* 当会话绑定了 Worktree 时，侧边栏会话列表项的时间标识（ DOM 节点 `.YDXeBa_time`）**左侧显示 Git 分支图标**。
+* 完成“检出本地”后，该会话恢复为普通本地会话，移除分支图标，后续对话在本地工作区继续。
+
+---
+
+### 二、 系统架构与后端逻辑
+
+#### 1. 工作树创建与存储路径
+
+* **Hash 生成**：根据当前项目路径与会话 ID 自动计算唯一哈希值 `[hash]`。
+* **存储目录**：`~/.dsh/worktrees/[hash]/[dirname]`
+
+#### 2. Tool 扩展与 Agent 感知
+
+* **新增 Tool 声明**：
+```typescript
+checkout_worktree(params: {
+  worktree_hash_dirname: string;
+  branch_name: string;
+}): Promise<void>;
+
+```
+
+
+* **Agent 系统提示词（System Prompt）注入**：
+* 处于 Worktree 环境时，注入上下文标识 `is_worktree: true`。
+* **自发调用逻辑**：当需要“提交 PR”、“合并到本地”、“切回主分支”等 Git 操作指令时，Agent 应主动触发 `checkout_worktree` 工具。
+
+
+---
+
+### 三、 参考实现与依赖
+
+* `packages/clutch-dsh-worktree` (Cerbur/clutch-dsh)
+* `dsh-worktree-panel` (HeathHe/dsh-worktree-panel)

--- a/src-tauri/resources/preset-plugins.json
+++ b/src-tauri/resources/preset-plugins.json
@@ -29,6 +29,15 @@
     "recommended": true
   },
   {
+    "id": "dsh-tauri-worktree",
+    "spec": "github:dsh-tauri-desk/dsh-tauri-worktree",
+    "internal": true,
+    "name": "DSH Tauri Worktree",
+    "description": "Per-session isolated Git Worktree for the desktop shell: switch a conversation to its own isolated worktree, then check changes back into a local dsh/ branch or discard them.",
+    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-worktree",
+    "recommended": true
+  },
+  {
     "id": "dshmarket",
     "spec": "dshmarket",
     "name": "DSH Market",

--- a/src-tauri/resources/preset-plugins.json
+++ b/src-tauri/resources/preset-plugins.json
@@ -30,7 +30,7 @@
   },
   {
     "id": "dsh-tauri-worktree",
-    "spec": "github:dsh-tauri-desk/dsh-tauri-worktree",
+    "spec": "dsh-tauri-worktree@0.1.0",
     "internal": true,
     "name": "DSH Tauri Worktree",
     "description": "Per-session isolated Git Worktree for the desktop shell: switch a conversation to its own isolated worktree, then check changes back into a local dsh/ branch or discard them.",

--- a/src-tauri/src/service/workflow/client_hmr_patch.rs
+++ b/src-tauri/src/service/workflow/client_hmr_patch.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use crate::config;
 use crate::service::core::{active_source, local_core_package_dir, CoreSource};
 
+// HARDCODE：以下锚点绑定内置 DSH 0.1.1-rc.2 的 client-HMR bundle；仅 debug 生效。
 const PATCH_MARKER: &str = "dsh-tauri-desktop: debug client plugin reload fallback";
 const ORIGINAL: &str = r#"case "rebuilt":
 						queue = queue.then(() => reload(frame.id)).catch((error) => {

--- a/src-tauri/src/service/workflow/client_hmr_patch.rs
+++ b/src-tauri/src/service/workflow/client_hmr_patch.rs
@@ -1,0 +1,124 @@
+//! Debug 客户端插件重载兼容补丁。
+//!
+//! 当前内置 DSH `0.1.1-rc.2` 的 client-HMR 在收到 `rebuilt` 后会卸载旧插件，
+//! 但第三方插件的 Loader 条目不会重新挂载，表现为构建后插件消失、手动刷新才恢复。
+//! debug 桌面端本来就直接联接本地插件源码，因此将该坏 hot-swap 降级为页面自动刷新：
+//! 仍由 `/plugins/events` 精确触发，不轮询页面，也不会影响 release。
+
+use std::fs;
+use std::path::PathBuf;
+
+use crate::config;
+use crate::service::core::{active_source, local_core_package_dir, CoreSource};
+
+const PATCH_MARKER: &str = "dsh-tauri-desktop: debug client plugin reload fallback";
+const ORIGINAL: &str = r#"case "rebuilt":
+						queue = queue.then(() => reload(frame.id)).catch((error) => {
+							ctx.logger.error(`client-hmr: reload of "${frame.id}" failed`);
+							ctx.logger.error(error);
+						});
+						break;"#;
+const PATCHED: &str = r#"case "rebuilt":
+						/* dsh-tauri-desktop: debug client plugin reload fallback */
+						window.location.reload();
+						break;"#;
+
+#[derive(Debug, PartialEq, Eq)]
+enum PatchOutcome {
+    AlreadyPatched,
+    AnchorMissing,
+    Patched(String),
+}
+
+fn patch_source(source: &str) -> PatchOutcome {
+    if source.contains(PATCH_MARKER) {
+        return PatchOutcome::AlreadyPatched;
+    }
+    if !source.contains(ORIGINAL) {
+        return PatchOutcome::AnchorMissing;
+    }
+    PatchOutcome::Patched(source.replacen(ORIGINAL, PATCHED, 1))
+}
+
+/// debug 启动前把损坏的插件 hot-swap 降级为自动页面刷新。
+#[cfg(debug_assertions)]
+pub fn apply(app_handle: &tauri::AppHandle) -> Result<(), String> {
+    let client_js = active_core_install_dir(app_handle)
+        .join("node_modules/@deepseek-ai/dsh-client-hmr/lib/client.js");
+    if !client_js.exists() {
+        log::info!(
+            "client-hmr client.js not found, skip debug reload patch: {}",
+            client_js.display()
+        );
+        return Ok(());
+    }
+    let source = fs::read_to_string(&client_js)
+        .map_err(|e| format!("CLIENT_HMR_PATCH_READ: {} failed: {e}", client_js.display()))?;
+    match patch_source(&source) {
+        PatchOutcome::AlreadyPatched => {
+            log::info!("debug client plugin reload fallback already applied")
+        }
+        PatchOutcome::AnchorMissing => log::warn!(
+            "debug client plugin reload fallback anchor missing, skip patch: {}",
+            client_js.display()
+        ),
+        PatchOutcome::Patched(patched) => {
+            fs::write(&client_js, patched).map_err(|e| {
+                format!(
+                    "CLIENT_HMR_PATCH_WRITE: {} failed: {e}",
+                    client_js.display()
+                )
+            })?;
+            log::info!(
+                "debug client plugin reload fallback patched: {}",
+                client_js.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// release 不修改客户端重载行为。
+#[cfg(not(debug_assertions))]
+pub fn apply(_app_handle: &tauri::AppHandle) -> Result<(), String> {
+    Ok(())
+}
+
+fn active_core_install_dir(app_handle: &tauri::AppHandle) -> PathBuf {
+    match active_source(app_handle) {
+        CoreSource::Local => local_core_package_dir(app_handle)
+            .unwrap_or_else(|| config::get_dsh_install_path(app_handle)),
+        CoreSource::App => config::get_dsh_install_path(app_handle),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_broken_hot_swap_with_page_reload() {
+        let PatchOutcome::Patched(patched) = patch_source(ORIGINAL) else {
+            panic!("expected patched source");
+        };
+        assert!(patched.contains(PATCH_MARKER));
+        assert!(patched.contains("window.location.reload();"));
+        assert!(!patched.contains("queue = queue.then"));
+    }
+
+    #[test]
+    fn patch_is_idempotent() {
+        let PatchOutcome::Patched(patched) = patch_source(ORIGINAL) else {
+            panic!("expected patched source");
+        };
+        assert_eq!(patch_source(&patched), PatchOutcome::AlreadyPatched);
+    }
+
+    #[test]
+    fn skips_unknown_upstream_layout() {
+        assert_eq!(
+            patch_source("case \"rebuilt\": break;"),
+            PatchOutcome::AnchorMissing
+        );
+    }
+}

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -1,5 +1,6 @@
 pub mod status;
 pub mod utils;
+pub(crate) mod client_hmr_patch;
 pub(crate) mod renderer_patch;
 pub(crate) mod workspace_patch;
 pub(crate) mod win_inspector;
@@ -764,6 +765,11 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     // attach 的 cwd 相等约束，其他 cwd 有效性校验保持不变。最佳努力且幂等。
     if let Err(e) = workspace_patch::apply(&app_handle) {
         log::warn!("workspace worktree membership patch failed: {e}");
+    }
+    // 当前 DSH client-HMR 会卸载第三方插件却不重新挂载。debug 直接联接本地
+    // 插件源码，故将 rebuilt 降级为自动刷新页面；release 保持上游行为。
+    if let Err(e) = client_hmr_patch::apply(&app_handle) {
+        log::warn!("debug client plugin reload fallback patch failed: {e}");
     }
     // 预防性处理：pnpm 在无 TTY 环境（dsh-market 等子进程）下重装/更新插件时，
     // 清理/重建 node_modules 会触发交互确认并因无 TTY 直接中止

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -1,6 +1,7 @@
 pub mod status;
 pub mod utils;
 pub(crate) mod renderer_patch;
+pub(crate) mod workspace_patch;
 pub(crate) mod win_inspector;
 #[cfg(windows)]
 pub(crate) mod win_spawn;
@@ -758,6 +759,11 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     // 启动——未打补丁时插件侧降级，官方设置 dialog 照常工作，绝不白屏。
     if let Err(e) = renderer_patch::apply(&app_handle) {
         log::warn!("renderer SlotOutlet patch failed: {e}");
+    }
+    // worktree 会话以隔离 cwd 执行，但产品归属仍是源 Workspace；放宽上游显式
+    // attach 的 cwd 相等约束，其他 cwd 有效性校验保持不变。最佳努力且幂等。
+    if let Err(e) = workspace_patch::apply(&app_handle) {
+        log::warn!("workspace worktree membership patch failed: {e}");
     }
     // 预防性处理：pnpm 在无 TTY 环境（dsh-market 等子进程）下重装/更新插件时，
     // 清理/重建 node_modules 会触发交互确认并因无 TTY 直接中止

--- a/src-tauri/src/service/workflow/workspace_patch.rs
+++ b/src-tauri/src/service/workflow/workspace_patch.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use crate::config;
 use crate::service::core::{active_source, local_core_package_dir, CoreSource};
 
+// HARDCODE：以下锚点绑定内置 DSH 0.1.1-rc.2 的压缩后源码；锚点变化时安全跳过并告警。
 const PATCH_MARKER: &str = "dsh-tauri-worktree: relaxed explicit workspace membership";
 const GETTER_ORIGINAL: &str =
     "return this.record.sessionIds.filter((id) => this.host.sessionPath(id) === this.record.path);";

--- a/src-tauri/src/service/workflow/workspace_patch.rs
+++ b/src-tauri/src/service/workflow/workspace_patch.rs
@@ -1,0 +1,128 @@
+//! Workspace 会话归属补丁：允许显式 attach 的会话使用不同于 Workspace 的 cwd。
+//!
+//! worktree 会话必须以隔离目录作为 `session.header.cwd`，但产品上仍应归属源项目的
+//! Workspace。上游 `@deepseek-ai/dsh-workspace` 同时在 attach、getter 与 mutate 三处按
+//! `cwd === workspace.path` 过滤，导致合法 worktree 会话只能落入“未分组”。本补丁仅
+//! 放宽显式 attach 后的归属保持；cwd 缺失、无法解析或不是目录的安全校验仍由上游保留。
+
+use std::fs;
+use std::path::PathBuf;
+
+use crate::config;
+use crate::service::core::{active_source, local_core_package_dir, CoreSource};
+
+const PATCH_MARKER: &str = "dsh-tauri-worktree: relaxed explicit workspace membership";
+const GETTER_ORIGINAL: &str =
+    "return this.record.sessionIds.filter((id) => this.host.sessionPath(id) === this.record.path);";
+const GETTER_PATCHED: &str = "return this.record.sessionIds; /* dsh-tauri-worktree: relaxed explicit workspace membership */";
+const ATTACH_ORIGINAL: &str = "if (cwd !== this.record.path) throw new Error(`cannot attach session '${sessionId}' to workspace '${this.record.path}': its cwd resolves to '${cwd}'`);";
+const ATTACH_PATCHED: &str = "/* dsh-tauri-worktree: relaxed explicit workspace membership */";
+const MUTATE_ORIGINAL: &str = "const sessionIds = changed.sessionIds.filter((id) => this.host.sessionPath(id) === changed.path);";
+const MUTATE_PATCHED: &str = "const sessionIds = changed.sessionIds; /* dsh-tauri-worktree: relaxed explicit workspace membership */";
+
+#[derive(Debug, PartialEq, Eq)]
+enum PatchOutcome {
+    AlreadyPatched,
+    AnchorMissing,
+    Patched(String),
+}
+
+fn patch_source(source: &str) -> PatchOutcome {
+    if source.contains(PATCH_MARKER) {
+        return PatchOutcome::AlreadyPatched;
+    }
+    if !source.contains(GETTER_ORIGINAL)
+        || !source.contains(ATTACH_ORIGINAL)
+        || !source.contains(MUTATE_ORIGINAL)
+    {
+        return PatchOutcome::AnchorMissing;
+    }
+    let patched = source
+        .replacen(GETTER_ORIGINAL, GETTER_PATCHED, 1)
+        .replacen(ATTACH_ORIGINAL, ATTACH_PATCHED, 1)
+        .replacen(MUTATE_ORIGINAL, MUTATE_PATCHED, 1);
+    PatchOutcome::Patched(patched)
+}
+
+pub fn apply(app_handle: &tauri::AppHandle) -> Result<(), String> {
+    let workspace_js = active_core_install_dir(app_handle)
+        .join("node_modules/@deepseek-ai/dsh-workspace/lib/index.js");
+    if !workspace_js.exists() {
+        log::info!(
+            "workspace index.js not found, skip worktree membership patch: {}",
+            workspace_js.display()
+        );
+        return Ok(());
+    }
+    let source = fs::read_to_string(&workspace_js).map_err(|e| {
+        format!(
+            "WORKSPACE_PATCH_READ: {} failed: {e}",
+            workspace_js.display()
+        )
+    })?;
+    match patch_source(&source) {
+        PatchOutcome::AlreadyPatched => {
+            log::info!("workspace worktree membership patch already applied")
+        }
+        PatchOutcome::AnchorMissing => log::warn!(
+            "workspace worktree membership anchors missing, skip patch: {}",
+            workspace_js.display()
+        ),
+        PatchOutcome::Patched(patched) => {
+            fs::write(&workspace_js, patched).map_err(|e| {
+                format!(
+                    "WORKSPACE_PATCH_WRITE: {} failed: {e}",
+                    workspace_js.display()
+                )
+            })?;
+            log::info!(
+                "workspace worktree membership patched: {}",
+                workspace_js.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn active_core_install_dir(app_handle: &tauri::AppHandle) -> PathBuf {
+    match active_source(app_handle) {
+        CoreSource::Local => local_core_package_dir(app_handle)
+            .unwrap_or_else(|| config::get_dsh_install_path(app_handle)),
+        CoreSource::App => config::get_dsh_install_path(app_handle),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> String {
+        format!("{GETTER_ORIGINAL}\n{ATTACH_ORIGINAL}\n{MUTATE_ORIGINAL}\n")
+    }
+
+    #[test]
+    fn patches_all_three_membership_guards() {
+        let PatchOutcome::Patched(patched) = patch_source(&fixture()) else {
+            panic!("expected patched source");
+        };
+        assert!(patched.contains(GETTER_PATCHED));
+        assert!(patched.contains(ATTACH_PATCHED));
+        assert!(patched.contains(MUTATE_PATCHED));
+        assert!(!patched.contains(GETTER_ORIGINAL));
+        assert!(!patched.contains(ATTACH_ORIGINAL));
+        assert!(!patched.contains(MUTATE_ORIGINAL));
+    }
+
+    #[test]
+    fn patch_is_idempotent() {
+        let PatchOutcome::Patched(patched) = patch_source(&fixture()) else {
+            panic!("expected patched source");
+        };
+        assert_eq!(patch_source(&patched), PatchOutcome::AlreadyPatched);
+    }
+
+    #[test]
+    fn skips_partial_upstream_layout() {
+        assert_eq!(patch_source(GETTER_ORIGINAL), PatchOutcome::AnchorMissing);
+    }
+}


### PR DESCRIPTION
## Summary

- bundle `dsh-tauri-worktree@0.1.0` as a first-party internal Desktop plugin
- add per-session isolated Git worktree creation, Agent-driven `create_worktree(branch_name)` handoff, local checkout, archive/discard lifecycle, and live UI synchronization
- attach worktree sessions to their source Workspace while preserving immutable session cwd semantics
- patch the bundled DSH Workspace runtime for explicit cross-cwd membership and add a debug-only client-plugin reload fallback
- document the feature specification, built-in plugin entries (Chinese and English), and DSH compatibility hardcodes

## Validation

- `npm view dsh-tauri-worktree` confirms latest `0.1.0`
- published tarball contains `lib/client.js`, `lib/index.js`, `cordis.patch.yml`, `README.md`, and `NOTICE`
- `pnpm prebuild` installs and embeds `dsh-tauri-worktree@0.1.0` from npm
- `cargo check`
- targeted Workspace patch tests: 3/3 passed
- targeted debug client HMR patch tests: 3/3 passed
- plugin `pnpm typecheck`, `pnpm build`, and `pnpm test` passed before publication

## Notes

The compatibility patches use exact upstream DSH anchors and fail closed when those anchors change; the risks and mitigations are documented in the plugin README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the DSH Tauri Worktree plugin to bundled first-party plugin presets.
  * Added documentation for isolated Git worktrees, branch workflows, session indicators, and change management.
* **Bug Fixes**
  * Improved workspace association for sessions using different working directories.
  * Improved development hot-reload behavior while preserving release-build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->