### PR TITLE
chore: release v0.8.4-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.8.3",
+  "version": "0.8.4-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.8.3"
+version = "0.8.4-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.8.3"
+version = "0.8.4-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.8.3",
+  "version": "0.8.4-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.8.4-beta.1` (`0.8.3` → `0.8.4-beta.1`).

### Bug Fixes

- **tauri**: fix Windows data directory conflicts and update preset plugin versions (3a9b423)
- **windows**: support touch window dragging (7f14734)
- **windows**: support touch window dragging (2d7c2b6)
- stabilize Windows pnpm plugin execution (b092a82)
- stabilize pnpm plugin execution on Windows (c09a0f5)
- **windows**: provision Git in blank environments (#131) (e4c55c7)

### Styles

- **config**: Adjust the layout of the configuration component list and rmove show plugin versions (8641389)

### CI

- unify release workflow (c1cb0bc)

### Chores

- lint fix (2d14c2d)

### Other Changes

- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (8036aa4)
- Merge pull request #133 from dsh-tauri-desk/dsh/issues120 (53f039c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to **0.8.4-beta.1** across supported builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->