### PR TITLE
fix(navbar): let native title bar show through on macOS

### DIFF
--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -209,9 +209,13 @@ export function Navbar({ iframeRef }: NavbarProps) {
       // 透过来，与系统标题栏融为一体。Win/Linux 关闭了 decorations(),
       // 没有原生 chrome 可借，靠 bg-panel / border-b 提供可拖拽区视觉锚点和
       // 右侧窗口控制按钮的位置载体，故保留彩条。
+      // 两份完整的字面量同时出现在源里，Tailwind JIT 能静态扫到全部类。
+      // bg-transparent! 使用 Tailwind `!important` 后缀，兜底覆盖可能的
+      // 父级 / ShellNavBar 容器的样式。
       className={cn(
-        'relative flex h-11 w-full flex-none select-none items-center gap-0.5',
-        IS_MACOS ? 'bg-transparent' : 'border-b border-line bg-panel',
+        IS_MACOS
+          ? 'relative flex h-11 w-full flex-none select-none items-center gap-0.5 bg-transparent!'
+          : 'relative flex h-11 w-full flex-none select-none items-center gap-0.5 border-b border-line bg-panel',
         {
           'hidden': IS_MACOS && isFullscreen,
           'pl-20 pr-1.5': IS_MACOS && !isFullscreen,

--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -204,8 +204,14 @@ export function Navbar({ iframeRef }: NavbarProps) {
 
   return (
     <div
+      // macOS 上窗口已用 Overlay 模式保留原生标题栏（见 desktop::builder::build_main_window），
+      // ShellNavBar 浮在原生 chrome 上方：去掉底色和下边框，让 vibrancy 材质
+      // 透过来，与系统标题栏融为一体。Win/Linux 关闭了 decorations(),
+      // 没有原生 chrome 可借，靠 bg-panel / border-b 提供可拖拽区视觉锚点和
+      // 右侧窗口控制按钮的位置载体，故保留彩条。
       className={cn(
-        'relative flex h-11 w-full flex-none select-none items-center gap-0.5 border-b border-line bg-panel',
+        'relative flex h-11 w-full flex-none select-none items-center gap-0.5',
+        IS_MACOS ? 'bg-transparent' : 'border-b border-line bg-panel',
         {
           'hidden': IS_MACOS && isFullscreen,
           'pl-20 pr-1.5': IS_MACOS && !isFullscreen,


### PR DESCRIPTION
## Problem

On macOS the main window already keeps the native title bar chrome (`decorations(true)` + `TitleBarStyle::Overlay` + `hidden_title(true)`, see `desktop::builder::build_main_window`), with traffic lights and appearance synced to the dsh theme (`theme.rs::apply_window_theme`, issue #93).

However, the 44px shell `Navbar` painted itself with an opaque `bg-panel` background plus a `border-b border-line` divider **on every platform**. On macOS that opaque strip sits directly on top of the native vibrancy title bar, cutting off the material transition and making the window look non-native.

Windows/Linux cannot drop the strip: with `decorations(false)` there is no native chrome, and the colored bar doubles as the drag-region visual anchor and the position carrier for the custom min/max/close buttons.

## Solution

Platform-split the `Navbar` root className:

- **macOS**: `bg-transparent!` + no bottom border → native vibrancy shows through, blending the shell nav into the system title bar
- **Windows/Linux**: keep `bg-panel border-b border-line` unchanged

Both branches are written as complete string literals so Tailwind JIT statically picks up every class.

```tsx
className={cn(
  IS_MACOS
    ? 'relative flex h-11 w-full flex-none select-none items-center gap-0.5 bg-transparent!'
    : 'relative flex h-11 w-full flex-none select-none items-center gap-0.5 border-b border-line bg-panel',
  {
    'hidden': IS_MACOS && isFullscreen,
    'pl-20 pr-1.5': IS_MACOS && !isFullscreen,
    'px-1.5': !IS_MACOS || isFullscreen,
  },
)}
```

## Verification

- [x] `pnpm tauri dev` on macOS: nav strip is transparent, native vibrancy visible around traffic lights
- [x] Release build (`pnpm tauri build`) runs fine
- [x] Windows/Linux untouched — same code path as before
- [x] No conflicts with current `main` (neither `navbar.tsx` nor `builder.rs` changed upstream since fork point)

## Notes

Single-file frontend change (`src/layout/components/navbar.tsx`), no new dependencies, no i18n keys added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the navigation bar appearance on macOS to blend with the native title bar.
  * Preserved the existing background and bottom border styling on Windows and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->