### PR TITLE
fix(plugin): 修复预装插件安装时 pnpm shim 找不到 node（issue #121）

### DIFF
--- a/docs/testing/06-plugin/04-预装插件安装引导.md
+++ b/docs/testing/06-plugin/04-预装插件安装引导.md
@@ -39,3 +39,10 @@
 [前置条件] 预装引导列出 dshmarket（repoUrl 为 https://github.com/dsh-market/dsh-market）
 [测试步骤] 1. 在引导页点击 dshmarket 的「打开仓库」。2. 调用 open_preinstall_repo（id 为 dshmarket）观察系统浏览器。3. 调用 open_preinstall_repo（id 为 unknown-package）
 [预期结果] 1. 系统浏览器打开该插件仓库首页。2. 浏览器地址为 https://github.com/dsh-market/dsh-market，与 preset-plugins.json 的 repoUrl 一致。3. 传入非法 id 返回 PREINSTALL_INVALID_ID，浏览器未打开任何页面
+
+## [P2] 验证预检通过但 pnpm shim 找不到 node 时安装仍成功（issue #121）
+
+[测试类型] 兼容性
+[前置条件] Windows 平台；应用预检通过（Node.js 运行时可用：本机兼容 node 或捆绑运行时）；`%APP_DIR%\runtime\node.exe` 不存在（复用本机 node 场景）或子进程 PATH 无法解析到 node（相对 PATH 条目 / junction / 子进程 PATH 布局差异）
+[测试步骤] 1. 构造上述环境后进入预装引导勾选插件并点击「安装」。2. 观察安装日志与 dsh/pnpm 子进程环境。3. 核对 pnpm.cmd shim 内容与 build_plugin_envs 注入
+[预期结果] 1. 安装不再出现 `[pnpm] Node.js runtime not found`；dsh plugin 子进程成功执行 pnpm 完成安装。2. 子进程环境变量含 DSH_NODE（值为 get_node_binary_path 规范化后的绝对路径），pnpm.cmd shim 的 node 解析优先采用 DSH_NODE（`if defined DSH_NODE ... goto :node_dsh`），其次本地 node，最后捆绑运行时。3. 终端（无 DSH_NODE）下 shim 行为不变：仍按「本地兼容 node → 捆绑运行时」顺序解析

--- a/src-tauri/src/service/cli/shim.rs
+++ b/src-tauri/src/service/cli/shim.rs
@@ -23,17 +23,26 @@ pub const PNPM_SHIM_SH_NAME: &str = "pnpm";
 // ---------------------------------------------------------------------------
 // shim 共享片段：node 解析逻辑（dsh / pnpm shim 共用）
 //
-// 规则：优先 PATH 中版本兼容的本地 node（v22.15+ / v23.8+ / v24+，
-// 与 config::is_supported_node_version 一致），否则回退捆绑运行时。
+// 规则：优先 `DSH_NODE` 环境变量（桌面端注入其已解析并核验过的 node 路径，
+// 保证 shim 与应用预检一致），其次 PATH 中版本兼容的本地 node（v22.15+ /
+// v23.8+ / v24+，与 config::is_supported_node_version 一致），否则回退捆绑
+// 运行时。`DSH_NODE` 只在桌面端自身派生的子进程里存在，终端用户环境不受影响。
 // 变量约定：cmd 用 %APP_DIR%，ps1 用 $appDir，sh 用 $APP_DIR。
 // 这些常量作为 format! 的参数传入，其中的 `{`/`}` 是字面量。
 // ---------------------------------------------------------------------------
 
 const CMD_NODE_RESOLVE: &str = r#"
-rem Prefer a version-compatible local node, fall back to the bundled runtime.
+rem Prefer the desktop-resolved node (DSH_NODE, injected by the app into its
+rem own child processes), then a version-compatible local node, then the
+rem bundled runtime. DSH_NODE makes the shim and the app's pre-check agree:
+rem the app verified the node exists before spawning the child, and the shim
+rem must not re-derive it from PATH (which can miss nodes the app found).
 rem Pure batch version check (for /f tokens + numeric compare), no powershell
 rem child: avoids console flashes when invoked without a console and skips the
 rem per-call powershell startup cost.
