### PR TITLE
fix(macos): use native clipboard for run logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@overlastic/react": "^0.9.0",
     "@tanstack/react-query": "^5.101.4",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "i18next": "^26.3.6",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       i18next:
         specifier: ^26.3.6
         version: 26.3.6(typescript@5.8.3)
@@ -1467,6 +1470,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -4509,6 +4515,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/src/components/config-debug.tsx
+++ b/src/components/config-debug.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { If } from 'react-if-lite'
 import { useStore } from 'valtio-define'
 import { store } from '@/store'
+import { writeClipboardText } from '@/utils/clipboard'
 import { toast } from '@/utils/toast'
 import { Info } from './info'
 
@@ -66,6 +67,17 @@ export function ConfigDebug() {
     queryFn: () => invoke<string>('read_service_logs'),
     refetchInterval: 2000,
   })
+
+  async function copyLogs() {
+    try {
+      await writeClipboardText(logs || '')
+      toast(t('messages.logs_copied'))
+    }
+    catch (err) {
+      console.error('[ConfigDebug] copy logs failed:', err)
+      toast(t('messages.logs_copy_failed'), { variant: 'danger' })
+    }
+  }
 
   const { mutate: onClearLogs } = useMutation({
     mutationFn: async () => {
@@ -344,10 +356,7 @@ export function ConfigDebug() {
               size="sm"
               className="rounded-md size-6"
               variant="ghost"
-              onPress={async () => {
-                await navigator.clipboard.writeText(logs || '')
-                toast(t('messages.logs_copied'))
-              }}
+              onPress={() => { void copyLogs() }}
             >
               <Copy className="scale-80" />
             </Button>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -93,6 +93,7 @@
   "messages.copy_success": "URL copied to clipboard",
   "messages.log_copied": "Logs copied to clipboard",
   "messages.copy_failed": "Failed to copy URL",
+  "messages.logs_copy_failed": "Failed to copy logs",
   "messages.port_changed": "Port changed",
   "messages.port_restart_hint": "It takes effect after the service restarts. Restart now?",
   "messages.logs_cleared": "Logs cleared",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -93,6 +93,7 @@
   "messages.copy_success": "地址已复制到剪贴板",
   "messages.log_copied": "日志已复制到剪贴板",
   "messages.copy_failed": "复制地址失败",
+  "messages.logs_copy_failed": "复制日志失败",
   "messages.port_changed": "端口已更改",
   "messages.port_restart_hint": "重启服务后生效，是否立即重启？",
   "messages.logs_cleared": "日志已清空",

--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -23,6 +23,7 @@ import { DesktopUpdateDialog } from '@/components/desktop-update-dialog'
 import { useDshPlugins } from '@/hooks/use-dsh-plugins'
 import { useIframeTauri } from '@/hooks/use-iframe-tauri'
 import { store } from '@/store'
+import { writeClipboardText } from '@/utils/clipboard'
 import { toast } from '@/utils/toast'
 import { useMacOSAppMenu } from './use-macos-app-menu'
 
@@ -196,12 +197,12 @@ export function Navbar({ iframeRef }: NavbarProps) {
   async function copyRunLogs() {
     try {
       const logs = await invoke<string>('read_run_logs')
-      await navigator.clipboard.writeText(logs)
+      await writeClipboardText(logs)
       toast(t('messages.logs_copied'), {})
     }
     catch (err) {
       console.error('[Navbar] failed to copy run logs:', err)
-      toast(t('messages.copy_failed'), {})
+      toast(t('messages.logs_copy_failed'), { variant: 'danger' })
     }
   }
 

--- a/src/layout/components/preinstall-setup.tsx
+++ b/src/layout/components/preinstall-setup.tsx
@@ -10,6 +10,7 @@ import { Empty } from '@/components/empty'
 import { Item } from '@/components/item'
 import { Logs } from '@/components/logs'
 import { store } from '@/store'
+import { writeClipboardText } from '@/utils/clipboard'
 import { toast } from '@/utils/toast'
 
 /**
@@ -95,11 +96,12 @@ function LogPanel({ logs }: { logs: readonly string[] }) {
 
   async function copyLogs() {
     try {
-      await navigator.clipboard.writeText(text || '')
+      await writeClipboardText(text || '')
       toast(t('messages.log_copied'), {})
     }
     catch (err) {
       console.error('[Harness] copy preinstall logs failed:', err)
+      toast(t('messages.logs_copy_failed'), { variant: 'danger' })
     }
   }
 

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,5 @@
+import { writeText } from '@tauri-apps/plugin-clipboard-manager'
+
+export function writeClipboardText(text: string): Promise<void> {
+  return writeText(text)
+}

--- a/test/clipboard.test.ts
+++ b/test/clipboard.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { writeText } from '@tauri-apps/plugin-clipboard-manager'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { writeClipboardText } from '../src/utils/clipboard'
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  writeText: vi.fn(),
+}))
+
+const CLIPBOARD_CALL_SITES = [
+  '../src/components/config-debug.tsx',
+  '../src/layout/components/navbar.tsx',
+  '../src/layout/components/preinstall-setup.tsx',
+]
+
+describe('clipboard integration', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('routes every shell copy action through the native helper and handles failures', () => {
+    for (const path of CLIPBOARD_CALL_SITES) {
+      const source = readFileSync(new URL(path, import.meta.url), 'utf8')
+      expect(source).not.toContain('navigator.clipboard.writeText')
+
+      const nativeWrite = source.indexOf('writeClipboardText(')
+      expect(nativeWrite).toBeGreaterThan(-1)
+
+      const failurePath = source.slice(nativeWrite, nativeWrite + 500)
+      expect(failurePath).toContain('catch (err)')
+      expect(failurePath).toContain('messages.logs_copy_failed')
+    }
+  })
+
+  it('writes the exact text through the native clipboard plugin', async () => {
+    vi.mocked(writeText).mockResolvedValue()
+
+    await expect(writeClipboardText('diagnostic logs')).resolves.toBeUndefined()
+
+    expect(writeText).toHaveBeenCalledExactlyOnceWith('diagnostic logs')
+  })
+
+  it('propagates native clipboard failures to the caller', async () => {
+    const failure = new Error('clipboard unavailable')
+    vi.mocked(writeText).mockRejectedValue(failure)
+
+    await expect(writeClipboardText('diagnostic logs')).rejects.toBe(failure)
+  })
+})


### PR DESCRIPTION
## Summary / 摘要

Fixes #145.

macOS Run Logs currently reads the diagnostics successfully, then hands them to the browser `navigator.clipboard` API inside WKWebView. That copy can fail even though this app already initializes and authorizes Tauri's native clipboard-manager plugin, and the catch path misleadingly reports “Failed to copy URL.”

This change:

- routes Run Logs through the existing native clipboard-manager permission;
- uses the same shared helper for the two other log-copy surfaces, so they do not retain the same latent WKWebView failure;
- adds a precise synchronized English/Chinese “Failed to copy logs” message;
- catches native failures at every call site, avoiding unhandled copy rejections;
- adds regression coverage for all three call sites, the exact native payload, and rejection propagation.

The Rust plugin registration and `clipboard-manager:allow-write-text` capability already existed, so no Rust permission expansion is included.

## Verification / 验证

- `pnpm test` — 18/18 passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm build` — passed (2,899 modules)
- `cargo check` in `src-tauri` — passed
- `cargo test` in `src-tauri` — 251/251 passed; doc tests passed
- English/Chinese locale parity — 198/198 keys
- `git diff --check` — passed
- independent exact-diff review — publish verdict, no correctness or security findings

## Platform note / 平台说明

These automated gates ran on a Windows host. The native Tauri plugin is already registered and authorized cross-platform, but I have not claimed a manual macOS 26 click-through. Reporter confirmation that Run Logs now reaches the clipboard on macOS would close that final runtime-validation gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved log copying across the app using the native clipboard.
  * Added success and failure notifications when copying logs.
  * Added localized copy-failure messages in English and Simplified Chinese.

* **Bug Fixes**
  * Improved clipboard reliability in debug, navigation, and setup views.
  * Clipboard errors are now reported clearly instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->