### PR TITLE
chore: release v0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.8.4-beta.1",
+  "version": "0.8.4",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.8.4-beta.1"
+version = "0.8.4"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.8.4-beta.1"
+version = "0.8.4"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.8.4-beta.1",
+  "version": "0.8.4",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.8.4` (`0.8.4-beta.1` → `0.8.4`).

### Features

- include panel plugins in presets (5a1fe84)

### Bug Fixes

- **windows**: synchronize async terminal pid (930e58c)
- **windows**: detect newly installed pnpm (7abc82a)
- correct network error classification compile (a2e42be)
- show network errors during plugin install (5e41142)

### Other Changes

- Merge pull request #143 from dsh-tauri-desk/fix/issue-134-async-terminal-pid (52b5845)
- Merge pull request #142 from dsh-tauri-desk/dsh/issues139 (2c5dbe9)
- Merge pull request #141 from dsh-tauri-desk/dsh/fix-network-error-message (061af4b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Promoted the application from version 0.8.4-beta.1 to the stable 0.8.4 release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->