### PR TITLE
fix(windows): synchronize asynchronous node-pty terminal PID

### DIFF
--- a/src-tauri/src/service/workflow/win_inspector.rs
+++ b/src-tauri/src/service/workflow/win_inspector.rs
@@ -58,6 +58,15 @@ mod imp {
     /// 注入判定标记：patch 中出现该字符串即视为已挂载。
     const PATCH_MARKER: &str = "dsh-win-terminal-inspector";
 
+    /// 社区插件异步 PID 兼容补丁的幂等标记。
+    const ASYNC_PID_PATCH_MARKER: &str = "dsh-desktop: synchronize asynchronous node-pty pid";
+
+    /// 插件中创建 spawn 串行队列的稳定锚点。
+    const SPAWN_CHAIN_ANCHOR: &str = "  let chain = Promise.resolve();";
+
+    /// 插件中 inspector 挂载的稳定锚点。
+    const INSPECTOR_ATTACH_ANCHOR: &str = "        if (handle !== undefined && handle.terminal !== undefined) inspector.attach(handle.terminal);";
+
     /// 用户 preset 目录名（`$DSH_HOME/.agent-presets/<id>/`）。
     const WIN_PRESET_ID: &str = "minimal-win";
 
@@ -104,6 +113,100 @@ mod imp {
             .and_then(serde_json::Value::as_object)
             .map(|deps| deps.contains_key(PLUGIN_DEP_NAME))
             .unwrap_or(false)
+    }
+
+    /// node-pty 1.2 的 ConPTY client pid 异步就绪时，同步插件包装器拿到的 handle 身份。
+    ///
+    /// `LocalTerminalHandle` 在构造时快照 `terminal.pid` 与 `rootIdentity`；Windows 下
+    /// node-pty 1.2.0-beta.15 此刻固定返回 0，随后才在 `ready_datapipe` 更新真实 pid。
+    /// 社区插件已持有 terminal、handle 与 inspector，故在挂载后短时轮询并回填是
+    /// 不修改官方包源码的最小修复。返回值用于安全处理上游插件布局变化。
+    #[derive(Debug, PartialEq, Eq)]
+    enum AsyncPidPatchOutcome {
+        AlreadyPatched,
+        AnchorMissing,
+        Patched(String),
+    }
+
+    fn patch_async_pid_source(source: &str) -> AsyncPidPatchOutcome {
+        if source.contains(ASYNC_PID_PATCH_MARKER) {
+            return AsyncPidPatchOutcome::AlreadyPatched;
+        }
+        if !source.contains(SPAWN_CHAIN_ANCHOR) || !source.contains(INSPECTOR_ATTACH_ANCHOR) {
+            return AsyncPidPatchOutcome::AnchorMissing;
+        }
+
+        let helper = format!(
+            r#"  // {ASYNC_PID_PATCH_MARKER}
+  // node-pty >= 1.2 在 spawn 返回后才解析 ConPTY client pid，
+  // LocalTerminalHandle 则已在构造函数中快照 pid/rootIdentity。
+  const syncShellIdentity = (handle, inspector, terminal) => {{
+    let tries = 0;
+    const tick = () => {{
+      if (handle.exited) return;
+      const pid = typeof terminal?.pid === "number" ? terminal.pid : 0;
+      if (pid > 0) {{
+        handle.pid = pid;
+        try {{
+          const rootIdentity =
+            inspector.processTree(pid).find((member) => member.pid === pid);
+          if (rootIdentity !== undefined) {{
+            handle.rootIdentity = rootIdentity;
+            return;
+          }}
+        }} catch (_tableUnavailable) {{}}
+      }}
+      if (++tries < 60) setTimeout(tick, 100);
+    }};
+    tick();
+  }};
+
+"#
+        );
+        let patched = source.replacen(
+            SPAWN_CHAIN_ANCHOR,
+            &format!("{helper}{SPAWN_CHAIN_ANCHOR}"),
+            1,
+        );
+        let attach = format!(
+            "        if (handle !== undefined && handle.terminal !== undefined) {{\n          inspector.attach(handle.terminal);\n          syncShellIdentity(handle, inspector, handle.terminal);\n        }}"
+        );
+        AsyncPidPatchOutcome::Patched(patched.replacen(INSPECTOR_ATTACH_ANCHOR, &attach, 1))
+    }
+
+    /// 对 profile 中已安装的社区插件应用异步 PID 兼容补丁（幂等）。
+    fn ensure_async_pid_patch(profile: &Path) -> Result<(), String> {
+        let entry = profile.join("node_modules/dsh-win-terminal-inspector/index.js");
+        if !entry.exists() {
+            log::warn!(
+                "win terminal inspector entry missing, skip async pid patch: {}",
+                entry.display()
+            );
+            return Ok(());
+        }
+        let source = fs::read_to_string(&entry)
+            .map_err(|e| format!("WIN_INSPECTOR_PATCH_READ: {} failed: {e}", entry.display()))?;
+        match patch_async_pid_source(&source) {
+            AsyncPidPatchOutcome::AlreadyPatched => {
+                log::info!("win terminal inspector async pid patch already applied");
+            }
+            AsyncPidPatchOutcome::AnchorMissing => {
+                log::warn!(
+                    "win terminal inspector async pid patch anchors missing, skip: {}",
+                    entry.display()
+                );
+            }
+            AsyncPidPatchOutcome::Patched(patched) => {
+                fs::write(&entry, patched).map_err(|e| {
+                    format!("WIN_INSPECTOR_PATCH_WRITE: {} failed: {e}", entry.display())
+                })?;
+                log::info!(
+                    "win terminal inspector async pid compatibility patched: {}",
+                    entry.display()
+                );
+            }
+        }
+        Ok(())
     }
 
     /// 幂等地写入 web profile 的 `cordis.patch.yml` 挂载行。
@@ -425,6 +528,7 @@ mod imp {
         }
 
         ensure_patch(&profile)?;
+        ensure_async_pid_patch(&profile)?;
         ensure_win_minimal_preset(app_handle)?;
         log::info!("win32 terminal support applied to {:?}", profile.display());
         Ok(())
@@ -436,6 +540,81 @@ mod imp {
 
         fn temp_dir(tag: &str) -> PathBuf {
             std::env::temp_dir().join(format!("win-inspector-test-{}-{tag}", std::process::id()))
+        }
+
+        fn plugin_source_fixture() -> String {
+            format!(
+                r#"export function apply(ctx) {{
+  let chain = Promise.resolve();
+  const wrapped = (spec) => {{
+    const run = chain.then(async () => {{
+      const inspector = new WindowsProcessInspector();
+      try {{
+        const handle = await original.call(runtime, spec);
+        if (handle !== undefined && handle.terminal !== undefined) inspector.attach(handle.terminal);
+        return handle;
+      }} finally {{}}
+    }});
+    return run;
+  }};
+}}
+"#
+            )
+        }
+
+        #[test]
+        fn async_pid_patch_syncs_handle_after_terminal_pid_is_ready() {
+            let AsyncPidPatchOutcome::Patched(patched) =
+                patch_async_pid_source(&plugin_source_fixture())
+            else {
+                panic!("expected patched plugin source");
+            };
+            assert!(patched.contains(ASYNC_PID_PATCH_MARKER));
+            assert!(patched.contains("if (++tries < 60) setTimeout(tick, 100);"));
+            assert!(patched.contains("handle.pid = pid;"));
+            assert!(patched.contains("handle.rootIdentity ="));
+            assert!(patched.contains("syncShellIdentity(handle, inspector, handle.terminal);"));
+            assert!(patched.contains("inspector.attach(handle.terminal);"));
+        }
+
+        #[test]
+        fn async_pid_patch_is_idempotent() {
+            let AsyncPidPatchOutcome::Patched(patched) =
+                patch_async_pid_source(&plugin_source_fixture())
+            else {
+                panic!("expected patched plugin source");
+            };
+            assert_eq!(
+                patch_async_pid_source(&patched),
+                AsyncPidPatchOutcome::AlreadyPatched
+            );
+        }
+
+        #[test]
+        fn async_pid_patch_skips_changed_upstream_layout() {
+            assert_eq!(
+                patch_async_pid_source("export function apply() {}"),
+                AsyncPidPatchOutcome::AnchorMissing
+            );
+        }
+
+        #[test]
+        fn async_pid_patch_updates_installed_plugin_file() {
+            let dir = temp_dir("async-pid");
+            let plugin_dir = dir.join("node_modules/dsh-win-terminal-inspector");
+            std::fs::create_dir_all(&plugin_dir).unwrap();
+            let entry = plugin_dir.join("index.js");
+            std::fs::write(&entry, plugin_source_fixture()).unwrap();
+
+            ensure_async_pid_patch(&dir).unwrap();
+            let once = std::fs::read_to_string(&entry).unwrap();
+            assert!(once.contains(ASYNC_PID_PATCH_MARKER));
+
+            ensure_async_pid_patch(&dir).unwrap();
+            let twice = std::fs::read_to_string(&entry).unwrap();
+            assert_eq!(once, twice);
+
+            std::fs::remove_dir_all(&dir).ok();
         }
 
         #[test]


### PR DESCRIPTION
## Summary

- patch the installed dsh-win-terminal-inspector wrapper before DSH starts
- synchronize LocalTerminalHandle pid and rootIdentity after node-pty publishes the ConPTY PID asynchronously
- keep the compatibility patch idempotent and safely skip changed upstream layouts
- add regression coverage for injection, retries, idempotency, and on-disk patching

## Validation

- cargo check
- cargo test (251 passed)
- cargo test service::workflow::win_inspector::imp::tests (16 passed)
- git diff --check

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows terminal inspection by reliably detecting asynchronously initialized terminal processes.
  * Added compatibility handling for supported terminal plugin layouts.
  * Ensured the update applies safely and only once when the required plugin components are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->