### PR TITLE
fix: allow dragging the window by touch on the titlebar (#120)

### DIFF
--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -150,6 +150,17 @@ export function Navbar({ iframeRef }: NavbarProps) {
       void getCurrentWindow().toggleMaximize()
   }
 
+  function handleDragRegionPointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    // data-tauri-drag-region 原生只监听鼠标事件（mousedown/mouseup），
+    // 触摸屏/笔输入不会触发原生拖拽（见 tauri#13762）。
+    // 这里对非鼠标输入手动调用 startDragging 进入系统边拖边跟随。
+    if (event.pointerType === 'mouse')
+      return
+    // 阻止浏览器生成兼容鼠标事件，避免与 data-tauri-drag-region 的原生拖拽重复触发。
+    event.preventDefault()
+    void getCurrentWindow().startDragging()
+  }
+
   function handleHelpAction(key: string) {
     if (key === 'check-update')
       void handleCheckUpdate()
@@ -313,10 +324,12 @@ export function Navbar({ iframeRef }: NavbarProps) {
         </Chip>
       </If>
 
-      {/* 拖拽区：Tauri 原生拖拽（仅此元素带 data-tauri-drag-region，按钮不受影响） */}
+      {/* 拖拽区：Tauri 原生拖拽（仅此元素带 data-tauri-drag-region，按钮不受影响）。
+           touch-none 让触摸被当作拖拽而非滚动/平移手势，配合 onPointerDown 支持触摸/笔。 */}
       <div
-        className="min-w-0 flex-1 self-stretch"
+        className="min-w-0 flex-1 self-stretch touch-none"
         data-tauri-drag-region
+        onPointerDown={handleDragRegionPointerDown}
         onDoubleClick={handleDragRegionDoubleClick}
       />
 


### PR DESCRIPTION
### 问题

触摸屏设备上无法通过触摸拖动顶栏空白区域移动窗口；鼠标拖动同一区域正常。（#120）

### 根因

顶栏拖拽区依赖 Tauri 的 `data-tauri-drag-region`，而它仅用**鼠标事件**（`mousedown`/`mouseup`）实现，触摸/笔输入永远进不了原生窗口拖拽循环（见 tauri#13762 与 [drag.js](https://github.com/tauri-apps/tauri/blob/dev/crates/tauri/src/window/scripts/drag.js)）。因此触摸时窗口纹丝不动，鼠标却正常。

### 改动

在 `src/layout/components/navbar.tsx` 的拖拽区上新增指针事件处理：

- 非鼠标输入（触摸/笔）时调用 `getCurrentWindow().startDragging()` 进入系统窗口拖拽循环，窗口随手指/笔移动；
- `event.preventDefault()` 抑制浏览器生成的兼容 `mousedown`，避免与 `data-tauri-drag-region` 原生拖拽**重复触发**；
- 加 `touch-none`（`touch-action: none`），让浏览器把该手势当作拖拽而非滚动/平移。

鼠标行为不变（仍走原生拖拽区）。

### 验证

- `pnpm typecheck` 通过
- `npx eslint src/layout/components/navbar.tsx` 通过
- 无需新增 i18n 文案

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navbar dragging support for touch and pen input.
  * Preserved native mouse dragging behavior while preventing unintended compatibility events on touch devices.
  * Updated the drag region to handle touch interactions more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->