### PR TITLE
fix: detect Linux inotify watcher limit crash on startup (#116)

### DIFF
--- a/src-tauri/src/config/utils.rs
+++ b/src-tauri/src/config/utils.rs
@@ -1,5 +1,26 @@
 use std::path::{Path, PathBuf};
 
+/// Linux inotify 文件监视上限的推荐最小值。
+///
+/// harness 服务（dsh web）用 chokidar 递归监视 `$DSH_HOME/profiles/*`，node 的
+/// 每个被监视目录都要消耗一个 inotify watch。系统默认值在新版 Ubuntu 上往往过小
+/// （如 65536），一旦监视到 `node_modules` 等庞大树就抛
+/// `ENOSPC: System limit for number of file watchers reached` 并使服务启动即崩溃
+/// （issue #116）。低于该推荐值时在启动日志给出明确提示，引导用户调高参数。
+#[cfg(unix)]
+pub const MIN_INOTIFY_MAX_USER_WATCHES: u64 = 524_288;
+
+/// 读取 Linux `fs.inotify.max_user_watches` 系统参数。
+///
+/// 进程无法自我调高该参数（需要 root / sysctl），但启动前探测并告警能让用户第一
+/// 时间知道「服务崩溃与系统监视上限有关」，而非看到一串 node 堆栈不知所云。
+/// 仅 Unix 存在该 procfs 节点；Windows / macOS 返回 None。纯函数，便于单测。
+#[cfg(unix)]
+pub fn linux_inotify_max_user_watches() -> Option<u64> {
+    let content = std::fs::read_to_string("/proc/sys/fs/inotify/max_user_watches").ok()?;
+    content.trim().parse::<u64>().ok()
+}
+
 /// 生成不冲突的下载路径：目标已存在时按 `name (n).ext` 递增命名，
 /// 与浏览器下载管理器的重名行为保持一致。
 ///
@@ -67,4 +88,32 @@ pub fn search_node_binary(dir: &PathBuf, target: &str) -> Option<PathBuf> {
     }
 
     None
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inotify_watch_limit_is_below_recommended_minimum() {
+        // 推荐最小值本身应远高于常见默认（如 65536/8192），否则提示会过早触发
+        assert!(
+            MIN_INOTIFY_MAX_USER_WATCHES > 65_536,
+            "recommended minimum {} should exceed common defaults",
+            MIN_INOTIFY_MAX_USER_WATCHES
+        );
+    }
+
+    #[test]
+    fn inotify_watch_limit_reads_procfs_when_present() {
+        // 存在该 procfs 节点（Linux 主机）时返回 Some(>0)；不存在时返回 None。
+        // 只验证类型与基本不变量，不绑定具体值，避免在不同内核配置下 flake。
+        match linux_inotify_max_user_watches() {
+            Some(v) => assert!(v > 0),
+            None => {
+                // 非 Linux / 无 procfs（CI 容器裁剪等情况）：返回 None 属预期
+                println!("inotify max_user_watches not available; skipping");
+            }
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,11 +13,21 @@ pub fn run() {
     // works, but AppImage needs compositing disabled. Auto-set when on Wayland
     // if user hasn't already set it — fixes hairyf#??? (PikaOS report).
     if std::env::var("XDG_SESSION_TYPE").unwrap_or_default() == "wayland" {
-        if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err()
-            && std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err()
-        {
+        // 与 README 文档一致地同时关闭 compositing 与 DMABUF renderer：只关前者在部分
+        // 发行版/驱动上仍会 SIGSEGV（issue #116 的 WebKitGTK 崩溃）。两个参数互相独立，
+        // 用户已手动设置其中一个时只补齐另一个。
+        let mut applied = Vec::new();
+        if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
             std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
-            eprintln!("[wayland] set WEBKIT_DISABLE_COMPOSITING_MODE=1 for WebKitGTK EGL");
+            applied.push("WEBKIT_DISABLE_COMPOSITING_MODE");
+        }
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+            applied.push("WEBKIT_DISABLE_DMABUF_RENDERER");
+        }
+        if !applied.is_empty() {
+            // 此处在 logger::init() 之前执行，log 宏尚无 subscriber，用 eprintln 输出
+            eprintln!("[wayland] set {} for WebKitGTK EGL", applied.join("="));
         }
     }
     // 初始化日志系统

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -450,6 +450,21 @@ pub fn terminate_stale_harness_processes(app_handle: &tauri::AppHandle) {
     }
 }
 
+#[cfg(unix)]
+pub(crate) fn warn_if_inotify_watch_limit_low() {
+    let Some(limit) = crate::config::linux_inotify_max_user_watches() else {
+        return;
+    };
+    if limit < crate::config::MIN_INOTIFY_MAX_USER_WATCHES {
+        log::warn!(
+            "Linux inotify.max_user_watches is {} (below recommended {}); dsh web may crash with ENOSPC (issue #116). To fix, run `sudo sysctl fs.inotify.max_user_watches={}` and write the same value to /etc/sysctl.conf to persist.",
+            limit,
+            crate::config::MIN_INOTIFY_MAX_USER_WATCHES,
+            crate::config::MIN_INOTIFY_MAX_USER_WATCHES,
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // 孤儿 Harness 清扫：崩溃/强杀残留实例的识别与回收（issue #34 关联现象）
 // ---------------------------------------------------------------------------
@@ -748,6 +763,13 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     // 构造环境变量：隔离的 $DSH_HOME + 隐私默认（关闭遥测）
     let dsh_home = config::get_dsh_data_path(&app_handle);
     fs::create_dir_all(&dsh_home).map_err(|e| format!("create dsh home failed: {e}"))?;
+
+    // Linux 起步前探测 inotify 监视上限：harness 服务（dsh web）用 chokidar 递归
+    // 监视 profile 目录，上限过低会在启动一瞬间抛 ENOSPC 直接退出（issue #116）。
+    // 进程无法自我调高该参数，这里只做告警（启动日志 + 读取 run logs 中的环境信息），
+    // 前端据服务日志的 ENOSPC 特征给出「调高 fs.inotify.max_user_watches」的针对性提示。
+    #[cfg(unix)]
+    warn_if_inotify_watch_limit_low();
 
     // Windows 极简模式修复的自愈：插件已装入 profile 时确保 patch 挂载行与
     // minimal-win 用户 preset 落盘（幂等）。最佳努力：失败只告警，不阻断启动。

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -65,6 +65,7 @@
   "download.show_in_folder": "Open",
   "errors.service_start_timeout": "DeepSeek Harness startup timeout. Please check whether port {{port}} is occupied or the startup is too slow.",
   "errors.plugin_route_conflict": "Detected a plugin route conflict: two plugins registered the same route twice. Uninstall the recently added plugin (e.g. dsh-web-ui-all / dsh-better-sidebar) from the Plugins panel, or run dsh plugin --profile <profile> remove <package> for the active profile and retry.",
+  "errors.inotify_limit": "The Harness service crashed on startup: your system reached the limit for file watchers (inotify ENOSPC). Increase the watcher limit and restart — e.g. run `sudo sysctl fs.inotify.max_user_watches=524288` (and add `fs.inotify.max_user_watches=524288` to `/etc/sysctl.conf` to persist), then restart the app.",
   "ui.service_url": "Service URL",
   "ui.port": "Port",
   "ui.cli_link": "CLI Integration",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -65,6 +65,7 @@
   "download.show_in_folder": "打开",
   "errors.service_start_timeout": "DeepSeek Harness 启动超时，请检查端口 {{port}} 是否被占用或启动过慢。",
   "errors.plugin_route_conflict": "检测到插件路由冲突：两个插件重复注册了同一路由。请在「插件」面板卸载最近安装的插件（如 dsh-web-ui-all / dsh-better-sidebar），或在终端对当前档案执行 dsh plugin --profile <档案名> remove <包名> 后重试。",
+  "errors.inotify_limit": "Harness 服务启动即崩溃：系统文件监视（inotify）数量达到上限。请调高监视上限后重试——例如执行 `sudo sysctl fs.inotify.max_user_watches=524288`（并将 `fs.inotify.max_user_watches=524288` 写入 `/etc/sysctl.conf` 以持久化），然后重启应用。",
   "ui.service_url": "服务地址",
   "ui.port": "端口",
   "ui.cli_link": "命令行集成",

--- a/src/layout/components/setup.tsx
+++ b/src/layout/components/setup.tsx
@@ -23,7 +23,14 @@ const STATUS_ICONS: Record<SetupStatus, IconComponent> = {
  */
 export function Setup() {
   const { t } = useTranslation()
-  const { status, installer, errorMsg, errorLogs, pluginConflictHint } = useStore(store.harness)
+  const {
+    status,
+    installer,
+    errorMsg,
+    errorLogs,
+    pluginConflictHint,
+    inotifyLimitHint,
+  } = useStore(store.harness)
   const error = status === 'error'
   const installing = status === 'installing'
   const heading = error ? t('status.error') : installer.title || t('status.installing')
@@ -33,6 +40,8 @@ export function Setup() {
   const logs = installing
     ? installer.logs
     : (error && errorLogs.length > 0 ? errorLogs : undefined)
+  // 错误态的针对性提示：插件路由冲突 / Linux inotify 文件监视上限，二选一优先展示
+  const hint = error ? (pluginConflictHint || inotifyLimitHint) : undefined
 
   return (
     <Loadable
@@ -44,8 +53,8 @@ export function Setup() {
       errorMsg={error ? errorMsg : undefined}
       onRetry={error ? store.harness.boot : undefined}
     >
-      {error && pluginConflictHint && (
-        <p className="m-0 text-xs leading-[18px] break-all text-load-muted">{pluginConflictHint}</p>
+      {hint && (
+        <p className="m-0 text-xs leading-[18px] break-all text-load-muted">{hint}</p>
       )}
     </Loadable>
   )

--- a/src/store/modules/harness/store.ts
+++ b/src/store/modules/harness/store.ts
@@ -17,7 +17,7 @@ import { listen } from '@tauri-apps/api/event'
 import i18next from 'i18next'
 import { defineStore } from 'valtio-define'
 import { queryClient } from '@/config/client'
-import { pickErrorLines } from '@/utils/log'
+import { containsInotifyLimitError, pickErrorLines } from '@/utils/log'
 import { harnessUpdater } from '../harness-updater'
 
 const MAX_RETRIES = 8
@@ -31,6 +31,8 @@ interface StartupError extends Error {
   /** 完整清洗后的日志尾（供插件异常定位使用，非仅错误行） */
   logLines?: string[]
   pluginConflictHint?: string
+  /** Linux inotify 文件监视上限（ENOSPC）导致服务启动即崩溃时的针对性提示 */
+  inotifyLimitHint?: string
 }
 
 const initialInstaller: InstallerState = {
@@ -135,6 +137,11 @@ async function attachStartupDiagnostics(err: unknown): Promise<StartupError> {
     if (lines.join('\n').includes('duplicate prefix route')) {
       startupError.pluginConflictHint = i18next.t('errors.plugin_route_conflict')
     }
+    // 识别 Linux inotify 文件监视上限（ENOSPC）：harness 服务启动即崩溃且用户无法直接解决，
+    // 需要系统级调高 fs.inotify.max_user_watches（见 errors.inotify_limit 文案）
+    if (containsInotifyLimitError(lines)) {
+      startupError.inotifyLimitHint = i18next.t('errors.inotify_limit')
+    }
   }
   return startupError as StartupError
 }
@@ -156,6 +163,8 @@ export const harness = defineStore({
     errorLogs: [] as string[],
     /** 识别到插件路由冲突时的针对性提示（Loadable children 展示） */
     pluginConflictHint: '',
+    /** 识别到 Linux inotify 文件监视上限（ENOSPC）时的针对性提示（Loadable children 展示） */
+    inotifyLimitHint: '',
     /** 插件异常修复界面状态（启动崩溃/运行期异常 → 弹出「卸除此插件并继续检测」） */
     recovery: initialRecovery,
     /** 用户已「暂不处理」的插件 id（避免同一运行期异常反复弹窗） */
@@ -273,6 +282,7 @@ export const harness = defineStore({
       this.errorMsg = ''
       this.errorLogs = []
       this.pluginConflictHint = ''
+      this.inotifyLimitHint = ''
       this.recovery = initialRecovery
       this.dismissedRecoveryIds = []
       this.serviceHealthy = false
@@ -342,6 +352,7 @@ export const harness = defineStore({
       this.errorMsg = ''
       this.errorLogs = []
       this.pluginConflictHint = ''
+      this.inotifyLimitHint = ''
       this.recovery = { required: false, info: null, attempts: this.recovery.attempts, busy: false }
       this.status = 'ready'
       let unlistenInstall: UnlistenFn | null = null
@@ -416,7 +427,12 @@ export const harness = defineStore({
         const startupError = await attachStartupDiagnostics(err)
         // 尝试从日志定位问题插件：能定位则弹出修复界面（全屏恢复页）
         await this.reviewStartupRecovery(startupError.logLines ?? startupError.logs ?? [])
-        this.fail(String(startupError), startupError.logs, startupError.pluginConflictHint)
+        this.fail(
+          String(startupError),
+          startupError.logs,
+          startupError.pluginConflictHint,
+          startupError.inotifyLimitHint,
+        )
       }
       finally {
         unlistenInstall?.()
@@ -430,10 +446,11 @@ export const harness = defineStore({
     },
 
     /** 进入错误态（供本模块与 updater 模块共用） */
-    fail(message: string, logs?: string[], pluginConflictHint?: string) {
+    fail(message: string, logs?: string[], pluginConflictHint?: string, inotifyLimitHint?: string) {
       this.errorMsg = message
       this.errorLogs = logs ?? []
       this.pluginConflictHint = pluginConflictHint ?? ''
+      this.inotifyLimitHint = inotifyLimitHint ?? ''
       this.status = 'error'
       this.serviceRunning = false
     },
@@ -552,6 +569,7 @@ export const harness = defineStore({
       this.errorMsg = i18next.t('ui.stopped')
       this.errorLogs = []
       this.pluginConflictHint = ''
+      this.inotifyLimitHint = ''
       this.recovery = initialRecovery
       this.dismissedRecoveryIds = []
     },

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -26,3 +26,16 @@ export function pickErrorLines(lines: readonly string[]): string[] {
   const errored = lines.filter(line => ERROR_LINE_MARKERS.test(line)).slice(0, 8)
   return errored.length > 0 ? errored : lines.slice(-8)
 }
+
+/**
+ * 判断日志是否命中 Linux 的 inotify 文件监视上限（ENOSPC）错误。
+ *
+ * harness 服务（dsh web）会用 chokidar 递归监视 `$DSH_HOME/profiles/*`，
+ * 当系统 `fs.inotify.max_user_watches` 上限过低（常见于 Docker/容器或新装 Ubuntu
+ * 默认值偏小）时，node 会抛 `ENOSPC: System limit for number of file watchers
+ * reached` 并直接退出，表现为「服务启动即崩溃」。这类错误对用户无解，必须提示
+ * 调高系统参数（见 errors.inotify_limit 文案）。纯函数，便于单元测试。
+ */
+export function containsInotifyLimitError(lines: readonly string[]): boolean {
+  return lines.some(line => /ENOSPC/i.test(line) && /file watchers/i.test(line))
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatLogLine, pickErrorLines } from '../src/utils/log'
+import { containsInotifyLimitError, formatLogLine, pickErrorLines } from '../src/utils/log'
 
 describe('formatLogLine', () => {
   it('strips the official GitHub release download prefix', () => {
@@ -39,5 +39,32 @@ describe('pickErrorLines', () => {
 
   it('handles empty input', () => {
     expect(pickErrorLines([])).toEqual([])
+  })
+})
+
+describe('containsInotifyLimitError', () => {
+  it('detects the Linux inotify ENOSPC signature', () => {
+    const lines = [
+      'Error: ENOSPC: System limit for number of file watchers reached, watch \'/home/u/.dsh/profiles/web\'',
+      '  code: \'ENOSPC\',',
+    ]
+    expect(containsInotifyLimitError(lines)).toBe(true)
+  })
+
+  it('is case-insensitive on the ENOSPC marker', () => {
+    expect(containsInotifyLimitError(['enospc: number of file watchers reached'])).toBe(true)
+  })
+
+  it('does not match a lone ENOSPC (must also mention file watchers)', () => {
+    expect(containsInotifyLimitError(['Error: ENOSPC: no space left on device'])).toBe(false)
+  })
+
+  it('does not match unrelated file-watcher lines', () => {
+    expect(containsInotifyLimitError(['file watchers initialized'])).toBe(false)
+    expect(containsInotifyLimitError(['watch /x started'])).toBe(false)
+  })
+
+  it('handles empty input', () => {
+    expect(containsInotifyLimitError([])).toBe(false)
   })
 })


### PR DESCRIPTION
### 问题
修复 #116 —— Ubuntu 26.04 启动崩溃。

harness 服务（dsh web）用 chokidar 递归监视 profile 目录。在 Linux 上，当系统 s.inotify.max_user_watches 上限被耗尽时，node 会抛 ENOSPC: System limit for number of file watchers reached 并直接退出，表现为「服务启动即崩溃」。日志还显示主窗口在 libwebkit2gtk-4.1.so.0 中 SIGSEGV（需禁用 compositing / DMABUF renderer 规避）。

### 改动
- **前端**：启动失败诊断时识别服务日志中的 ENOSPC 特征（containsInotifyLimitError），并给出针对性提示，指导用户调高 s.inotify.max_user_watches（如 sysctl 到 524288）。新增中英文文案 rrors.inotify_limit。
- **后端**：Unix 下启动服务前探测 inotify 监视上限，低于推荐最小值时在启动日志输出明确的修复命令（warn_if_inotify_watch_limit_low）。
- **WebKitGTK**：Wayland 下自动补齐 WEBKIT_DISABLE_COMPOSITING_MODE 与 WEBKIT_DISABLE_DMABUF_RENDERER 两个环境变量（与 README 一致），仅在缺失时补，避免覆盖用户手动设置。

### 测试
- 前端：containsInotifyLimitError 单元测试（命中 / 大小写 / 误判 / 空输入），pnpm typecheck、pnpm test、slint 全部通过。
- 后端：inotify 助手单元测试（Unix-gated），cargo check 无警告。

Close #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup diagnostics for systems with low Linux file-watcher limits.
  * Displays localized recovery instructions when the file-watcher limit prevents startup.
  * Improved Wayland compatibility by applying required rendering settings independently.

* **Bug Fixes**
  * Detects file-watcher limit failures more reliably and preserves user-configured rendering settings.

* **Tests**
  * Added coverage for file-watcher error detection and system-limit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->