### PR TITLE
fix: recover delayed plugin startup

### DIFF
--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -21,10 +21,10 @@ use crate::service::download;
 use crate::service::download::Installable;
 use crate::service::profile::active_profile;
 use crate::service::workflow;
-use serde_yaml::{Mapping, Value};
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use serde_yaml::{Mapping, Value};
 use tauri::{AppHandle, Emitter, Manager, WebviewWindow};
 
 use super::errors;
@@ -54,8 +54,10 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
 
     // 单次读取预设并构建查找表，提升算法效率至 O(N)
     let presets = load_presets(app_handle);
-    let preset_map: HashMap<&str, &PreinstallPluginInfo> =
-        presets.iter().map(|p| (p.id.as_str(), p)).collect();
+    let preset_map: HashMap<&str, &PreinstallPluginInfo> = presets
+        .iter()
+        .map(|p| (p.id.as_str(), p))
+        .collect();
 
     let mut specs = Vec::with_capacity(ids.len());
     for id in ids {
@@ -80,10 +82,7 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
         // 对账的 `expected`（bundled_dep_spec）一致。macOS/Linux 是直接
         // `spawnSync`（无 shell），spec 作为单个 argv 传递、空格天然保留，
         // 引号只会被当作包名字符导致安装失败（见 [`shell_quote_spec`]）。
-        let raw = normalize_git_spec(&preset_spec_for_install(
-            preset,
-            bundled_dir_of(app_handle, preset),
-        )?);
+        let raw = normalize_git_spec(&preset_spec_for_install(preset, bundled_dir_of(app_handle, preset))?);
         specs.push(shell_quote_spec(&raw));
     }
 
@@ -144,7 +143,13 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
     // 后重试，直至成功或再无键可加（升级路径同样依赖该重试，见
     // [`run_plugin_with_allow_build_retry`]）。
     let (exit_code, last_output) = run_plugin_with_allow_build_retry(
-        app_handle, &node, &args, &cwd, &envs, &window, "install",
+        app_handle,
+        &node,
+        &args,
+        &cwd,
+        &envs,
+        &window,
+        "install",
     )
     .await?;
 
