### PR TITLE
fix(windows): support touch window dragging

### DIFF
--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -27,6 +27,19 @@ use crate::desktop::window::on_page_load;
 use crate::desktop::window::{on_download, on_new_window};
 use crate::utils::show_main_window;
 
+/// WebView2 原生拖拽区域所需的参数。
+///
+/// `data-tauri-drag-region` 的兼容脚本只处理鼠标事件；WebView2 的原生
+/// `app-region: drag` 才能让触摸输入进入窗口非客户区拖拽。ElasticOverscroll
+/// 会抢走触摸手势，因此必须同时禁用。Wry 的默认安全功能也要显式保留。
+#[cfg(windows)]
+const WINDOWS_DRAG_BROWSER_ARGS: &str = "--enable-features=msWebView2EnableDraggableRegions --disable-features=ElasticOverscroll,msWebOOUI,msPdfOOUI,msSmartScreenProtection";
+
+#[cfg(windows)]
+fn windows_drag_browser_args() -> &'static str {
+    WINDOWS_DRAG_BROWSER_ARGS
+}
+
 /// setup app
 pub fn setup(app_handle: tauri::AppHandle) {
     // 启动前清扫上次崩溃残留的孤儿 Harness（端口/PID 双重确认，见
@@ -325,7 +338,10 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
     // Windows/WebView2 在 build() 尚未返回时就可能绘制窗口。先隐藏创建，
     // 等保存的几何恢复完成再显示，避免启动时先闪出默认尺寸再跳到历史尺寸。
     #[cfg(windows)]
-    let webview_builder = webview_builder.visible(false);
+    let webview_builder = webview_builder
+        .visible(false)
+        // WebView2 原生非客户区可直接接收触摸输入；同时禁用会抢占手势的弹性滚动。
+        .additional_browser_args(windows_drag_browser_args());
 
     // macOS 保留原生交通灯：绿色按钮由 AppKit 进入独立 Space 的原生全屏，
     // 同时用 Overlay 让 44px 壳层导航栏继续与窗口 chrome 融合。其他平台
@@ -414,6 +430,19 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
     }
 
     Ok(webview_window)
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::windows_drag_browser_args;
+
+    #[test]
+    fn windows_drag_args_enable_touch_drag_and_disable_overscroll() {
+        let args = windows_drag_browser_args();
+        assert!(args.contains("--enable-features=msWebView2EnableDraggableRegions"));
+        assert!(args.contains("--disable-features=ElasticOverscroll"));
+        assert!(args.contains("msWebOOUI,msPdfOOUI,msSmartScreenProtection"));
+    }
 }
 
 // configure invoke handler

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -5,6 +5,13 @@
 
 @import "./components/scrollbar.css";
 
+/* WebView2 123+ 的原生拖拽区域支持触摸屏；Windows runtime 110+ 通过
+   msWebView2EnableDraggableRegions 参数启用。按钮不在该区域内，故无需 no-drag。 */
+[data-tauri-drag-region] {
+  app-region: drag;
+  -webkit-app-region: drag;
+}
+
 /* 主题变量：默认深色，html[data-theme="light"] 切换到浅色。
    取值与官方 dsw alias token（design-platform.css）逐项一致 */
 :root {


### PR DESCRIPTION
## Summary\n- enable WebView2 draggable regions for the manually-created main window\n- disable ElasticOverscroll, preserving Wry's default safety feature disables\n- add app-region drag CSS for data-tauri-drag-region\n- add Windows regression test for the browser argument contract\n\nFixes #120.\n\n## Validation\n- pnpm typecheck\n- pnpm lint\n- pnpm test -- --run\n- cargo check --all-features --locked\n- cargo test --all-features --locked\n- pnpm build\n\nThe WebView2 runtime must be version 110+ for draggable regions; the fix targets the actual manually-created Rust window builder rather than the unused config windows section.