### PR TITLE
fix(workflow): macOS port probe false EADDRINUSE flakiness

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "socket2",
  "tar",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,11 @@ tokio = { version = "1", features = [ "full" ] }
 semver = "1"
 dunce = "1.0.5"
 
+# macOS/BSD 的 TCP 端口释放存在短暂滞后（close 后立即重绑会误报 EADDRINUSE），
+# 端口探测需要 SO_REUSEADDR；Windows 上该选项会掩盖真实监听者，故仅 macOS 启用。
+[target.'cfg(target_os = "macos")'.dependencies]
+socket2 = "0.6"
+
 [target.'cfg(windows)'.dependencies]
 rfd = "0.16"
 webview2-com = "0.38"

--- a/src-tauri/src/service/workflow/utils.rs
+++ b/src-tauri/src/service/workflow/utils.rs
@@ -1,5 +1,7 @@
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+#[cfg(not(target_os = "macos"))]
+use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use std::thread;
@@ -83,11 +85,42 @@ pub async fn is_dsh_running(port: u16) -> bool {
     check_status.await.unwrap_or(false)
 }
 
-/// 检查指定端口是否被占用（通过尝试连接来判断）
+/// 检查指定端口是否被占用（通过尝试绑定来判断）
 pub fn is_port_in_use(port: u16) -> bool {
     // 以实际绑定结果判断，能够识别“已绑定但尚未 listen”的占用状态。
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-    TcpListener::bind(addr).is_err()
+    bind_probe(addr).is_err()
+}
+
+/// 端口占用探测：能成功绑定即视为空闲。平台差异见下方 macOS 分支注释。
+#[cfg(not(target_os = "macos"))]
+fn bind_probe(addr: SocketAddr) -> std::io::Result<()> {
+    TcpListener::bind(addr).map(|_| ())
+}
+
+/// macOS/BSD 上刚 close 的监听 socket 会留下一个极短的“端口暂不可复用”窗口：
+/// 不带 SO_REUSEADDR 时紧随其后的 bind 会误报 EADDRINUSE（典型表现为服务重启
+/// 偶发 “address already in use”）。本函数每次探测都是 bind→drop，探测自身也会
+/// 制造这个窗口——`wait_for_port_release` 轮询到“空闲”返回后立刻再探测就可能
+/// 踩中，导致占用的误判（CI 偶发的端口拉高/测试失败）。
+///
+/// 因此探测前先设 SO_REUSEADDR：
+///   - 真实占用（残留 dsh 等仍 listen 在同一端口）依然 bind 失败 → 判为占用；
+///   - 上一次探测留下的 linger 不再误判为占用。
+/// SO_REUSEADDR 只放宽 TIME_WAIT/linger 状态的复用，并不会允许两个 socket 同时
+/// listen 同一地址（那是 SO_REUSEPORT 的语义），因此不会掩盖真实监听者。
+/// Windows 上 SO_REUSEADDR 语义不同（可强制覆盖既有监听者），会掩盖真实占用，
+/// 故只对 macOS 启用。
+#[cfg(target_os = "macos")]
+fn bind_probe(addr: SocketAddr) -> std::io::Result<()> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV4,
+        socket2::Type::STREAM,
+        Some(socket2::Protocol::TCP),
+    )?;
+    socket.set_reuse_address(true)?;
+    socket.bind(&socket2::SockAddr::from(addr))?;
+    Ok(())
 }
 
 /// 在独立线程中读取子进程的输出，同时写入日志文件


### PR DESCRIPTION
## 背景

macOS CI 又偶发失败（例如 [run 33041852373 / job 98421181982](https://github.com/dsh-tauri-desk/deepseek-harness-desktop/actions/runs/33041852373/job/98421181982?pr=148)，PR #148 的 Rust tests (macos-14)）：

```
thread 'service::workflow::tests::wait_for_port_release_returns_shortly_after_port_is_released' panicked at src/service/workflow/mod.rs:1380:9:
assertion failed: !is_port_in_use(held)
```

## 根因

`is_port_in_use`（`workflow/utils.rs`）用「bind→立即 drop」的方式探测端口。macOS/BSD 上 close 监听 socket 后会留下一个极短的「端口暂不可复用」窗口——不带 `SO_REUSEADDR` 时紧随其后的 bind 会误报 `EADDRINUSE`（典型表现为服务重启偶发 `address already in use`）。

由于每次探测都是 bind→drop，**探测自身也会制造这个窗口**：`wait_for_port_release` 轮询到「空闲」返回（某次探测 bind 成功），紧接着下一次探测立刻重绑刚 drop 的端口，就会踩中 linger → 误判为仍占用。CI 上表现为该测试偶发断言失败；生产上同样会让 `wait_for_port_release` 之后的 `find_available_port` 偶发把配置端口误顶高（正是 #91 / `7b31d00` 想避免的漂移）。

## 修复

在 macOS 的端口探测里，bind 前先设 `SO_REUSEADDR`（新增 macOS 专属依赖 `socket2`，lockfile 中已存在该包，仅标记为直接依赖）：

- 真实占用（残留 dsh 等仍 listen 在同一端口）依然 bind 失败 → 占用判定不变（`SO_REUSEADDR` 不允许多个 socket 同时 listen 同一地址，那是 `SO_REUSEPORT` 的语义）；
- 上一次探测留下的 linger 不再误判为占用 → 测试与启动路径都变得确定。

**仅 macOS 启用**：Windows 上 `SO_REUSEADDR` 语义不同（可强制覆盖既有监听者），会掩盖真实占用，故保持原逻辑。

## 验证

- `cargo check --all-features --locked` ✅（Windows 本机）
- `cargo test --all-features --locked --lib service::workflow::` ✅ 49 passed，含原先偶发失败的 `wait_for_port_release_returns_shortly_after_port_is_released`
- macOS 分支的编译与行为由本 PR 的 macOS CI 验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port availability checks on macOS.
  * Reduced false reports that a port is still in use immediately after a connection closes.
  * Preserved existing port-checking behavior on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->