+if defined DSH_NODE (
+  if exist "%DSH_NODE%" goto :node_dsh
+)
 where node >nul 2>nul
 if errorlevel 1 goto :use_bundled
 for /f "tokens=1,2 delims=v." %%a in ('node --version 2^>nul ^| findstr /b "v"') do set "NODE_MAJOR=%%a" & set "NODE_MINOR=%%b"
@@ -47,6 +56,10 @@ goto :use_bundled
 set "NODE=node"
 goto :launch
 
+:node_dsh
+set "NODE=%DSH_NODE%"
+goto :launch
+
 :use_bundled
 if not exist "%APP_DIR%\runtime\node.exe" goto :no_node
 set "NODE=%APP_DIR%\runtime\node.exe"
@@ -54,20 +67,27 @@ set "PATH=%APP_DIR%\runtime;%PATH%"
 "#;
 
 const PS1_NODE_RESOLVE: &str = r#"
-# Prefer a version-compatible local node, fall back to the bundled runtime.
+# Prefer the desktop-resolved node (DSH_NODE, injected by the app into its
+# own child processes), then a version-compatible local node, then the
+# bundled runtime — see the CMD shim for why DSH_NODE wins first.
 $node = $null
-$localNode = Get-Command node -ErrorAction SilentlyContinue
-if ($localNode) {
-    try {
-        $version = & node --version 2>$null
-        if ($version -match '^v(\d+)\.(\d+)') {
-            $major = [int]$matches[1]
-            $minor = [int]$matches[2]
-            if (($major -eq 22 -and $minor -ge 15) -or ($major -eq 23 -and $minor -ge 8) -or $major -ge 24) {
-                $node = 'node'
+if ($env:DSH_NODE -and (Test-Path -LiteralPath $env:DSH_NODE)) {
+    $node = $env:DSH_NODE
+}
+if (-not $node) {
+    $localNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($localNode) {
+        try {
+            $version = & node --version 2>$null
+            if ($version -match '^v(\d+)\.(\d+)') {
+                $major = [int]$matches[1]
+                $minor = [int]$matches[2]
+                if (($major -eq 22 -and $minor -ge 15) -or ($major -eq 23 -and $minor -ge 8) -or $major -ge 24) {
+                    $node = 'node'
+                }
             }
-        }
-    } catch { }
+        } catch { }
+    }
 }
 if (-not $node) {
     $bundled = Join-Path $appDir 'runtime\node.exe'
@@ -84,7 +104,13 @@ if (-not $node) {
 
 const SH_NODE_RESOLVE: &str = r#"
 NODE=""
-if command -v node >/dev/null 2>&1; then
+# Prefer the desktop-resolved node (DSH_NODE, injected by the app into its
+# own child processes), then a version-compatible local node, then the
+# bundled runtime — see the CMD shim for why DSH_NODE wins first.
+if [ -n "$DSH_NODE" ] && [ -x "$DSH_NODE" ]; then
+  NODE="$DSH_NODE"
+fi
+if [ -z "$NODE" ] && command -v node >/dev/null 2>&1; then
   NODE_V=$(node --version 2>/dev/null)
   MAJOR=$(printf '%s' "$NODE_V" | awk -F. '{ gsub(/^v/, "", $1); print $1 }')
   MINOR=$(printf '%s' "$NODE_V" | awk -F. '{ print $2 }')
@@ -718,6 +744,53 @@ mod tests {
         assert!(content.contains(r#"exec "$NODE" "$PNPM_BIN" "$@""#));
         assert!(content.contains(r#"$APP_DIR/runtime/bin/node"#));
         assert!(content.contains("DSH_PREFER_BUNDLED_PNPM"));
+    }
+
+    /// issue #121：桌面端注入的 DSH_NODE（预检解析出的 node 路径）必须在
+    /// 本地 node / 捆绑运行时解析之前被采用——shim 与应用预检保持一致。
+    #[test]
+    fn cmd_shim_prefers_dsh_node_before_local_node() {
+        let content = build_cmd_shim(&sample_app_dir(), &sample_dsh_home());
+        let dsh_node_at = content.find("DSH_NODE").unwrap();
+        let where_node_at = content.find("where node").unwrap();
+        // `:node_dsh` 标签行（独占一行）位于 `:node_ok` 之后、`:use_bundled`
+        // 之前；`goto :node_dsh` 引用出现在 `where node` 之前，不能作为定位点。
+        let node_dsh_label_at = content.find("\n:node_dsh").unwrap();
+        let node_ok_at = content.find("\n:node_ok").unwrap();
+        assert!(
+            dsh_node_at < where_node_at,
+            "DSH_NODE must be checked before the local node search"
+        );
+        assert!(content.contains(r#"set "NODE=%DSH_NODE%""#));
+        assert!(
+            node_ok_at < node_dsh_label_at,
+            "the :node_dsh label must come after :node_ok"
+        );
+    }
+
+    #[test]
+    fn ps1_shim_prefers_dsh_node_before_local_node() {
+        let content = build_ps1_shim(&sample_app_dir(), &sample_dsh_home());
+        let dsh_node_at = content.find("$env:DSH_NODE").unwrap();
+        let local_at = content.find("Get-Command node").unwrap();
+        assert!(
+            dsh_node_at < local_at,
+            "DSH_NODE must be checked before the local node search"
+        );
+    }
+
+    #[test]
+    fn sh_shim_prefers_dsh_node_before_local_node() {
+        #[cfg(not(windows))]
+        {
+            let content = build_sh_shim(&sample_app_dir(), &sample_dsh_home());
+            let dsh_node_at = content.find("$DSH_NODE").unwrap();
+            let local_at = content.find("command -v node").unwrap();
+            assert!(
+                dsh_node_at < local_at,
+                "DSH_NODE must be checked before the local node search"
+            );
+        }
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -304,13 +304,20 @@ fn silent_install_failure_detail(missing: &[(String, PathBuf)], command_output: 
     )
 }
 
-/// 构建 `dsh plugin` 子进程的环境变量：隔离 $DSH_HOME、关闭遥测与颜色，
+/// 构建 `dsh plugin` 子进程的环境变量：隔离 $DSH_HOME、关闭遥测与颜色、
+/// 注入预检解析出的 node 路径（`DSH_NODE`，shim 优先采用，见 shim.rs）、
 /// PATH 前置 shim 目录与 node 目录；用户 pnpm 过旧时强制捆绑版（见 ensure_pnpm）。
 ///
 /// 供本模块的安装/升级/卸载与 [`super::verify`] 的完整性修复共用：子进程（dsh
 /// 或 pnpm）都按同一套桌面端环境策略运行，保证 $DSH_HOME / PATH 布局一致。
 pub(crate) fn build_plugin_envs(app_handle: &AppHandle, prefer_bundled_pnpm: bool) -> HashMap<String, String> {
     let node = config::get_node_binary_path(app_handle);
+    // 规范化为绝对路径：get_node_binary_path 可能返回相对路径（PATH 上出现
+    // 相对条目时，如 `.` 或 `tools\node`），而子进程 CWD 与应用进程不同，
+    // 相对路径会被解析到错误位置——shim 经 DSH_NODE / PATH 都找不到 node
+    // （issue #121 的 "Node.js runtime not found"）。已存在（预检通过）的
+    // node 可安全 canonicalize；失败时回退原值。
+    let node_abs = std::fs::canonicalize(&node).unwrap_or_else(|_| node.clone());
     let bin_dir = cli::get_bin_dir(app_handle);
     let mut envs = HashMap::from([
         (
@@ -321,6 +328,14 @@ pub(crate) fn build_plugin_envs(app_handle: &AppHandle, prefer_bundled_pnpm: boo
         ),
         ("DSH_TELEMETRY_DISABLED".to_string(), "1".to_string()),
         ("NO_COLOR".to_string(), "1".to_string()),
+        // 把预检解析出的 node 路径显式交给 pnpm/dsh shim（DSH_NODE 优先）：
+        // shim 自身经 PATH 解析 node 可能与应用预检不一致（PATH 上的相对条目、
+        // junction/符号链接、或子进程 PATH 布局差异），导致 pnpm shim 报
+        // "Node.js runtime not found" 而应用预检却通过（issue #121）。
+        (
+            "DSH_NODE".to_string(),
+            node_abs.to_string_lossy().into_owned(),
+        ),
     ]);
     // 用户 pnpm 过旧/不可探测时强制 pnpm shim 优先捆绑版，避免 8/9 的
     // autoInstallPeers 语义与 workspace-root gate 破坏插件安装（见 ensure_pnpm）
@@ -329,7 +344,7 @@ pub(crate) fn build_plugin_envs(app_handle: &AppHandle, prefer_bundled_pnpm: boo
     }
 
     let mut paths = vec![bin_dir];
-    if let Some(node_dir) = node.parent() {
+    if let Some(node_dir) = node_abs.parent() {
         paths.push(node_dir.to_path_buf());
     }
     paths.extend(std::env::split_paths(

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -824,6 +824,18 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     envs.insert("DSH_TELEMETRY_DISABLED".to_string(), "1".to_string());
     envs.insert("NO_COLOR".to_string(), "1".to_string());
     envs.insert("DSH_WEB_PORT".to_string(), setting.port.to_string());
+    // 把服务实际使用的 node 路径显式交给子进程（pnpm/dsh shim 的 DSH_NODE
+    // 优先）：市场（dsh-market）等子进程经 PATH 解析 node 可能与桌面端预检
+    // 不一致（相对 PATH 条目 / junction / 子进程 PATH 布局差异），导致 pnpm
+    // shim 报 "Node.js runtime not found"（issue #121，与 build_plugin_envs
+    // 的注入保持一致）。先规范化为绝对路径：相对路径在子进程 CWD 下会解析
+    // 到错误位置；已存在（上面校验过）的 node 可安全 canonicalize。
+    let node_abs = std::fs::canonicalize(&node_binary_path)
+        .unwrap_or_else(|_| node_binary_path.clone());
+    envs.insert(
+        "DSH_NODE".to_string(),
+        node_abs.to_string_lossy().into_owned(),
+    );
 
     // 扩展 PATH，让 dsh 及其子进程能找到 node；Windows 上再注入 Git Bash 的
     // bin 目录：persistent bash（--noprofile --norc）不执行 profile 脚本、PATH


### PR DESCRIPTION
### 问题

Windows 下安装预设插件报 `[pnpm] Node.js runtime not found`，但应用预检通过。

### 根因

`install()` 的预检用 `get_node_binary_path()`（优先 PATH 上版本兼容的本地 node，其次捆绑运行时）判定 node 可用；而 pnpm shim 独立按「`where node`(PATH) → `%APP_DIR%\runtime\node.exe`(捆绑运行时)」解析 node。两者不一致时 shim 即失败：

- 复用本机 node 时捆绑运行时未被下载（`runtime\node.exe` 不存在）；
- 本机 node 经**相对 PATH 条目**（如 `.` 或 `tools\node`）找到时，子进程 CWD 与应用不同，相对路径解析错位，`where node` 找不到；
- junction / 符号链接 / 子进程 PATH 布局差异同理。

shim 走到 `:use_bundled` → `runtime\node.exe` 缺失 → `:no_node`，于是「预检通过但 pnpm shim 找不到 Node」。

### 修复

让 shim 与应用预检**按构造一致**：

1. `service/cli/shim.rs`：三种 shim（cmd/ps1/sh）的 node 解析新增 `DSH_NODE` 优先分支（`if defined DSH_NODE ... goto :node_dsh`），其次本地 node，最后捆绑运行时；终端（无 `DSH_NODE`）行为不变。
2. `service/plugin/install.rs`：`build_plugin_envs`（安装/升级/卸载/完整性修复共用）把 `get_node_binary_path()` 结果 `canonicalize` 为绝对路径后注入 `DSH_NODE`，PATH 前置目录同步改用规范化路径。
3. `service/workflow/mod.rs`：服务进程环境同样注入 `DSH_NODE`，覆盖 dsh-market 等市场子进程。
4. 补充回归测试用例文档。

### 验证

- `cargo check` 无警告；`cargo test` 230 通过 / 0 失败（含 3 个新增 DSH_NODE 优先级单测）。
- 本机实测：PATH 无 node、无捆绑运行时 + 注入 `DSH_NODE` → shim 用 DSH_NODE 的 node 正常执行 pnpm；不注入则复现原报错。

Closes #121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows plugin installation when Node.js is detected but cannot be resolved through the standard path.
  * Plugin and workflow processes now reliably use the configured Node.js runtime.
  * Preserved existing terminal behavior when the enhanced runtime setting is unavailable.

* **Tests**
  * Added compatibility coverage for Node.js resolution across supported shell and shim formats.
  * Added a Windows preinstalled-plugin installation test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->