@@ -303,10 +308,7 @@ fn silent_install_failure_detail(missing: &[(String, PathBuf)], command_output: 
 ///
 /// 供本模块的安装/升级/卸载与 [`super::verify`] 的完整性修复共用：子进程（dsh
 /// 或 pnpm）都按同一套桌面端环境策略运行，保证 $DSH_HOME / PATH 布局一致。
-pub(crate) fn build_plugin_envs(
-    app_handle: &AppHandle,
-    prefer_bundled_pnpm: bool,
-) -> HashMap<String, String> {
+pub(crate) fn build_plugin_envs(app_handle: &AppHandle, prefer_bundled_pnpm: bool) -> HashMap<String, String> {
     let node = config::get_node_binary_path(app_handle);
     let bin_dir = cli::get_bin_dir(app_handle);
     let mut envs = HashMap::from([
@@ -374,7 +376,9 @@ async fn run_plugin_with_allow_build_retry(
         if !new_keys.is_empty() && retries < MAX_ALLOW_LIST_RETRIES {
             retries += 1;
             add_allow_build_keys(app_handle, &new_keys)?;
-            log::info!("pnpm allowBuilds updated with {new_keys:?}, retrying {action} ({retries})");
+            log::info!(
+                "pnpm allowBuilds updated with {new_keys:?}, retrying {action} ({retries})"
+            );
             let _ = window.emit(
                 PREINSTALL_LOG_EVENT,
                 PreinstallLogPayload {
@@ -403,24 +407,15 @@ async fn run_plugin_with_allow_build_retry(
 
 /// 升级单个插件：`dsh plugin --profile <当前档案> update <id>`
 pub async fn update(app_handle: &AppHandle, id: &str) -> Result<(), String> {
-    run_single_plugin_command(
-        app_handle,
-        id,
-        "update",
-        &["update".to_string(), id.to_string()],
-    )
-    .await
+    run_single_plugin_command(app_handle, id, "update", &["update".to_string(), id.to_string()])
+        .await
 }
 
 /// 卸载单个插件：`dsh plugin --profile <当前档案> remove <id>`
 pub async fn remove(app_handle: &AppHandle, id: &str) -> Result<(), String> {
-    let command_result = run_single_plugin_command(
-        app_handle,
-        id,
-        "remove",
-        &["remove".to_string(), id.to_string()],
-    )
-    .await;
+    let command_result =
+        run_single_plugin_command(app_handle, id, "remove", &["remove".to_string(), id.to_string()])
+            .await;
     // `dsh plugin remove` 以子进程退出码为准，可能出现「命令成功但插件仍在」的
     // 边界（如 bundle 层残留、pnpm 静默失败）；node_modules / lockfile 损坏时
     // （典型：安装只写入了 profile 清单而产物缺失，见 issue #90）pnpm 甚至会
@@ -504,9 +499,16 @@ async fn run_single_plugin_command(
 
     let cwd = config::get_dsh_install_path(app_handle);
     log::info!("Running dsh plugin {action} for {id}");
-    let (exit_code, output) =
-        run_plugin_with_allow_build_retry(app_handle, &node, &args, &cwd, &envs, &window, action)
-            .await?;
+    let (exit_code, output) = run_plugin_with_allow_build_retry(
+        app_handle,
+        &node,
+        &args,
+        &cwd,
+        &envs,
+        &window,
+        action,
+    )
+    .await?;
 
     if exit_code != 0 {
         log::error!("dsh plugin {action} failed for {id} with exit code {exit_code}");
@@ -638,9 +640,7 @@ async fn ensure_pnpm(app_handle: &AppHandle, window: &WebviewWindow) -> Result<b
             );
         }
         None => {
-            log::warn!(
-                "User pnpm version not detectable (broken/blocked shim?), using bundled pnpm"
-            );
+            log::warn!("User pnpm version not detectable (broken/blocked shim?), using bundled pnpm");
         }
     }
 
@@ -721,9 +721,9 @@ pub(crate) fn profile_store_major(app_handle: &AppHandle) -> Option<u32> {
 
 /// 从 `.modules.yaml` 文本解析 store 主版本（纯函数，便于单测）。
 fn parse_store_major_from_modules_yaml(content: &str) -> Option<u32> {
-    let store_dir = content
-        .lines()
-        .find_map(|line| line.trim().strip_prefix("storeDir:").map(str::trim))?;
+    let store_dir = content.lines().find_map(|line| {
+        line.trim().strip_prefix("storeDir:").map(str::trim)
+    })?;
     // storeDir 形如 `C:\Users\xx\AppData\Local\pnpm\store\v10`，取末段 `v10` 的数字
     let major = store_dir
         .trim_matches(['"', '\''])
@@ -832,7 +832,8 @@ fn add_allow_build_keys(app_handle: &AppHandle, keys: &[String]) -> Result<(), S
     std::fs::create_dir_all(dir).map_err(|e| format!("PREINSTALL_MKDIR: {e}"))?;
 
     let content = if path.exists() {
-        std::fs::read_to_string(&path).map_err(|e| format!("PREINSTALL_READ_WORKSPACE: {e}"))?
+        std::fs::read_to_string(&path)
+            .map_err(|e| format!("PREINSTALL_READ_WORKSPACE: {e}"))?
     } else {
         // 与 dsh `initProfile` 生成的基础模板保持一致（尚无 allowBuilds）。
         "packages:\n  - .\n\nnodeLinker: hoisted\nautoInstallPeers: false\n".to_string()
@@ -843,10 +844,7 @@ fn add_allow_build_keys(app_handle: &AppHandle, keys: &[String]) -> Result<(), S
         return Ok(()); // 无变化（所有键已就位），避免无意义写盘
     }
 
-    log::info!(
-        "pnpm-workspace.yaml rewritten with allowBuilds {keys:?} at {}",
-        path.display()
-    );
+    log::info!("pnpm-workspace.yaml rewritten with allowBuilds {keys:?} at {}", path.display());
     std::fs::write(&path, rendered).map_err(|e| format!("PREINSTALL_WRITE_WORKSPACE: {e}"))
 }
 
@@ -869,11 +867,14 @@ fn apply_allow_build_keys(content: &str, keys: &[String]) -> Result<String, Stri
         Err(first_err) => {
             let normalized = collapse_allow_builds_duplicates(content);
             if normalized == content {
-                return Err(format!("PREINSTALL_WORKSPACE_INVALID_YAML: {first_err}"));
+                return Err(format!(
+                    "PREINSTALL_WORKSPACE_INVALID_YAML: {first_err}"
+                ));
             }
             repaired = true;
-            serde_yaml::from_str(&normalized)
-                .map_err(|e| format!("PREINSTALL_WORKSPACE_INVALID_YAML: {e}"))?
+            serde_yaml::from_str(&normalized).map_err(|e| {
+                format!("PREINSTALL_WORKSPACE_INVALID_YAML: {e}")
+            })?
         }
     };
 
@@ -1036,8 +1037,7 @@ fn shell_quote_spec(spec: &str) -> String {
 /// 从 pnpm 失败输出里识别 git 传输层错误（区别于 allowBuilds 构建门禁），命中时
 /// 返回一句可读的成因/指引。pnpm 在这些场景下已经退到 git+ssh，再去补 allowBuilds
 /// 白名单是无效且误导的。
-fn git_transport_hint(output: &str) -> Option<&'static str> {
-    const SIGNALS: &[(&str, &str)] = &[
+fn git_transport_hint(output: &str) -> Option<&'static str> {    const SIGNALS: &[(&str, &str)] = &[
         (
             "host key verification failed",
             "git fell back to SSH and could not verify GitHub's host key (no known_hosts entry; the process ran non-interactively). Make sure GitHub is reachable over HTTPS.",
@@ -1091,13 +1091,8 @@ pub(crate) fn harness_prefer_bundled_pnpm(app_handle: &AppHandle) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        apply_allow_build_keys, collapse_allow_builds_duplicates, extract_allow_line_key,
-        git_transport_hint, normalize_git_spec, parse_allowlist_keys,
-        parse_store_major_from_modules_yaml, preset_spec_for_install, shell_quote_spec,
-        silent_install_failure_detail, PreinstallPluginInfo,
-    };
     use std::path::PathBuf;
+    use super::{apply_allow_build_keys, collapse_allow_builds_duplicates, extract_allow_line_key, git_transport_hint, normalize_git_spec, parse_allowlist_keys, parse_store_major_from_modules_yaml, preset_spec_for_install, shell_quote_spec, silent_install_failure_detail, PreinstallPluginInfo};
 
     /// 构造预设条目的测试助手（internal 由各用例显式指定）
     fn preset(id: &str, spec: &str, internal: bool) -> PreinstallPluginInfo {
@@ -1120,7 +1115,10 @@ mod tests {
     fn install_spec_passthrough_for_regular_preset() {
         // 普通插件：spec 原样返回，与捆绑目录无关
         let p = preset("dshmarket", "dshmarket", false);
-        assert_eq!(preset_spec_for_install(&p, None).unwrap(), "dshmarket");
+        assert_eq!(
+            preset_spec_for_install(&p, None).unwrap(),
+            "dshmarket"
+        );
         assert_eq!(
             preset_spec_for_install(&p, Some(PathBuf::from("/ignored"))).unwrap(),
             "dshmarket"
@@ -1199,9 +1197,7 @@ virtualStoreDir: node_modules/.pnpm
     #[test]
     fn store_major_supports_unix_and_quoted_paths() {
         assert_eq!(
-            parse_store_major_from_modules_yaml(
-                "storeDir: /home/test/.local/share/pnpm/store/v11\n"
-            ),
+            parse_store_major_from_modules_yaml("storeDir: /home/test/.local/share/pnpm/store/v11\n"),
             Some(11)
         );
         assert_eq!(
@@ -1213,10 +1209,7 @@ virtualStoreDir: node_modules/.pnpm
     #[test]
     fn store_major_missing_when_no_store_dir() {
         // 档案尚未装过依赖：无 storeDir 段 → None
-        assert_eq!(
-            parse_store_major_from_modules_yaml("lockfileVersion: '9.0'\n"),
-            None
-        );
+        assert_eq!(parse_store_major_from_modules_yaml("lockfileVersion: '9.0'\n"), None);
         assert_eq!(parse_store_major_from_modules_yaml(""), None);
         assert_eq!(
             parse_store_major_from_modules_yaml("storeDir: C:\\Users\\x\\pnpm\\store\n"),
@@ -1234,10 +1227,7 @@ allowBuilds:
   dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89: true
 ";
         let keys = parse_allowlist_keys(out);
-        assert!(keys.contains(
-            &"dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89"
-                .to_string()
-        ));
+        assert!(keys.contains(&"dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89".to_string()));
         assert!(!keys.contains(&"dsh-better-sidebar".to_string()));
     }
 
@@ -1298,22 +1288,16 @@ allowBuilds:
 
     #[test]
     fn apply_quotes_git_dep_path_keys() {
-        let dep =
-            "dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89"
-                .to_string();
+        let dep = "dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89".to_string();
         // 空内容也能生成合法配置
         let out = apply_allow_build_keys("", &[dep.clone()]).unwrap();
         let map = allow_builds_map(&out);
-        assert_eq!(
-            map.get(&serde_yaml::Value::String(dep)),
-            Some(&serde_yaml::Value::Bool(true))
-        );
+        assert_eq!(map.get(&serde_yaml::Value::String(dep)), Some(&serde_yaml::Value::Bool(true)));
         // 库负责正确加引号，键原样（含 @ / : / #）可回读
         let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
         assert_eq!(
             doc["allowBuilds"][&serde_yaml::Value::String(
-                "dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89"
-                    .to_string()
+                "dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89".to_string()
             )],
             serde_yaml::Value::Bool(true)
         );
@@ -1333,9 +1317,7 @@ allowBuilds:
         // 序列化后全局不允许再出现“重复键”的等价行（node-pty 只出现一次）
         let node_pty_keys = out
             .lines()
-            .filter(|l| {
-                l.trim_start().starts_with("node-pty") || l.trim_start().starts_with("'node-pty'")
-            })
+            .filter(|l| l.trim_start().starts_with("node-pty") || l.trim_start().starts_with("'node-pty'"))
             .count();
         assert_eq!(node_pty_keys, 1);
     }
@@ -1348,18 +1330,13 @@ allowBuilds:
         // 重复的 node-pty 只剩最后一个（值 true），同键不再重复
         let node_pty = normalized
             .lines()
-            .filter(|l| {
-                l.trim_start().starts_with("node-pty") || l.trim_start().starts_with("'node-pty'")
-            })
+            .filter(|l| l.trim_start().starts_with("node-pty") || l.trim_start().starts_with("'node-pty'"))
             .count();
         assert_eq!(node_pty, 1);
         assert!(normalized.contains("keep"));
         // 去重结果必须是合法 YAML，且能被后续解析
         let out = apply_allow_build_keys(&normalized, &["node-pty".to_string()]).unwrap();
-        assert_eq!(
-            allow_builds_map(&out).get("node-pty"),
-            Some(&serde_yaml::Value::Bool(true))
-        );
+        assert_eq!(allow_builds_map(&out).get("node-pty"), Some(&serde_yaml::Value::Bool(true)));
     }
 
     // ---- git GitHub 简写规范化（issue #51 根因绕行）----
@@ -1425,10 +1402,7 @@ allowBuilds:
             shell_quote_spec("link:/Applications/Deepseek Harness Desktop.app/Contents/Resources/resources/preset-plugins/dsh-tauri-ui"),
             "link:/Applications/Deepseek Harness Desktop.app/Contents/Resources/resources/preset-plugins/dsh-tauri-ui"
         );
-        assert_eq!(
-            shell_quote_spec("link:/Users/me/my plugins/dsh-tauri"),
-            "link:/Users/me/my plugins/dsh-tauri"
-        );
+        assert_eq!(shell_quote_spec("link:/Users/me/my plugins/dsh-tauri"), "link:/Users/me/my plugins/dsh-tauri");
     }
 
     #[test]
@@ -1450,8 +1424,7 @@ allowBuilds:
     #[test]
     fn shell_quote_preserves_link_prefix_semantics() {
         // 引号只包 path 部分也不影响 pnpm 解析（落盘值仍为不带引号的 link: 规范形）
-        let quoted =
-            shell_quote_spec("link:G:/Deepseek Harness Desktop/resources/preset-plugins/dsh-tauri");
+        let quoted = shell_quote_spec("link:G:/Deepseek Harness Desktop/resources/preset-plugins/dsh-tauri");
         assert!(quoted.starts_with('"'));
         assert!(quoted.ends_with('"'));
         assert!(quoted.contains("Deepseek Harness Desktop"));
@@ -1468,10 +1441,7 @@ allowBuilds:
     #[test]
     fn git_transport_hint_detects_publickey_and_ssh() {
         assert!(git_transport_hint("git@github.com: Permission denied (publickey)").is_some());
-        assert!(
-            git_transport_hint("ssh: connect to host github.com port 22: Connection refused")
-                .is_some()
-        );
+        assert!(git_transport_hint("ssh: connect to host github.com port 22: Connection refused").is_some());
     }
 
     #[test]

--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -244,7 +244,8 @@ fn preset_spec_for_install(
 /// 存在：缺失者记录错误并整体返回 Err，避免前端误报「已安装 N 个插件」。
 ///
 /// 已落盘的插件同步清除其历史错误；`ids` 里未匹配到预设的条目忽略（调用处已先
-/// 校验过 ID，正常不可达）。
+/// 校验过 ID，正常不可达）。同时接收全部命令输出，以便静默失败时保留早期重试的
+/// 诊断，而不是因最后一次重试无输出而误报「子进程完全无输出」。
 fn verify_installed_products(
     app_handle: &AppHandle,
     ids: &[String],
@@ -352,12 +353,15 @@ pub(crate) fn build_plugin_envs(app_handle: &AppHandle, prefer_bundled_pnpm: boo
 /// `lib/index.js` 缺失」的坏态，下一次启动便因 `${DSH_HOME}/profiles/<档案>/node_modules/<pkg>/lib/index.js`
 /// 无法解析而 `ERR_MODULE_NOT_FOUND` 失败。
 ///
-/// 返回 `(退出码, 最后一次捕获的输出)`。输出仍逐行经 `preinstall-log` 实时推送。
+/// 返回 `(退出码, 所有尝试累积的输出)`，避免最后一次重试无输出时丢失此前诊断。
+/// 输出仍逐行经 `preinstall-log` 实时推送。
 ///
 /// 注意：pnpm v11 在 `allowBuilds` 将 git 托管插件（`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`）
 /// 或传递依赖（`ERR_PNPM_IGNORED_BUILDS`）拦截时仍可能以 **exit 0** 退出（假成功），
 /// 因此不能仅凭退出码判断成败——必须先解析输出里的 `allowBuilds` 键，有键就写入
 /// profile 的 `pnpm-workspace.yaml` 并重试。无键可加（或到达重试上限）才以本次退出码为准。
+///
+/// 每次重试的输出都必须累积，避免最终尝试无输出时覆盖此前真正有用的 pnpm 诊断。
 async fn run_plugin_with_allow_build_retry(
     app_handle: &AppHandle,
     node: &Path,
@@ -368,8 +372,10 @@ async fn run_plugin_with_allow_build_retry(
     action: &str,
 ) -> Result<(i32, String), String> {
     let mut retries = 0usize;
-    let (exit_code, last_output) = loop {
+    let mut all_output = String::new();
+    let exit_code = loop {
         let (code, captured) = run_plugin_process(node, args, cwd, envs, window).await?;
+        append_command_output(&mut all_output, &captured);
         let new_keys = parse_allowlist_keys(&captured);
         // 有可补充的 allowBuilds 键且未达上限 → 写入并重试（无论本次退出码是否为 0，
         // 见上方注释：pnpm 可能在阻断时仍以 0 退出）。
@@ -393,16 +399,27 @@ async fn run_plugin_with_allow_build_retry(
             log::error!(
                 "dsh plugin {action}: allowBuilds retry limit reached ({retries}), keys {new_keys:?} unresolved"
             );
-            break (if code == 0 { 1 } else { code }, captured);
+            break if code == 0 { 1 } else { code };
         }
         if code != 0 {
             log::error!(
                 "dsh plugin {action} failed with exit code {code}; no allowBuilds entries to add"
             );
         }
-        break (code, captured);
+        break code;
     };
-    Ok((exit_code, last_output))
+    Ok((exit_code, all_output))
+}
+
+/// 合并单次命令输出，并在相邻尝试之间补换行，保证后续错误解析不会粘连两段日志。
+fn append_command_output(all_output: &mut String, captured: &str) {
+    if captured.is_empty() {
+        return;
+    }
+    if !all_output.is_empty() && !all_output.ends_with('\n') {
+        all_output.push('\n');
+    }
+    all_output.push_str(captured);
 }
 
 /// 升级单个插件：`dsh plugin --profile <当前档案> update <id>`
@@ -1092,7 +1109,7 @@ pub(crate) fn harness_prefer_bundled_pnpm(app_handle: &AppHandle) -> bool {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use super::{apply_allow_build_keys, collapse_allow_builds_duplicates, extract_allow_line_key, git_transport_hint, normalize_git_spec, parse_allowlist_keys, parse_store_major_from_modules_yaml, preset_spec_for_install, shell_quote_spec, silent_install_failure_detail, PreinstallPluginInfo};
+    use super::{append_command_output, apply_allow_build_keys, collapse_allow_builds_duplicates, extract_allow_line_key, git_transport_hint, normalize_git_spec, parse_allowlist_keys, parse_store_major_from_modules_yaml, preset_spec_for_install, shell_quote_spec, silent_install_failure_detail, PreinstallPluginInfo};
 
     /// 构造预设条目的测试助手（internal 由各用例显式指定）
     fn preset(id: &str, spec: &str, internal: bool) -> PreinstallPluginInfo {
@@ -1146,6 +1163,7 @@ mod tests {
         assert!(err.contains("dsh-tauri"));
     }
 
+    /// 验证命令无输出且产物缺失时，会同时报告预期清单路径和可操作提示。
     #[test]
     fn silent_install_failure_reports_empty_output_and_expected_artifact() {
         let missing = vec![(
@@ -1164,6 +1182,7 @@ mod tests {
         assert!(detail.contains("Retry the installation"));
     }
 
+    /// 验证已有命令日志时，引导用户查看日志而不会误报为完全无输出。
     #[test]
     fn silent_install_failure_points_to_existing_command_log() {
         let missing = vec![(
@@ -1175,6 +1194,16 @@ mod tests {
 
         assert!(detail.contains("Review the preinstall log above"));
         assert!(!detail.contains("produced no output"));
+    }
+
+    /// 验证最终重试无输出时，早期尝试产生的诊断不会被覆盖丢失。
+    #[test]
+    fn command_output_retains_earlier_retry_diagnostics() {
+        let mut output = String::new();
+        append_command_output(&mut output, "ERR_PNPM_IGNORED_BUILDS");
+        append_command_output(&mut output, "");
+
+        assert_eq!(output, "ERR_PNPM_IGNORED_BUILDS");
     }
 
     #[test]

--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -21,10 +21,10 @@ use crate::service::download;
 use crate::service::download::Installable;
 use crate::service::profile::active_profile;
 use crate::service::workflow;
+use serde_yaml::{Mapping, Value};
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use serde_yaml::{Mapping, Value};
 use tauri::{AppHandle, Emitter, Manager, WebviewWindow};
 
 use super::errors;
@@ -54,10 +54,8 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
 
     // 单次读取预设并构建查找表，提升算法效率至 O(N)
     let presets = load_presets(app_handle);
-    let preset_map: HashMap<&str, &PreinstallPluginInfo> = presets
-        .iter()
-        .map(|p| (p.id.as_str(), p))
-        .collect();
+    let preset_map: HashMap<&str, &PreinstallPluginInfo> =
+        presets.iter().map(|p| (p.id.as_str(), p)).collect();
 
     let mut specs = Vec::with_capacity(ids.len());
     for id in ids {
@@ -82,7 +80,10 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
         // 对账的 `expected`（bundled_dep_spec）一致。macOS/Linux 是直接
         // `spawnSync`（无 shell），spec 作为单个 argv 传递、空格天然保留，
         // 引号只会被当作包名字符导致安装失败（见 [`shell_quote_spec`]）。
-        let raw = normalize_git_spec(&preset_spec_for_install(preset, bundled_dir_of(app_handle, preset))?);
+        let raw = normalize_git_spec(&preset_spec_for_install(
+            preset,
+            bundled_dir_of(app_handle, preset),
+        )?);
         specs.push(shell_quote_spec(&raw));
     }
 
@@ -143,13 +144,7 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
     // 后重试，直至成功或再无键可加（升级路径同样依赖该重试，见
     // [`run_plugin_with_allow_build_retry`]）。
     let (exit_code, last_output) = run_plugin_with_allow_build_retry(
-        app_handle,
-        &node,
-        &args,
-        &cwd,
-        &envs,
-        &window,
-        "install",
+        app_handle, &node, &args, &cwd, &envs, &window, "install",
     )
     .await?;
 
@@ -187,7 +182,7 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
     // 真正修复：核验本次安装是否真实落盘。pnpm 可能在 allowBuilds 阻断时仍以
     // exit 0 退出（假成功），若产物缺失则记录错误并返回 Err，让前端如实展示失败、
     // 允许重试，而不是误报「已安装」。已落盘的插件在上一步被核验并清除历史错误。
-    verify_installed_products(app_handle, ids, &preset_map)?;
+    verify_installed_products(app_handle, ids, &preset_map, &last_output)?;
 
     // Windows 极简模式专项修复
     if ids.iter().any(|id| id == "dsh-win-terminal-inspector") {
@@ -249,29 +244,30 @@ fn verify_installed_products(
     app_handle: &AppHandle,
     ids: &[String],
     preset_map: &HashMap<&str, &PreinstallPluginInfo>,
+    command_output: &str,
 ) -> Result<(), String> {
     let node_modules = profile_dir(app_handle).join("node_modules");
-    let mut missing: Vec<String> = Vec::new();
+    let mut missing = Vec::new();
     for id in ids {
         let Some(preset) = preset_map.get(id.as_str()) else {
             continue;
         };
         let name = installed_name(preset);
-        if node_modules.join(name).join("package.json").is_file() {
+        let manifest = node_modules.join(name).join("package.json");
+        if manifest.is_file() {
             if let Err(e) = errors::clear(app_handle, id) {
                 log::warn!("failed to clear plugin error for {id}: {e}");
             }
         } else {
-            missing.push(id.clone());
+            missing.push((id.clone(), manifest));
         }
     }
     if missing.is_empty() {
         return Ok(());
     }
-    let detail = format!(
-        "PREINSTALL_SILENT_FAIL: 以下插件退出码为 0 但未真正安装（node_modules 缺少产物）：{missing:?}"
-    );
-    for id in &missing {
+    let detail = silent_install_failure_detail(&missing, command_output);
+    log::error!("{detail}");
+    for (id, _) in &missing {
         if let Err(e) = errors::record(app_handle, id, "install", &detail) {
             log::warn!("failed to record plugin error for {id}: {e}");
         }
@@ -279,12 +275,38 @@ fn verify_installed_products(
     Err(detail)
 }
 
+/// 为 exit 0 但无落盘产物的假成功生成可操作诊断：明确缺失插件、预期清单路径，
+/// 并区分「子进程完全无输出」与「有输出但仍未落盘」，方便日志反馈直接定位。
+fn silent_install_failure_detail(missing: &[(String, PathBuf)], command_output: &str) -> String {
+    let ids = missing
+        .iter()
+        .map(|(id, _)| id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let manifests = missing
+        .iter()
+        .map(|(_, path)| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let output_hint = if command_output.trim().is_empty() {
+        "The dsh plugin command produced no output."
+    } else {
+        "Review the preinstall log above for the command output."
+    };
+    format!(
+        "PREINSTALL_SILENT_FAIL: dsh plugin exited with code 0, but no install artifact was created for [{ids}]. Expected package manifests: [{manifests}]. {output_hint} Retry the installation; if it repeats, include the preinstall log and these paths in the bug report."
+    )
+}
+
 /// 构建 `dsh plugin` 子进程的环境变量：隔离 $DSH_HOME、关闭遥测与颜色，
 /// PATH 前置 shim 目录与 node 目录；用户 pnpm 过旧时强制捆绑版（见 ensure_pnpm）。
 ///
 /// 供本模块的安装/升级/卸载与 [`super::verify`] 的完整性修复共用：子进程（dsh
 /// 或 pnpm）都按同一套桌面端环境策略运行，保证 $DSH_HOME / PATH 布局一致。
-pub(crate) fn build_plugin_envs(app_handle: &AppHandle, prefer_bundled_pnpm: bool) -> HashMap<String, String> {
+pub(crate) fn build_plugin_envs(
+    app_handle: &AppHandle,
+    prefer_bundled_pnpm: bool,
+) -> HashMap<String, String> {
     let node = config::get_node_binary_path(app_handle);
     let bin_dir = cli::get_bin_dir(app_handle);
     let mut envs = HashMap::from([
@@ -352,9 +374,7 @@ async fn run_plugin_with_allow_build_retry(
         if !new_keys.is_empty() && retries < MAX_ALLOW_LIST_RETRIES {
             retries += 1;
             add_allow_build_keys(app_handle, &new_keys)?;
-            log::info!(
-                "pnpm allowBuilds updated with {new_keys:?}, retrying {action} ({retries})"
-            );
+            log::info!("pnpm allowBuilds updated with {new_keys:?}, retrying {action} ({retries})");
             let _ = window.emit(
                 PREINSTALL_LOG_EVENT,
                 PreinstallLogPayload {
@@ -383,15 +403,24 @@ async fn run_plugin_with_allow_build_retry(
 
 /// 升级单个插件：`dsh plugin --profile <当前档案> update <id>`
 pub async fn update(app_handle: &AppHandle, id: &str) -> Result<(), String> {
-    run_single_plugin_command(app_handle, id, "update", &["update".to_string(), id.to_string()])
-        .await
+    run_single_plugin_command(
+        app_handle,
+        id,
+        "update",
+        &["update".to_string(), id.to_string()],
+    )
+    .await
 }
 
 /// 卸载单个插件：`dsh plugin --profile <当前档案> remove <id>`
 pub async fn remove(app_handle: &AppHandle, id: &str) -> Result<(), String> {
-    let command_result =
-        run_single_plugin_command(app_handle, id, "remove", &["remove".to_string(), id.to_string()])
-            .await;
+    let command_result = run_single_plugin_command(
+        app_handle,
+        id,
+        "remove",
+        &["remove".to_string(), id.to_string()],
+    )
+    .await;
     // `dsh plugin remove` 以子进程退出码为准，可能出现「命令成功但插件仍在」的
     // 边界（如 bundle 层残留、pnpm 静默失败）；node_modules / lockfile 损坏时
     // （典型：安装只写入了 profile 清单而产物缺失，见 issue #90）pnpm 甚至会
@@ -475,16 +504,9 @@ async fn run_single_plugin_command(
 
     let cwd = config::get_dsh_install_path(app_handle);
     log::info!("Running dsh plugin {action} for {id}");
-    let (exit_code, output) = run_plugin_with_allow_build_retry(
-        app_handle,
-        &node,
-        &args,
-        &cwd,
-        &envs,
-        &window,
-        action,
-    )
-    .await?;
+    let (exit_code, output) =
+        run_plugin_with_allow_build_retry(app_handle, &node, &args, &cwd, &envs, &window, action)
+            .await?;
 
     if exit_code != 0 {
         log::error!("dsh plugin {action} failed for {id} with exit code {exit_code}");
@@ -616,7 +638,9 @@ async fn ensure_pnpm(app_handle: &AppHandle, window: &WebviewWindow) -> Result<b
             );
         }
         None => {
-            log::warn!("User pnpm version not detectable (broken/blocked shim?), using bundled pnpm");
+            log::warn!(
+                "User pnpm version not detectable (broken/blocked shim?), using bundled pnpm"
+            );
         }
     }
 
@@ -697,9 +721,9 @@ pub(crate) fn profile_store_major(app_handle: &AppHandle) -> Option<u32> {
 
 /// 从 `.modules.yaml` 文本解析 store 主版本（纯函数，便于单测）。
 fn parse_store_major_from_modules_yaml(content: &str) -> Option<u32> {
-    let store_dir = content.lines().find_map(|line| {
-        line.trim().strip_prefix("storeDir:").map(str::trim)
-    })?;
+    let store_dir = content
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("storeDir:").map(str::trim))?;
     // storeDir 形如 `C:\Users\xx\AppData\Local\pnpm\store\v10`，取末段 `v10` 的数字
     let major = store_dir
         .trim_matches(['"', '\''])
@@ -808,8 +832,7 @@ fn add_allow_build_keys(app_handle: &AppHandle, keys: &[String]) -> Result<(), S
     std::fs::create_dir_all(dir).map_err(|e| format!("PREINSTALL_MKDIR: {e}"))?;
 
     let content = if path.exists() {
-        std::fs::read_to_string(&path)
-            .map_err(|e| format!("PREINSTALL_READ_WORKSPACE: {e}"))?
+        std::fs::read_to_string(&path).map_err(|e| format!("PREINSTALL_READ_WORKSPACE: {e}"))?
     } else {
         // 与 dsh `initProfile` 生成的基础模板保持一致（尚无 allowBuilds）。
         "packages:\n  - .\n\nnodeLinker: hoisted\nautoInstallPeers: false\n".to_string()
@@ -820,7 +843,10 @@ fn add_allow_build_keys(app_handle: &AppHandle, keys: &[String]) -> Result<(), S
         return Ok(()); // 无变化（所有键已就位），避免无意义写盘
     }
 
-    log::info!("pnpm-workspace.yaml rewritten with allowBuilds {keys:?} at {}", path.display());
+    log::info!(
+        "pnpm-workspace.yaml rewritten with allowBuilds {keys:?} at {}",
+        path.display()
+    );
     std::fs::write(&path, rendered).map_err(|e| format!("PREINSTALL_WRITE_WORKSPACE: {e}"))
 }
 
@@ -843,14 +869,11 @@ fn apply_allow_build_keys(content: &str, keys: &[String]) -> Result<String, Stri
         Err(first_err) => {
             let normalized = collapse_allow_builds_duplicates(content);
             if normalized == content {
-                return Err(format!(
-                    "PREINSTALL_WORKSPACE_INVALID_YAML: {first_err}"
-                ));
+                return Err(format!("PREINSTALL_WORKSPACE_INVALID_YAML: {first_err}"));
             }
             repaired = true;
-            serde_yaml::from_str(&normalized).map_err(|e| {
-                format!("PREINSTALL_WORKSPACE_INVALID_YAML: {e}")
-            })?
+            serde_yaml::from_str(&normalized)
+                .map_err(|e| format!("PREINSTALL_WORKSPACE_INVALID_YAML: {e}"))?
         }
     };
 
@@ -1013,7 +1036,8 @@ fn shell_quote_spec(spec: &str) -> String {
 /// 从 pnpm 失败输出里识别 git 传输层错误（区别于 allowBuilds 构建门禁），命中时
 /// 返回一句可读的成因/指引。pnpm 在这些场景下已经退到 git+ssh，再去补 allowBuilds
 /// 白名单是无效且误导的。
-fn git_transport_hint(output: &str) -> Option<&'static str> {    const SIGNALS: &[(&str, &str)] = &[
+fn git_transport_hint(output: &str) -> Option<&'static str> {
+    const SIGNALS: &[(&str, &str)] = &[
         (
             "host key verification failed",
             "git fell back to SSH and could not verify GitHub's host key (no known_hosts entry; the process ran non-interactively). Make sure GitHub is reachable over HTTPS.",
@@ -1067,8 +1091,13 @@ pub(crate) fn harness_prefer_bundled_pnpm(app_handle: &AppHandle) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::{
+        apply_allow_build_keys, collapse_allow_builds_duplicates, extract_allow_line_key,
+        git_transport_hint, normalize_git_spec, parse_allowlist_keys,
+        parse_store_major_from_modules_yaml, preset_spec_for_install, shell_quote_spec,
+        silent_install_failure_detail, PreinstallPluginInfo,
+    };
     use std::path::PathBuf;
-    use super::{apply_allow_build_keys, collapse_allow_builds_duplicates, extract_allow_line_key, git_transport_hint, normalize_git_spec, parse_allowlist_keys, parse_store_major_from_modules_yaml, preset_spec_for_install, shell_quote_spec, PreinstallPluginInfo};
 
     /// 构造预设条目的测试助手（internal 由各用例显式指定）
     fn preset(id: &str, spec: &str, internal: bool) -> PreinstallPluginInfo {
@@ -1091,10 +1120,7 @@ mod tests {
     fn install_spec_passthrough_for_regular_preset() {
         // 普通插件：spec 原样返回，与捆绑目录无关
         let p = preset("dshmarket", "dshmarket", false);
-        assert_eq!(
-            preset_spec_for_install(&p, None).unwrap(),
-            "dshmarket"
-        );
+        assert_eq!(preset_spec_for_install(&p, None).unwrap(), "dshmarket");
         assert_eq!(
             preset_spec_for_install(&p, Some(PathBuf::from("/ignored"))).unwrap(),
             "dshmarket"
@@ -1123,6 +1149,37 @@ mod tests {
     }
 
     #[test]
+    fn silent_install_failure_reports_empty_output_and_expected_artifact() {
+        let missing = vec![(
+            "dsh-win-terminal-inspector".to_string(),
+            PathBuf::from(
+                "C:\\Users\\test\\.dsh\\profiles\\web\\node_modules\\dsh-win-terminal-inspector\\package.json",
+            ),
+        )];
+
+        let detail = silent_install_failure_detail(&missing, "  \r\n");
+
+        assert!(detail.starts_with("PREINSTALL_SILENT_FAIL:"));
+        assert!(detail.contains("dsh-win-terminal-inspector"));
+        assert!(detail.contains("package.json"));
+        assert!(detail.contains("produced no output"));
+        assert!(detail.contains("Retry the installation"));
+    }
+
+    #[test]
+    fn silent_install_failure_points_to_existing_command_log() {
+        let missing = vec![(
+            "dshmarket".to_string(),
+            PathBuf::from("/tmp/profile/node_modules/dshmarket/package.json"),
+        )];
+
+        let detail = silent_install_failure_detail(&missing, "pnpm completed\n");
+
+        assert!(detail.contains("Review the preinstall log above"));
+        assert!(!detail.contains("produced no output"));
+    }
+
+    #[test]
     fn store_major_parsed_from_modules_yaml() {
         // 真实 pnpm v10 写入的 .modules.yaml：storeDir 指向 store\v10
         let content = "\
@@ -1142,7 +1199,9 @@ virtualStoreDir: node_modules/.pnpm
     #[test]
     fn store_major_supports_unix_and_quoted_paths() {
         assert_eq!(
-            parse_store_major_from_modules_yaml("storeDir: /home/test/.local/share/pnpm/store/v11\n"),
+            parse_store_major_from_modules_yaml(
+                "storeDir: /home/test/.local/share/pnpm/store/v11\n"
+            ),
             Some(11)
         );
         assert_eq!(
@@ -1154,7 +1213,10 @@ virtualStoreDir: node_modules/.pnpm
     #[test]
     fn store_major_missing_when_no_store_dir() {
         // 档案尚未装过依赖：无 storeDir 段 → None
-        assert_eq!(parse_store_major_from_modules_yaml("lockfileVersion: '9.0'\n"), None);
+        assert_eq!(
+            parse_store_major_from_modules_yaml("lockfileVersion: '9.0'\n"),
+            None
+        );
         assert_eq!(parse_store_major_from_modules_yaml(""), None);
         assert_eq!(
             parse_store_major_from_modules_yaml("storeDir: C:\\Users\\x\\pnpm\\store\n"),
@@ -1172,7 +1234,10 @@ allowBuilds:
   dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89: true
 ";
         let keys = parse_allowlist_keys(out);
-        assert!(keys.contains(&"dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89".to_string()));
+        assert!(keys.contains(
+            &"dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89"
+                .to_string()
+        ));
         assert!(!keys.contains(&"dsh-better-sidebar".to_string()));
     }
 
@@ -1233,16 +1298,22 @@ allowBuilds:
 
     #[test]
     fn apply_quotes_git_dep_path_keys() {
-        let dep = "dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89".to_string();
+        let dep =
+            "dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89"
+                .to_string();
         // 空内容也能生成合法配置
         let out = apply_allow_build_keys("", &[dep.clone()]).unwrap();
         let map = allow_builds_map(&out);
-        assert_eq!(map.get(&serde_yaml::Value::String(dep)), Some(&serde_yaml::Value::Bool(true)));
+        assert_eq!(
+            map.get(&serde_yaml::Value::String(dep)),
+            Some(&serde_yaml::Value::Bool(true))
+        );
         // 库负责正确加引号，键原样（含 @ / : / #）可回读
         let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
         assert_eq!(
             doc["allowBuilds"][&serde_yaml::Value::String(
-                "dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89".to_string()
+                "dsh-better-sidebar@git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git#6c89"
+                    .to_string()
             )],
             serde_yaml::Value::Bool(true)
         );
@@ -1262,7 +1333,9 @@ allowBuilds:
         // 序列化后全局不允许再出现“重复键”的等价行（node-pty 只出现一次）
         let node_pty_keys = out
             .lines()
-            .filter(|l| l.trim_start().starts_with("node-pty") || l.trim_start().starts_with("'node-pty'"))
+            .filter(|l| {
+                l.trim_start().starts_with("node-pty") || l.trim_start().starts_with("'node-pty'")
+            })
             .count();
         assert_eq!(node_pty_keys, 1);
     }
@@ -1275,13 +1348,18 @@ allowBuilds:
         // 重复的 node-pty 只剩最后一个（值 true），同键不再重复
         let node_pty = normalized
             .lines()
-            .filter(|l| l.trim_start().starts_with("node-pty") || l.trim_start().starts_with("'node-pty'"))
+            .filter(|l| {
+                l.trim_start().starts_with("node-pty") || l.trim_start().starts_with("'node-pty'")
+            })
             .count();
         assert_eq!(node_pty, 1);
         assert!(normalized.contains("keep"));
         // 去重结果必须是合法 YAML，且能被后续解析
         let out = apply_allow_build_keys(&normalized, &["node-pty".to_string()]).unwrap();
-        assert_eq!(allow_builds_map(&out).get("node-pty"), Some(&serde_yaml::Value::Bool(true)));
+        assert_eq!(
+            allow_builds_map(&out).get("node-pty"),
+            Some(&serde_yaml::Value::Bool(true))
+        );
     }
 
     // ---- git GitHub 简写规范化（issue #51 根因绕行）----
@@ -1347,7 +1425,10 @@ allowBuilds:
             shell_quote_spec("link:/Applications/Deepseek Harness Desktop.app/Contents/Resources/resources/preset-plugins/dsh-tauri-ui"),
             "link:/Applications/Deepseek Harness Desktop.app/Contents/Resources/resources/preset-plugins/dsh-tauri-ui"
         );
-        assert_eq!(shell_quote_spec("link:/Users/me/my plugins/dsh-tauri"), "link:/Users/me/my plugins/dsh-tauri");
+        assert_eq!(
+            shell_quote_spec("link:/Users/me/my plugins/dsh-tauri"),
+            "link:/Users/me/my plugins/dsh-tauri"
+        );
     }
 
     #[test]
@@ -1369,7 +1450,8 @@ allowBuilds:
     #[test]
     fn shell_quote_preserves_link_prefix_semantics() {
         // 引号只包 path 部分也不影响 pnpm 解析（落盘值仍为不带引号的 link: 规范形）
-        let quoted = shell_quote_spec("link:G:/Deepseek Harness Desktop/resources/preset-plugins/dsh-tauri");
+        let quoted =
+            shell_quote_spec("link:G:/Deepseek Harness Desktop/resources/preset-plugins/dsh-tauri");
         assert!(quoted.starts_with('"'));
         assert!(quoted.ends_with('"'));
         assert!(quoted.contains("Deepseek Harness Desktop"));
@@ -1386,7 +1468,10 @@ allowBuilds:
     #[test]
     fn git_transport_hint_detects_publickey_and_ssh() {
         assert!(git_transport_hint("git@github.com: Permission denied (publickey)").is_some());
-        assert!(git_transport_hint("ssh: connect to host github.com port 22: Connection refused").is_some());
+        assert!(
+            git_transport_hint("ssh: connect to host github.com port 22: Connection refused")
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/store/modules/harness/store.ts
+++ b/src/store/modules/harness/store.ts
@@ -11,6 +11,7 @@ import type {
   SetupStatus,
   SidebarBusyAction,
 } from './types'
+import type { ReadinessProbeResult } from '@/utils/readiness'
 import { emitter } from '@hairy/react-lib'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
@@ -18,6 +19,7 @@ import i18next from 'i18next'
 import { defineStore } from 'valtio-define'
 import { queryClient } from '@/config/client'
 import { pickErrorLines } from '@/utils/log'
+import { pollReadiness } from '@/utils/readiness'
 import { harnessUpdater } from '../harness-updater'
 
 const MAX_RETRIES = 8
@@ -31,6 +33,8 @@ interface StartupError extends Error {
   /** 完整清洗后的日志尾（供插件异常定位使用，非仅错误行） */
   logLines?: string[]
   pluginConflictHint?: string
+  /** 初始就绪窗口已耗尽，但后端进程仍由桌面端持有，可继续后台探测 */
+  readinessTimedOut?: boolean
 }
 
 const initialInstaller: InstallerState = {
@@ -59,14 +63,8 @@ function generateTimestampedUrl(baseUrl: string): string {
   return `${baseUrl}${separator}t=${timestamp}`
 }
 
-/** 健康检查结果：healthy 表示服务就绪；notOwned 表示 dsh 进程已退出（启动即崩溃，快速失败信号） */
-interface HealthCheckResult {
-  healthy: boolean
-  notOwned: boolean
-}
-
 /** 通过 Rust 代理探测服务健康状态（超时 8s，网络抖动时重试） */
-async function checkHealthViaProxy(): Promise<HealthCheckResult> {
+async function checkHealthViaProxy(): Promise<ReadinessProbeResult> {
   try {
     const timeoutPromise = new Promise<never>((_, reject) => {
       setTimeout(() => reject(new Error('health check timeout')), 8000)
@@ -266,8 +264,66 @@ export const harness = defineStore({
       })
     },
 
+    /** 服务探测通过后的统一收尾；token 用于阻止旧启动流程覆盖新状态 */
+    async completeReadiness(token?: number): Promise<boolean> {
+      const readyInfo = await invoke<{ service_url: string }>('get_runtime_info')
+      if (token !== undefined && token !== bootToken)
+        return false
+
+      this.serviceUrl = readyInfo.service_url
+      this.iframeSrc = generateTimestampedUrl(readyInfo.service_url)
+      this.serviceHealthy = true
+      this.serviceRunning = true
+      this.status = 'ready'
+      this.errorMsg = ''
+      this.errorLogs = []
+      this.pluginConflictHint = ''
+      this.preinstall.error = ''
+      // 服务（重）启动成功：清空插件异常修复态（若曾进入），并重置已「暂不处理」的插件
+      this.recovery = { required: false, info: null, attempts: 0, busy: false }
+      this.dismissedRecoveryIds = []
+      // 服务（重）启动成功后，dsh 版本/端口/CLI 链接状态等运行时信息可能已变化
+      // （典型：Harness 更新后旧版本缓存仍在，调试侧边栏需刷新页面才显示新版本）。
+      // 使侧边栏相关查询缓存失效，重新打开/已挂载时自动拉取最新值。
+      void queryClient.invalidateQueries({ queryKey: ['info'] })
+      void queryClient.invalidateQueries({ queryKey: ['config'] })
+      void queryClient.invalidateQueries({ queryKey: ['cli_status'] })
+      // 档案/核心切换后重启：当前档案的插件列表、核心来源状态一并刷新
+      void queryClient.invalidateQueries({ queryKey: ['plugins'] })
+      void queryClient.invalidateQueries({ queryKey: ['profiles'] })
+      void queryClient.invalidateQueries({ queryKey: ['cores'] })
+      return true
+    },
+
+    /**
+     * 初始就绪窗口超时后继续探测同一已持有进程。错误界面仍会及时出现，但只要后端
+     * 稍后完成插件加载，就自动恢复并挂载 iframe；新一轮 boot 会用 token 终止旧探测。
+     */
+    async recoverReadiness(token: number) {
+      const result = await pollReadiness({
+        probe: checkHealthViaProxy,
+        intervalMs: 2000,
+        shouldContinue: () => token === bootToken && this.serviceRunning && !this.serviceHealthy,
+      })
+      if (token !== bootToken)
+        return
+      if (result.notOwned) {
+        this.serviceRunning = false
+        return
+      }
+      if (!result.healthy)
+        return
+
+      try {
+        await this.completeReadiness(token)
+      }
+      catch (err) {
+        console.error('[Harness] failed to complete delayed readiness recovery:', err)
+      }
+    },
+
     /** 拉起服务并等待健康检查通过，通过后才允许挂载 iframe */
-    async launchAndWait() {
+    async launchAndWait(token?: number) {
       this.status = 'ready'
       this.installer = initialInstaller
       this.errorMsg = ''
@@ -286,42 +342,24 @@ export const harness = defineStore({
         this.serviceUrl = runtimeInfo.service_url
         this.iframeSrc = generateTimestampedUrl(runtimeInfo.service_url)
 
-        let healthy = false
-        let notOwned = false
-        for (let attempt = 0; attempt < MAX_RETRIES && !healthy && !notOwned; attempt++) {
-          const result = await checkHealthViaProxy()
-          healthy = result.healthy
-          notOwned = result.notOwned
-          if (!healthy && !notOwned) {
-            await new Promise(resolve => setTimeout(resolve, 2000))
-          }
-        }
-        if (!healthy) {
-          throw new Error(
+        const result = await pollReadiness({
+          probe: checkHealthViaProxy,
+          intervalMs: 2000,
+          maxAttempts: MAX_RETRIES,
+          shouldContinue: () => token === undefined || token === bootToken,
+        })
+        if (!result.healthy) {
+          const error: StartupError = new Error(
             i18next.t('errors.service_start_timeout', { port: new URL(this.serviceUrl).port || '3080' }),
           )
+          error.readinessTimedOut = !result.notOwned
+          throw error
         }
         // 服务已就绪后再取一次真实地址：`launch_harness` 可能因后端已在并发拉起
         // （auto_start）而提前返回，此刻端口若尚未落库，上面读到的 service_url 会是
         // 旧端口；健康检查通过意味着服务已在最终端口就绪，此时读取必然准确。
         // 避免 iframe 挂载到一个无人监听的地址（表现为首次加载失败、刷新后恢复）。
-        const readyInfo = await invoke<{ service_url: string }>('get_runtime_info')
-        this.serviceUrl = readyInfo.service_url
-        this.iframeSrc = generateTimestampedUrl(readyInfo.service_url)
-        this.serviceHealthy = true
-        // 服务（重）启动成功：清空插件异常修复态（若曾进入），并重置已「暂不处理」的插件
-        this.recovery = { required: false, info: null, attempts: 0, busy: false }
-        this.dismissedRecoveryIds = []
-        // 服务（重）启动成功后，dsh 版本/端口/CLI 链接状态等运行时信息可能已变化
-        // （典型：Harness 更新后旧版本缓存仍在，调试侧边栏需刷新页面才显示新版本）。
-        // 使侧边栏相关查询缓存失效，重新打开/已挂载时自动拉取最新值。
-        void queryClient.invalidateQueries({ queryKey: ['info'] })
-        void queryClient.invalidateQueries({ queryKey: ['config'] })
-        void queryClient.invalidateQueries({ queryKey: ['cli_status'] })
-        // 档案/核心切换后重启：当前档案的插件列表、核心来源状态一并刷新
-        void queryClient.invalidateQueries({ queryKey: ['plugins'] })
-        void queryClient.invalidateQueries({ queryKey: ['profiles'] })
-        void queryClient.invalidateQueries({ queryKey: ['cores'] })
+        await this.completeReadiness(token)
       }
       catch (err) {
         // 失败时附上服务日志里的真实错误行，供错误界面展示而不是只显示超时文案
@@ -400,7 +438,7 @@ export const harness = defineStore({
           return
         }
 
-        await this.launchAndWait()
+        await this.launchAndWait(token)
 
         if (token !== bootToken)
           return
@@ -416,7 +454,11 @@ export const harness = defineStore({
         const startupError = await attachStartupDiagnostics(err)
         // 尝试从日志定位问题插件：能定位则弹出修复界面（全屏恢复页）
         await this.reviewStartupRecovery(startupError.logLines ?? startupError.logs ?? [])
-        this.fail(String(startupError), startupError.logs, startupError.pluginConflictHint)
+        const keepServiceRunning = startupError.readinessTimedOut === true
+        this.fail(String(startupError), startupError.logs, startupError.pluginConflictHint, keepServiceRunning)
+        if (keepServiceRunning) {
+          void this.recoverReadiness(token)
+        }
       }
       finally {
         unlistenInstall?.()
@@ -430,12 +472,12 @@ export const harness = defineStore({
     },
 
     /** 进入错误态（供本模块与 updater 模块共用） */
-    fail(message: string, logs?: string[], pluginConflictHint?: string) {
+    fail(message: string, logs?: string[], pluginConflictHint?: string, keepServiceRunning = false) {
       this.errorMsg = message
       this.errorLogs = logs ?? []
       this.pluginConflictHint = pluginConflictHint ?? ''
       this.status = 'error'
-      this.serviceRunning = false
+      this.serviceRunning = keepServiceRunning
     },
 
     /**
@@ -632,6 +674,9 @@ export const harness = defineStore({
       catch (err) {
         console.error('[Harness] preinstall failed:', err)
         this.preinstall.error = String(err)
+        if (err instanceof Error && (err as StartupError).readinessTimedOut) {
+          void this.recoverReadiness(bootToken)
+        }
       }
       finally {
         unlisten?.()

--- a/src/utils/readiness.ts
+++ b/src/utils/readiness.ts
@@ -26,6 +26,9 @@ export async function pollReadiness({
 
   while (shouldContinue() && remainingAttempts !== 0) {
     const result = await probe()
+    if (!shouldContinue()) {
+      return { healthy: false, notOwned: false }
+    }
     if (remainingAttempts !== undefined) {
       remainingAttempts--
     }

--- a/src/utils/readiness.ts
+++ b/src/utils/readiness.ts
@@ -1,0 +1,42 @@
+export interface ReadinessProbeResult {
+  healthy: boolean
+  notOwned: boolean
+}
+
+interface PollReadinessOptions {
+  probe: () => Promise<ReadinessProbeResult>
+  intervalMs: number
+  maxAttempts?: number
+  shouldContinue?: () => boolean
+  wait?: (milliseconds: number) => Promise<void>
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
+export async function pollReadiness({
+  probe,
+  intervalMs,
+  maxAttempts,
+  shouldContinue = () => true,
+  wait = delay,
+}: PollReadinessOptions): Promise<ReadinessProbeResult> {
+  let remainingAttempts = maxAttempts
+
+  while (shouldContinue() && remainingAttempts !== 0) {
+    const result = await probe()
+    if (remainingAttempts !== undefined) {
+      remainingAttempts--
+    }
+
+    if (result.healthy || result.notOwned) {
+      return result
+    }
+    if (shouldContinue() && remainingAttempts !== 0) {
+      await wait(intervalMs)
+    }
+  }
+
+  return { healthy: false, notOwned: false }
+}

--- a/test/readiness.test.ts
+++ b/test/readiness.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { pollReadiness } from '../src/utils/readiness'
+
+function noWait(): Promise<void> {
+  return Promise.resolve()
+}
+
+describe('pollReadiness', () => {
+  it('stops after the initial bounded attempts', async () => {
+    let attempts = 0
+    const result = await pollReadiness({
+      probe: async () => {
+        attempts++
+        return { healthy: false, notOwned: false }
+      },
+      intervalMs: 0,
+      maxAttempts: 3,
+      wait: noWait,
+    })
+
+    expect(result).toEqual({ healthy: false, notOwned: false })
+    expect(attempts).toBe(3)
+  })
+
+  it('keeps recovery polling until a slow service becomes healthy', async () => {
+    let attempts = 0
+    const result = await pollReadiness({
+      probe: async () => {
+        attempts++
+        return { healthy: attempts === 5, notOwned: false }
+      },
+      intervalMs: 0,
+      wait: noWait,
+    })
+
+    expect(result.healthy).toBe(true)
+    expect(attempts).toBe(5)
+  })
+
+  it('stops recovery when the owning startup is superseded', async () => {
+    let attempts = 0
+    let active = true
+    const result = await pollReadiness({
+      probe: async () => {
+        attempts++
+        active = false
+        return { healthy: false, notOwned: false }
+      },
+      intervalMs: 0,
+      shouldContinue: () => active,
+      wait: noWait,
+    })
+
+    expect(result).toEqual({ healthy: false, notOwned: false })
+    expect(attempts).toBe(1)
+  })
+})

--- a/test/readiness.test.ts
+++ b/test/readiness.test.ts
@@ -54,4 +54,20 @@ describe('pollReadiness', () => {
     expect(result).toEqual({ healthy: false, notOwned: false })
     expect(attempts).toBe(1)
   })
+
+  it('discards a healthy probe result when recovery is cancelled while probing', async () => {
+    let active = true
+    const pendingProbe = Promise.withResolvers<{ healthy: boolean, notOwned: boolean }>()
+    const resultPromise = pollReadiness({
+      probe: () => pendingProbe.promise,
+      intervalMs: 0,
+      shouldContinue: () => active,
+      wait: noWait,
+    })
+
+    active = false
+    pendingProbe.resolve({ healthy: true, notOwned: false })
+
+    await expect(resultPromise).resolves.toEqual({ healthy: false, notOwned: false })
+  })
 })


### PR DESCRIPTION
## Summary
- report successful plugin install commands that produce no manifest as `PREINSTALL_SILENT_FAIL`, including the missing manifest path and actionable retry guidance
- keep an already-started harness service alive after the initial readiness window and continue probing in the background
- automatically clear delayed-startup errors and remount the iframe when the service becomes ready, while cancelling stale probes with the boot token

## Validation
- ESLint
- `tsc --noEmit`
- Vitest: 9/9
- Vite production build
- `cargo check`
- `cargo test`: 226/226

The full prebuild remains blocked by the existing internal `dsh-tauri@0.2.0` source returning HTTP 404; this is unrelated to the patch.

Fixes cloga/dsh-windows-ops#4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup reliability with readiness checks, retry handling, and background recovery.
  * Prevented outdated startup attempts from overwriting newer service states.
  * Preserved running services during readiness timeouts when recovery remains possible.
  * Added localized guidance for Linux inotify-limit startup failures.
  * Added more detailed diagnostics when plugin installation completes silently or misses expected plugin information.

* **Tests**
  * Added coverage for readiness retries, recovery, superseded startup attempts, and plugin installation diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->