### PR TITLE
chore: release v0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.8.0"
+version = "0.8.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.8.1` (`0.8.0` → `0.8.1`).

### Features

- integrate dsh-tauri-worktree internal plugin (per-session isolated git worktree) (2de80e9)

### Bug Fixes

- refresh debug page after plugin rebuild (60e632d)
- allow explicit worktree workspace membership (c5c9874)
- **workflow**: match stale macOS harness processes (2bec623)
- **plugin**: recover stale profile bundles (2e8bb8e)
- **plugin**: 非 Windows 平台安装含空格路径的插件不再加引号（issue #104） (c2c118e)
- **migrate**: 迁移后清除 pnpm 节点模块元数据，修复 ERR_PNPM_UNEXPECTED_VIRTUAL_STORE (801939f)

### Documentation

- add built-in worktree plugin (1da5a67)
- mark dsh compatibility hardcodes (ae7548c)
- **readme**: simplify README and sync English translation (41a63f1)

### Tests

- **workflow**: make port scan checks deterministic (90858ce)
- **workflow**: 端口扫描用例改用低端口段，消除 CI 偶发 TOCTOU flake (1bc61d3)

### Other Changes

- Merge pull request #111 from dsh-tauri-desk/feat/dsh-tauri-worktree (8664409)
- Merge pull request #108 from dsh-tauri-desk/codex/fix-issue-107-profile-recovery (03222fe)
- Merge pull request #109 from dsh-tauri-desk/codex/fix-issue-91-macos-stale-process (e33d8d8)
- Update README.md (ebc19de)
- Merge pull request #106 from dsh-tauri-desk/fix/issue-104-spec-quote-non-windows (0689db7)
- Merge pull request #105 from dsh-tauri-desk/fix/issue-103-pnpm-modules-metadata (a0ed88d)
- Fix macOS Homebrew install to the deepseek-harness cask (da921f5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.8.1 across all release metadata.
  * No user-facing functionality changes were included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->