### PR TITLE
fix: stabilize Windows pnpm plugin execution

### DIFF
--- a/src-tauri/src/service/cli/shim.rs
+++ b/src-tauri/src/service/cli/shim.rs
@@ -352,6 +352,11 @@ setlocal
 set "APP_DIR={app_dir}"
 set "PNPM_BIN={pnpm_bin}"
 
+rem Use the absolute user pnpm selected and validated by the desktop app.
+if defined DSH_PNPM (
+  if exist "%DSH_PNPM%" goto :use_selected
+)
+
 rem App-internal installs (DSH_PREFER_BUNDLED_PNPM=1) use the bundled pnpm,
 rem falling back to the user's only when the bundled one is missing.
 if "%DSH_PREFER_BUNDLED_PNPM%"=="1" (
@@ -376,10 +381,17 @@ for /f "delims=" %%p in ('where pnpm 2^>nul') do (
     )
   )
 )
-if defined USER_PNPM (
-  call "%USER_PNPM%" %*
-  exit /b %ERRORLEVEL%
-)
+if defined USER_PNPM goto :use_user
+
+goto :after_user
+
+:use_selected
+call "%DSH_PNPM%" %*
+exit /b %ERRORLEVEL%
+
+:use_user
+call "%USER_PNPM%" %*
+exit /b %ERRORLEVEL%
 
 :after_user
 {node_resolve}
