### PR TITLE
chore: release v0.8.3-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.8.2",
+  "version": "0.8.3-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.8.2"
+version = "0.8.3-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.8.2"
+version = "0.8.3-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.8.2",
+  "version": "0.8.3-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.8.3-beta.1` (`0.8.2` → `0.8.3-beta.1`).

### Bug Fixes

- **plugin**: 兼容 pnpm 10 安装预设插件时 onlyBuiltDependencies 放行项 (#125) (3881b2d)
- **plugin**: 兼容 pnpm 10 安装预设插件时 onlyBuiltDependencies 放行项 (#123) (ec9d5ba)
- **plugin**: 预装插件安装时 pnpm shim 找不到 node（issue #121） (#124) (b0c4722)
- recover delayed plugin startup (#118) (4a4a979)
- allow dragging the window by touch on the titlebar (#122) (f6cd297)
- detect Linux inotify watcher limit crash on startup (#116, #119) (c9db151)

### Chores

- update script release (1935c59)
- update internal plugin (b8cd5cc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.8.3-beta.1** across all release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->