### PR TITLE
fix: show network errors during plugin install

### DIFF
--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -166,14 +166,31 @@ pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), Strin
         // 区分 git 传输层失败与 allowBuilds 构建门禁：前者是 pnpm 走了 git+ssh
         // （用户环境无 SSH 配置），后者才是补充白名单可自愈的。传输层错误给出
         // 可读指引，避免用户被 dsh 那条 allowBuilds 提示误导。
+        let network_error = network_error_hint(&last_output)
+            || (exit_code == 3 && last_output.trim().is_empty());
         let hint = git_transport_hint(&last_output);
-        let message = pick_error_message(&last_output, hint);
+        let network_hint = network_error.then_some(
+            "NETWORK_ERROR: plugin registry request failed; check network or proxy settings and retry.",
+        );
+        let message = network_hint
+            .or(hint)
+            .unwrap_or_else(|| pick_error_message(&last_output, None));
         // 批量安装失败时给本次选中的每个插件记一条错误（前端据此展示异常标记，
         // 可针对单个插件重试更新/卸载）
         for id in ids {
             if let Err(e) = errors::record(app_handle, id, "install", &message) {
                 log::warn!("failed to record plugin error for {id}: {e}");
             }
+        }
+        if let Some(network_hint) = network_hint {
+            log::warn!("network failure detected during plugin install: {network_hint}");
+            let _ = window.emit(
+                PREINSTALL_LOG_EVENT,
+                PreinstallLogPayload {
+                    line: format!("[network] {network_hint}"),
+                },
+            );
+            return Err(format!("NETWORK_ERROR: {network_hint}"));
         }
         if let Some(hint) = hint {
             log::warn!("git transport failure detected during plugin install: {hint}");
@@ -573,9 +590,19 @@ async fn run_single_plugin_command(
 
     if exit_code != 0 {
         log::error!("dsh plugin {action} failed for {id} with exit code {exit_code}");
-        let message = pick_error_message(&output, git_transport_hint(&output));
+        let network_error = network_error_hint(&output)
+            || (exit_code == 3 && output.trim().is_empty());
+        let message = if network_error {
+            "NETWORK_ERROR: plugin registry request failed; check network or proxy settings and retry."
+                .to_string()
+        } else {
+            pick_error_message(&output, git_transport_hint(&output))
+        };
         if let Err(e) = errors::record(app_handle, id, action, &message) {
             log::warn!("failed to record plugin error for {id}: {e}");
+        }
+        if network_error {
+            return Err("NETWORK_ERROR: plugin registry request failed; check network or proxy settings and retry.".to_string());
         }
         return Err(format!(
             "PLUGIN_{}_FAILED: dsh plugin exited with code {exit_code}",
@@ -1220,10 +1247,24 @@ fn shell_quote_spec(spec: &str) -> String {
     spec.to_string()
 }
 
-/// 从 pnpm 失败输出里识别 git 传输层错误（区别于 allowBuilds 构建门禁），命中时
-/// 返回一句可读的成因/指引。pnpm 在这些场景下已经退到 git+ssh，再去补 allowBuilds
-/// 白名单是无效且误导的。
-fn git_transport_hint(output: &str) -> Option<&'static str> {    const SIGNALS: &[(&str, &str)] = &[
+/// 从 pnpm 失败输出里识别网络错误，返回稳定提示，避免把网络问题误报为 dsh
+/// 子进程错误。代理、DNS、连接超时和 TLS 失败都属于此类。
+fn network_error_hint(output: &str) -> Option<&'static str> {
+    const SIGNALS: &[&str] = &[
+        "eai_again", "enotfound", "econnrefused", "econnreset", "etimedout",
+        "network timeout", "network request failed", "fetch failed",
+        "unable to verify the first certificate", "self signed certificate",
+        "socket hang up", "could not resolve host", "failed to connect",
+        "connection timed out", "connection reset",
+    ];
+    let lower = output.to_ascii_lowercase();
+    SIGNALS.iter().any(|signal| lower.contains(signal)).then_some(
+        "网络连接失败，请检查网络或代理设置后重试。",
+    )
+}
+
+fn git_transport_hint(output: &str) -> Option<&'static str> {
+    const SIGNALS: &[(&str, &str)] = &[
         (
             "host key verification failed",
             "git fell back to SSH and could not verify GitHub's host key (no known_hosts entry; the process ran non-interactively). Make sure GitHub is reachable over HTTPS.",
@@ -1278,7 +1319,7 @@ pub(crate) fn harness_prefer_bundled_pnpm(app_handle: &AppHandle) -> bool {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use super::{append_command_output, apply_allow_build_keys, collapse_allow_builds_duplicates, dep_path_to_name, extract_allow_line_key, extract_only_builds_git_name, git_transport_hint, normalize_git_spec, parse_allowlist_keys, parse_store_major_from_modules_yaml, preset_spec_for_install, shell_quote_spec, silent_install_failure_detail, PreinstallPluginInfo};
+    use super::{append_command_output, apply_allow_build_keys, collapse_allow_builds_duplicates, dep_path_to_name, extract_allow_line_key, extract_only_builds_git_name, git_transport_hint, network_error_hint, normalize_git_spec, parse_allowlist_keys, parse_store_major_from_modules_yaml, preset_spec_for_install, shell_quote_spec, silent_install_failure_detail, PreinstallPluginInfo};
 
     /// 构造预设条目的测试助手（internal 由各用例显式指定）
     fn preset(id: &str, spec: &str, internal: bool) -> PreinstallPluginInfo {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -25,6 +25,7 @@
   "preinstall.cancelling": "Cancelling...",
   "preinstall.open_repo": "Open repository of {{name}}",
   "preinstall.failed": "Installation failed",
+  "preinstall.network_error": "Network connection failed. Check your network or proxy settings and try again.",
   "preinstall.load_failed": "Failed to load preinstall plugin list",
   "preinstall.empty": "No preinstalled plugins available.",
   "preinstall.settings_title": "Recommended Plugins",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -25,6 +25,7 @@
   "preinstall.cancelling": "正在取消...",
   "preinstall.open_repo": "打开 {{name}} 的仓库",
   "preinstall.failed": "安装失败",
+  "preinstall.network_error": "网络连接失败，请检查网络或代理设置后重试。",
   "preinstall.load_failed": "预装插件列表加载失败",
   "preinstall.empty": "暂无可预装的插件。",
   "preinstall.settings_title": "预装插件",

--- a/src/store/modules/harness/store.ts
+++ b/src/store/modules/harness/store.ts
@@ -692,7 +692,10 @@ export const harness = defineStore({
       }
       catch (err) {
         console.error('[Harness] preinstall failed:', err)
-        this.preinstall.error = String(err)
+        const error = String(err)
+        this.preinstall.error = error.startsWith('NETWORK_ERROR:')
+          ? i18next.t('preinstall.network_error')
+          : error
         if (err instanceof Error && (err as StartupError).readinessTimedOut) {
           void this.recoverReadiness(bootToken)
         }


### PR DESCRIPTION
## Summary
- classify plugin install network failures separately from dsh process failures
- show a clear localized network/proxy message in the preinstall flow
- cover silent exit-code 3 failures observed in #140

Fixes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network-related failures during plugin installation, updates, removal, and batch installation.
  * Network failures now display a consistent, localized message instead of unclear or inconsistent errors.
  * Added support for detecting DNS, proxy, timeout, connection, and TLS issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->