@@ -722,6 +734,52 @@ mod tests {
         let env_at = content.find("DSH_PREFER_BUNDLED_PNPM").unwrap();
         let user_at = content.find("where pnpm").unwrap();
         assert!(env_at < user_at);
+    }
+
+    /// issue #130：真实执行生成的 cmd shim，确保用户 pnpm 的失败码不会因 cmd
+    /// 括号块预展开 `%ERRORLEVEL%` 而被吞成 0。
+    #[cfg(windows)]
+    #[test]
+    fn pnpm_cmd_shim_propagates_user_exit_code_in_real_cmd() {
+        let dir = temp_dir("pnpm-exit-code");
+        let shim_dir = dir.join("desktop-bin");
+        let user_dir = dir.join("user-bin");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        std::fs::create_dir_all(&user_dir).unwrap();
+        let shim = shim_dir.join("pnpm.cmd");
+        std::fs::write(&shim, build_pnpm_cmd_shim(&dir.join("app"))).unwrap();
+        std::fs::write(user_dir.join("pnpm.cmd"), "@echo off\r\necho REAL_USER_PNPM\r\nexit /b 37\r\n").unwrap();
+        let system_root = std::env::var_os("SystemRoot").unwrap_or_else(|| "C:\\Windows".into());
+        let system32 = PathBuf::from(&system_root).join("System32");
+        let path = std::env::join_paths([&shim_dir, &user_dir, &system32]).unwrap();
+        let output = std::process::Command::new(system32.join("cmd.exe"))
+            .args(["/d", "/c"]).arg(&shim).arg("--version")
+            .env("PATH", path).env("SystemRoot", system_root).output().unwrap();
+        assert_eq!(output.status.code(), Some(37));
+        assert!(String::from_utf8_lossy(&output.stdout).contains("REAL_USER_PNPM"));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// issue #121：选定 pnpm 即使不在子进程 PATH 中，也必须由 shim 执行。
+    #[cfg(windows)]
+    #[test]
+    fn pnpm_cmd_shim_uses_selected_pnpm_with_restricted_path() {
+        let dir = temp_dir("pnpm-selected");
+        let selected = dir.join("selected-pnpm.cmd");
+        std::fs::write(&selected, "@echo off\r\necho SELECTED_PNPM %*\r\nexit /b 0\r\n").unwrap();
+        let selected = dunce::canonicalize(&selected).unwrap();
+        assert!(!selected.to_string_lossy().starts_with(r"\\?\"));
+        let shim = dir.join("pnpm.cmd");
+        std::fs::write(&shim, build_pnpm_cmd_shim(&dir.join("app"))).unwrap();
+        let system_root = std::env::var_os("SystemRoot").unwrap_or_else(|| "C:\\Windows".into());
+        let system32 = PathBuf::from(&system_root).join("System32");
+        let output = std::process::Command::new(system32.join("cmd.exe"))
+            .args(["/d", "/c"]).arg(&shim).arg("probe-121")
+            .env("PATH", &system32).env("SystemRoot", system_root)
+            .env("DSH_PNPM", &selected).output().unwrap();
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("SELECTED_PNPM probe-121"));
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -110,6 +110,9 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
 
     // 选定/补齐安装用的 pnpm：返回是否应强制使用捆绑版（版本感知，见 ensure_pnpm）
     let prefer_bundled_pnpm = ensure_pnpm(app_handle, &window).await?;
+    // 首次安装可能早于服务启动；提前写入非交互清理配置，避免 pnpm 在无 TTY
+    // 环境以 ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY 中止（issue #130）。
+    super::ensure_profile_npmrc(app_handle)?;
 
     // 安装前停止运行中的服务，避免资源冲突
     if workflow::has_owned_process() {
@@ -322,7 +325,7 @@ pub(crate) fn build_plugin_envs(app_handle: &AppHandle, prefer_bundled_pnpm: boo
     // 相对路径会被解析到错误位置——shim 经 DSH_NODE / PATH 都找不到 node
     // （issue #121 的 "Node.js runtime not found"）。已存在（预检通过）的
     // node 可安全 canonicalize；失败时回退原值。
-    let node_abs = std::fs::canonicalize(&node).unwrap_or_else(|_| node.clone());
+    let node_abs = dunce::canonicalize(&node).unwrap_or_else(|_| node.clone());
     let bin_dir = cli::get_bin_dir(app_handle);
     let mut envs = HashMap::from([
         (
@@ -346,6 +349,19 @@ pub(crate) fn build_plugin_envs(app_handle: &AppHandle, prefer_bundled_pnpm: boo
     // autoInstallPeers 语义与 workspace-root gate 破坏插件安装（见 ensure_pnpm）
     if prefer_bundled_pnpm {
         envs.insert("DSH_PREFER_BUNDLED_PNPM".to_string(), "1".to_string());
+    } else if let Some(pnpm) = cli::find_user_pnpm(app_handle) {
+        // 应用预检选到的用户 pnpm 可能来自相对 PATH / junction；显式注入其绝对
+        // 路径，避免 dsh 子进程在不同 PATH/CWD 下重新发现失败（issue #121）。
+        // 防御性排除应用自身 shim，避免旧 PATH / 大小写差异导致递归调用。
+        // `cmd.exe` 无法 `call` 带 `\\?\` 前缀的 .cmd；dunce 同时剥离该前缀。
+        let pnpm_abs = dunce::canonicalize(&pnpm).unwrap_or(pnpm);
+        let shim_dir = dunce::canonicalize(&bin_dir).unwrap_or_else(|_| bin_dir.clone());
+        if pnpm_abs.parent() != Some(shim_dir.as_path()) {
+            envs.insert(
+                "DSH_PNPM".to_string(),
+                pnpm_abs.to_string_lossy().into_owned(),
+            );
+        }
     }
 
     let mut paths = vec![bin_dir];
@@ -509,6 +525,8 @@ async fn run_single_plugin_command(
     }
 
     let prefer_bundled_pnpm = ensure_pnpm(app_handle, &window).await?;
+    // `.npmrc` 可能在服务启动后被删除；升级/卸载同样可能触发 pnpm 非交互清理。
+    super::ensure_profile_npmrc(app_handle)?;
 
     // 插件操作会改写 profile，先停止运行中的服务（与安装一致）
     if workflow::has_owned_process() {


### PR DESCRIPTION
## Summary
- pass the desktop-selected user pnpm to child shims through a normalized absolute `DSH_PNPM` path, fixing the reopened #121 PATH/CWD mismatch
- preserve the real Windows pnpm exit code by leaving the cmd parenthesized block before expanding `%ERRORLEVEL%`, fixing #130 false-success artifact errors
- ensure `confirmModulesPurge=false` before install/update/remove to avoid non-TTY pnpm module purge aborts
- add real `cmd.exe` regression tests for restricted-PATH selected pnpm and exit-code 37 propagation

## Root causes
- #121: the app could validate a user pnpm that the nested dsh process could not rediscover from its PATH/CWD
- #130: `%ERRORLEVEL%` inside the generated parenthesized cmd block was expanded before `call`, turning pnpm failures into exit 0; pnpm could also abort module cleanup without a TTY

## Validation
- `cargo test --no-fail-fast` (241 passed)
- `cargo check`
- `git diff --check`
- generated shim executed against a real user pnpm and returned its non-zero failure status

Fixes #121
Fixes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin installation, upgrades, and removals now work reliably when the profile’s npm configuration file is missing.
  - The desktop-selected pnpm executable is now honored on Windows when available.
  - pnpm commands more reliably preserve and return their actual exit codes.
  - Plugin operations use consistent environment settings across installation workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->