### PR TITLE
refactor: separate internal plugin resources

### DIFF
--- a/docs/BUILTIN_PLUGINS.md
+++ b/docs/BUILTIN_PLUGINS.md
@@ -1,6 +1,6 @@
 # Built-in (Internal) Plugins
 
-Built-in plugins（内置插件）are plugins bundled with the installed desktop app and treated as part of the application itself. They are marked with `"internal": true` in `src-tauri/resources/preset-plugins.json`, fetched at build time by `scripts/prebuild.ts` into `src-tauri/resources/preset-plugins/<id>/`, shipped with the installer via `bundle.resources`, and auto-installed (and auto-healed) at service start by `src-tauri/src/service/plugin/internal.rs`.
+Built-in plugins（内置插件）are plugins bundled with the installed desktop app and treated as part of the application itself. They are declared in `src-tauri/resources/internal-plugins.json`, fetched at build time by `scripts/prebuild.ts` into `src-tauri/resources/internal-plugins/<id>/`, shipped with the installer via `bundle.resources`, and auto-installed (and auto-healed) at service start by `src-tauri/src/service/plugin/internal.rs`.
 
 Examples today: `dsh-tauri`, `dsh-tauri-ui`, `dsh-tauri-worktree`, `dsh-tauri-panel`, and `dsh-tauri-panel-extension`.
 
@@ -8,7 +8,7 @@ Examples today: `dsh-tauri`, `dsh-tauri-ui`, `dsh-tauri-worktree`, `dsh-tauri-pa
 
 | | Normal preset plugin | Built-in (internal) plugin |
 | --- | --- | --- |
-| Declared in `preset-plugins.json` | Yes | Yes, with `"internal": true` |
+| Manifest | `preset-plugins.json` | `internal-plugins.json` |
 | Source | npm / GitHub, installed at first-launch onboarding | Bundled in the installer, auto-installed at startup |
 | Shown in the first-launch checklist | Yes (`recommended` / `fix` / `defaultChecked` chips) | No — they are mandatory (filtered out in `installed.rs`) |
 | User can uninstall | Yes | Effectively no — restored on the next launch |
@@ -16,7 +16,7 @@ Examples today: `dsh-tauri`, `dsh-tauri-ui`, `dsh-tauri-worktree`, `dsh-tauri-pa
 
 ## How the mechanism works
 
-**Build time** — `scripts/prebuild.ts` is run automatically by `pnpm build` (the `prebuild` script, which Tauri invokes as its `beforeBuildCommand` = `pnpm build`). For each `internal: true` entry it produces `src-tauri/resources/preset-plugins/<id>/`:
+**Build time** — `scripts/prebuild.ts` is run automatically by `pnpm build` (the `prebuild` script, which Tauri invokes as its `beforeBuildCommand` = `pnpm build`). For each entry in `internal-plugins.json` it produces `src-tauri/resources/internal-plugins/<id>/`:
 
 - `github:owner/repo` — `git clone --depth 1` → `pnpm install` → `pnpm run build` (if a `build` script exists) → copy the build output plus `package.json`.
 - `name[@version]` (npm, incl. scoped `@scope/name`) — `pnpm add <spec> --ignore-scripts` in a temporary project → copy `node_modules/<name>/`.
@@ -25,7 +25,7 @@ Examples today: `dsh-tauri`, `dsh-tauri-ui`, `dsh-tauri-worktree`, `dsh-tauri-pa
 
 ## Add a new built-in plugin
 
-### 1. Declare it in `src-tauri/resources/preset-plugins.json`
+### 1. Declare it in `src-tauri/resources/internal-plugins.json`
 
 Append an entry:
 
@@ -33,7 +33,6 @@ Append an entry:
 {
   "id": "dsh-my-plugin",
   "spec": "github:you/dsh-my-plugin",
-  "internal": true,
   "name": "DSH My Plugin",
   "description": "What the plugin does",
   "repoUrl": "https://github.com/you/dsh-my-plugin"
@@ -44,14 +43,13 @@ Field reference:
 
 - `id` — unique preset id (the repo jump / lookup key; also the default npm package name used for install-state detection). Ids must be unique across the list (enforced by the `preset_json_ids_are_unique` unit test).
 - `spec` — the source. Either `github:owner/repo` (source form) or a bare npm package name `name[@version]` (published form, skips the build). This is what `prebuild.ts` feeds to git/pnpm.
-- `internal` — `true` marks it as a built-in plugin (drives build-time bundling and runtime self-heal). Defaults to `false`.
 - `name`, `description`, `repoUrl` — display metadata. `repoUrl` is used for the repo-jump link in the UI.
 - `package` — optional. When the real npm package name differs from `id` (typical for scoped `@scope/name`), declare it here; it is used for install-state detection and self-heal matching. Defaults to `id`.
 - Chip flags `recommended` / `fix` / `defaultChecked` — not meaningful for internal plugins (they never appear in the checklist) but harmless to keep.
 
 ### 2. Bundle it at build time
 
-No manual step. `pnpm tauri build` runs `pnpm build` → `pnpm prebuild` → `tsx scripts/prebuild.ts`, which reads the manifest, picks all `internal: true`, and produces `src-tauri/resources/preset-plugins/<id>/`. The build machine needs `git` and `pnpm` on PATH and network access to GitHub (for `github:` sources) and npm (for package-name sources).
+No manual step. `pnpm tauri build` runs `pnpm build` → `pnpm prebuild` → `tsx scripts/prebuild.ts`, which reads the internal manifest and produces `src-tauri/resources/internal-plugins/<id>/`. The build machine needs `git` and `pnpm` on PATH and network access to GitHub (for `github:` sources) and npm (for package-name sources).
 
 The bundled directory is shipped with the installer via `bundle.resources` (`"resources": ["resources/**/*"]` in `src-tauri/tauri.conf.json`).
 
@@ -69,7 +67,7 @@ Rules:
 
 - `.env` is gitignored and local-only; the key is only read in `debug_assertions` builds (release always uses the packaged dir).
 - If the id is missing in `<dir>`, the plugin is skipped rather than falling back to the packaged dir, so the misconfiguration is noticed explicitly.
-- Setting it empty or deleting the key disables the override (falls back to the packaged `resources/preset-plugins/<id>`).
+- Setting it empty or deleting the key disables the override (falls back to the packaged `resources/internal-plugins/<id>`).
 
 ## Gotchas
 
@@ -81,7 +79,7 @@ Rules:
 
 ## Reference
 
-- `src-tauri/resources/preset-plugins.json` — the preset manifest you edit.
+- `src-tauri/resources/internal-plugins.json` — the internal plugin manifest you edit.
 - `scripts/prebuild.ts` — build-time bundling (git / npm sources).
 - `src-tauri/src/service/plugin/preset.rs` — manifest parsing, bundled-dir discovery, and the `link:` spec builder.
 - `src-tauri/src/service/plugin/internal.rs` — runtime self-heal.

--- a/docs/BUILTIN_PLUGINS.zh.md
+++ b/docs/BUILTIN_PLUGINS.zh.md
@@ -1,6 +1,6 @@
 # 内置插件（Internal Plugins）
 
-内置插件（built-in plugin）是指随安装包分发、被视作应用本身一部分的插件。它们在 `src-tauri/resources/preset-plugins.json` 中标记 `"internal": true`，由 `scripts/prebuild.ts` 在构建期拉取到 `src-tauri/resources/preset-plugins/<id>/`，随 `bundle.resources` 一并打进安装包，并在服务启动时由 `src-tauri/src/service/plugin/internal.rs` 自动安装（并自愈）。
+内置插件（built-in plugin）是指随安装包分发、被视作应用本身一部分的插件。它们在 `src-tauri/resources/internal-plugins.json` 中声明，由 `scripts/prebuild.ts` 在构建期拉取到 `src-tauri/resources/internal-plugins/<id>/`，随 `bundle.resources` 一并打进安装包，并在服务启动时由 `src-tauri/src/service/plugin/internal.rs` 自动安装（并自愈）。
 
 目前的内置插件：`dsh-tauri`、`dsh-tauri-ui`、`dsh-tauri-worktree`、`dsh-tauri-panel`、`dsh-tauri-panel-extension`。
 
@@ -8,7 +8,7 @@
 
 | | 普通预装插件 | 内置（internal）插件 |
 | --- | --- | --- |
-| 在 `preset-plugins.json` 声明 | 是 | 是，且带 `"internal": true` |
+| 清单 | `preset-plugins.json` | `internal-plugins.json` |
 | 来源 | npm / GitHub，首次引导时安装 | 随安装包分发，启动时自动安装 |
 | 出现在首次引导清单 | 是（`recommended` / `fix` / `defaultChecked` chip） | 否——它们“必装”，在 `installed.rs` 里被过滤掉 |
 | 用户可卸载 | 可以 | 基本不行——下次启动自动恢复 |
@@ -16,7 +16,7 @@
 
 ## 机制是怎么运作的
 
-**构建期** — `scripts/prebuild.ts` 由 `pnpm build` 自动触发（`prebuild` 脚本，而 Tauri 的 `beforeBuildCommand` 恰好是 `pnpm build`）。对每个 `internal: true` 条目，它产出 `src-tauri/resources/preset-plugins/<id>/`：
+**构建期** — `scripts/prebuild.ts` 由 `pnpm build` 自动触发（`prebuild` 脚本，而 Tauri 的 `beforeBuildCommand` 恰好是 `pnpm build`）。对 `internal-plugins.json` 中的每个条目，它产出 `src-tauri/resources/internal-plugins/<id>/`：
 
 - `github:owner/repo` — `git clone --depth 1` → `pnpm install` → `pnpm run build`（存在 `build` 脚本时）→ 拷贝构建产物与 `package.json`。
 - `name[@version]`（npm 包名，含 scoped `@scope/name`）— 在临时工程里 `pnpm add <spec> --ignore-scripts` → 拷贝 `node_modules/<name>/`。
@@ -25,7 +25,7 @@
 
 ## 添加一个新的内置插件
 
-### 1. 在 `src-tauri/resources/preset-plugins.json` 中声明
+### 1. 在 `src-tauri/resources/internal-plugins.json` 中声明
 
 追加一条：
 
@@ -33,7 +33,6 @@
 {
   "id": "dsh-my-plugin",
   "spec": "github:you/dsh-my-plugin",
-  "internal": true,
   "name": "DSH My Plugin",
   "description": "插件做什么",
   "repoUrl": "https://github.com/you/dsh-my-plugin"
@@ -44,14 +43,13 @@
 
 - `id` — 预设唯一 id（仓库跳转 / 查找键；也是未显式声明 `package` 时的默认包名，用于“已安装”检测）。清单内 id 必须唯一（由 `preset_json_ids_are_unique` 单测保证）。
 - `spec` — 来源。要么 `github:owner/repo`（源码形态），要么裸 npm 包名 `name[@version]`（已发布产物形态，跳过构建）。这是 `prebuild.ts` 喂给 git/pnpm 的值。
-- `internal` — `true` 标记为内置插件（驱动构建期打包与运行期自愈）。默认 `false`。
 - `name`、`description`、`repoUrl` — 展示元数据；`repoUrl` 供界面“仓库跳转”链接使用。
 - `package` — 可选。当真实 npm 包名与 `id` 不一致（常见于 scoped 包 `@scope/name`）时在这里声明；用于“已安装”检测与自愈对账。缺省回落 `id`。
 - chip 标记 `recommended` / `fix` / `defaultChecked` — 对内置插件无意义（它们不进清单），保留也无妨。
 
 ### 2. 构建期打包
 
-无需手工操作。`pnpm tauri build` 会执行 `pnpm build` → `pnpm prebuild` → `tsx scripts/prebuild.ts`，读取清单、筛出所有 `internal: true` 并产出 `src-tauri/resources/preset-plugins/<id>/`。构建机需要 PATH 上有 `git` 与 `pnpm`，并能访问 GitHub（`github:` 来源）与 npm registry（包名来源）。
+无需手工操作。`pnpm tauri build` 会执行 `pnpm build` → `pnpm prebuild` → `tsx scripts/prebuild.ts`，读取内部插件清单并产出 `src-tauri/resources/internal-plugins/<id>/`。构建机需要 PATH 上有 `git` 与 `pnpm`，并能访问 GitHub（`github:` 来源）与 npm registry（包名来源）。
 
 捆绑目录通过 `bundle.resources` 随安装包分发（`src-tauri/tauri.conf.json` 中的 `"resources": ["resources/**/*"]`）。
 
@@ -69,7 +67,7 @@
 
 - `.env` 已被 `.gitignore` 忽略，仅本地生效；该键只在 `debug_assertions` 构建读取（release 恒用随包目录）。
 - 若 `<dir>` 缺该 id，则跳过（不回落随包目录），让开发者显式感知配置错误。
-- 置空或删除该键 = 关闭覆盖（回落随包分发的 `resources/preset-plugins/<id>`）。
+- 置空或删除该键 = 关闭覆盖（回落随包分发的 `resources/internal-plugins/<id>`）。
 
 ## 常见坑
 
@@ -81,7 +79,7 @@
 
 ## 参考
 
-- `src-tauri/resources/preset-plugins.json` — 你要编辑的预设清单。
+- `src-tauri/resources/internal-plugins.json` — 你要编辑的内部插件清单。
 - `scripts/prebuild.ts` — 构建期打包（git / npm 两种来源）。
 - `src-tauri/src/service/plugin/preset.rs` — 清单解析、捆绑目录发现、`link:` spec 构造。
 - `src-tauri/src/service/plugin/internal.rs` — 运行期自愈。

--- a/scripts/prebuild.ts
+++ b/scripts/prebuild.ts
@@ -1,6 +1,6 @@
 /**
- * prebuild：把 `src-tauri/resources/preset-plugins.json` 中标记 `internal: true`
- * 的插件制备为随包产物，拷入 `src-tauri/resources/preset-plugins/<id>/`
+ * prebuild：把 `src-tauri/resources/internal-plugins.json` 中声明的内部插件
+ * 制备为随包产物，拷入 `src-tauri/resources/internal-plugins/<id>/`
  * （随 `bundle.resources` 随安装包分发）。两种来源：
  *
  * - `github:owner/repo`：从上游仓库克隆、安装依赖并构建（源码形态的插件）；
@@ -30,15 +30,14 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import process from 'node:process'
 
-interface PresetPlugin {
+interface InternalPlugin {
   id: string
   spec: string
-  internal?: boolean
 }
 
 const REPO_ROOT = resolve(import.meta.dirname, '..')
-const PRESET_FILE = join(REPO_ROOT, 'src-tauri', 'resources', 'preset-plugins.json')
-const BUNDLE_ROOT = join(REPO_ROOT, 'src-tauri', 'resources', 'preset-plugins')
+const INTERNAL_PLUGINS_FILE = join(REPO_ROOT, 'src-tauri', 'resources', 'internal-plugins.json')
+const BUNDLE_ROOT = join(REPO_ROOT, 'src-tauri', 'resources', 'internal-plugins')
 const GIT_URL_RE = /^github:([^#/]+\/[^#/]+)(?:#.*)?$/
 
 function die(message: string): never {
@@ -83,7 +82,7 @@ function npmPackageName(spec: string): string {
  * `node_modules/<name>/`（发布包自带 lib/ 等运行必需文件，无需再构建）。
  * 依赖 pnpm 在 PATH 上（与 git 来源流程同一前提）。
  */
-function fetchNpmPackage(preset: PresetPlugin, temp: string): string {
+function fetchNpmPackage(preset: InternalPlugin, temp: string): string {
   const project = join(temp, 'project')
   mkdirSync(project, { recursive: true })
   writeFileSync(join(project, 'package.json'), JSON.stringify({ private: true }))
@@ -101,7 +100,7 @@ function fetchNpmPackage(preset: PresetPlugin, temp: string): string {
  * 缺失白名单时拷贝整目录但排除 node_modules/.git 等开发噪声；
  * `package.json` 恒在（它是 `pnpm add file:<dir>` 的包名/入口来源）。
  */
-function collectBundle(preset: PresetPlugin, clone: string): void {
+function collectBundle(preset: InternalPlugin, clone: string): void {
   const dest = join(BUNDLE_ROOT, preset.id)
   mkdirSync(dest, { recursive: true })
 
@@ -127,7 +126,7 @@ function collectBundle(preset: PresetPlugin, clone: string): void {
 }
 
 /** 构建单个 internal 插件：git 来源（克隆 → 装依赖 → 构建）或 npm 来源（拉产物）。 */
-function buildPlugin(preset: PresetPlugin): void {
+function buildPlugin(preset: InternalPlugin): void {
   const dest = join(BUNDLE_ROOT, preset.id)
   rmSync(dest, { recursive: true, force: true })
 
@@ -163,18 +162,17 @@ function buildPlugin(preset: PresetPlugin): void {
 }
 
 function main(): void {
-  if (!existsSync(PRESET_FILE)) {
-    die(`未找到预设清单 ${PRESET_FILE}`)
+  if (!existsSync(INTERNAL_PLUGINS_FILE)) {
+    die(`未找到内部插件清单 ${INTERNAL_PLUGINS_FILE}`)
   }
-  const presets = JSON.parse(readFileSync(PRESET_FILE, 'utf8')) as PresetPlugin[]
-  const internal = presets.filter(preset => preset.internal === true)
+  const internal = JSON.parse(readFileSync(INTERNAL_PLUGINS_FILE, 'utf8')) as InternalPlugin[]
   if (internal.length === 0) {
-    console.log('[prebuild] 预设清单无 internal 插件，跳过')
+    console.log('[prebuild] 内部插件清单为空，跳过')
     return
   }
   console.log(`[prebuild] 拉取 ${internal.length} 个 internal 插件: ${internal.map(p => p.id).join(', ')}`)
-  for (const preset of internal) {
-    buildPlugin(preset)
+  for (const plugin of internal) {
+    buildPlugin(plugin)
   }
   console.log(`[prebuild] 完成 → ${BUNDLE_ROOT}`)
 }

--- a/src-tauri/resources/README.md
+++ b/src-tauri/resources/README.md
@@ -75,10 +75,12 @@ time, so the PR only needs to add the JSON entry.
 
 ### Built-in (internal) plugins
 
-For plugins that must ship *with* the installer and are treated as part of the
-app (auto-installed and auto-healed at startup), set `"internal": true` and add
-an extra `package` field when the real npm name differs from `id`. Those entries
-are bundled at build time by `scripts/prebuild.ts` into
-`resources/preset-plugins/<id>/` (via `bundle.resources`) and never appear in the
-first-run checklist. See the [built-in plugin guide](../../docs/BUILTIN_PLUGINS.md)
-for the full workflow.
+Plugins that must ship *with* the installer and are treated as part of the app
+(auto-installed and auto-healed at startup) live in `internal-plugins.json`,
+separate from the community preset list. Add an extra `package` field when the
+real npm name differs from `id`. The entries are bundled at build time by
+`scripts/prebuild.ts` into `resources/internal-plugins/<id>/` (via
+`bundle.resources`) and never appear in the first-run checklist. On startup the
+app removes the legacy `resources/preset-plugins/` directory left by upgrades.
+See the [built-in plugin guide](../../docs/BUILTIN_PLUGINS.md) for the full
+workflow.

--- a/src-tauri/resources/internal-plugins.json
+++ b/src-tauri/resources/internal-plugins.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "dsh-tauri",
+    "spec": "dsh-tauri@0.4.6",
+    "name": "DSH Tauri",
+    "description": "Message bridge for the DeepSeek Harness desktop shell",
+    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri",
+    "recommended": true
+  },
+  {
+    "id": "dsh-tauri-ui",
+    "spec": "dsh-tauri-ui@0.4.6",
+    "name": "DSH Tauri UI",
+    "description": "Customized Tauri UI plugin for the DeepSeek Harness desktop shell (skeleton): registers the shell.overlay seat for the future desktop chrome",
+    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-ui",
+    "recommended": true
+  },
+  {
+    "id": "dsh-tauri-worktree",
+    "spec": "dsh-tauri-worktree@0.4.6",
+    "name": "DSH Tauri Worktree",
+    "description": "Per-session isolated Git Worktree for the desktop shell: switch a conversation to its own isolated worktree, then check changes back into a local dsh/ branch or discard them.",
+    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-worktree",
+    "recommended": true
+  },
+  {
+    "id": "dsh-tauri-panel",
+    "spec": "dsh-tauri-panel@0.4.6",
+    "name": "DSH Tauri Panel",
+    "description": "Sidebar shell for the desktop: compact logo row (32px), a panel area holding the New Session item plus third-party panel items (sidebar.panel.action slot), and the panel.protocol service (open/render/close panel content) consumed by dsh-tauri-panel-extension.",
+    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-plugins/tree/main/packages/dsh-tauri-panel",
+    "recommended": true
+  },
+  {
+    "id": "dsh-tauri-panel-extension",
+    "spec": "dsh-tauri-panel-extension@0.4.6",
+    "name": "DSH Tauri Panel Extension",
+    "description": "Skills and MCP management in the DeepSeek Harness desktop extension panel.",
+    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-plugins/tree/main/packages/dsh-tauri-panel-extension",
+    "recommended": true
+  }
+]

--- a/src-tauri/resources/preset-plugins.json
+++ b/src-tauri/resources/preset-plugins.json
@@ -11,51 +11,6 @@
     "winOnly": true
   },
   {
-    "id": "dsh-tauri",
-    "spec": "dsh-tauri@0.4.6",
-    "name": "DSH Tauri",
-    "internal": true,
-    "description": "Message bridge for the DeepSeek Harness desktop shell",
-    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri",
-    "recommended": true
-  },
-  {
-    "id": "dsh-tauri-ui",
-    "spec": "dsh-tauri-ui@0.4.6",
-    "internal": true,
-    "name": "DSH Tauri UI",
-    "description": "Customized Tauri UI plugin for the DeepSeek Harness desktop shell (skeleton): registers the shell.overlay seat for the future desktop chrome",
-    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-ui",
-    "recommended": true
-  },
-  {
-    "id": "dsh-tauri-worktree",
-    "spec": "dsh-tauri-worktree@0.4.6",
-    "internal": true,
-    "name": "DSH Tauri Worktree",
-    "description": "Per-session isolated Git Worktree for the desktop shell: switch a conversation to its own isolated worktree, then check changes back into a local dsh/ branch or discard them.",
-    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-worktree",
-    "recommended": true
-  },
-  {
-    "id": "dsh-tauri-panel",
-    "spec": "dsh-tauri-panel@0.4.6",
-    "internal": true,
-    "name": "DSH Tauri Panel",
-    "description": "Sidebar shell for the desktop: compact logo row (32px), a panel area holding the New Session item plus third-party panel items (sidebar.panel.action slot), and the panel.protocol service (open/render/close panel content) consumed by dsh-tauri-panel-extension.",
-    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-plugins/tree/main/packages/dsh-tauri-panel",
-    "recommended": true
-  },
-  {
-    "id": "dsh-tauri-panel-extension",
-    "spec": "dsh-tauri-panel-extension@0.4.6",
-    "internal": true,
-    "name": "DSH Tauri Panel Extension",
-    "description": "Skills and MCP management in the DeepSeek Harness desktop extension panel.",
-    "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-plugins/tree/main/packages/dsh-tauri-panel-extension",
-    "recommended": true
-  },
-  {
     "id": "dshmarket",
     "spec": "dshmarket",
     "name": "DSH Market",

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -39,6 +39,12 @@ fn windows_drag_browser_args() -> &'static str {
 
 /// setup app
 pub fn setup(app_handle: tauri::AppHandle) {
+    // 升级清理：内部插件资源已迁至 resources/internal-plugins；旧安装可能保留
+    // resources/preset-plugins 目录。仅删除旧目录，失败告警并继续启动。
+    if let Err(e) = crate::service::plugin::remove_legacy_bundled_plugins(&app_handle) {
+        log::warn!("legacy preset plugins cleanup skipped: {e}");
+    }
+
     // 启动前清扫上次崩溃残留的孤儿 Harness（端口/PID 双重确认，见
     // workflow::sweep_orphan_harness），避免新实例一路漂移端口
     crate::service::workflow::sweep_orphan_harness(&app_handle);

--- a/src-tauri/src/service/plugin/install.rs
+++ b/src-tauri/src/service/plugin/install.rs
@@ -1225,7 +1225,7 @@ fn normalize_git_spec(spec: &str) -> String {
 /// - Windows：`shell:true` 时 Node 只把参数按空格拼接、不做引号转义（官方文档
 ///   DEP0190：arguments are not escaped, only concatenated）。内置插件的依赖是
 ///   `link:<应用安装目录>`，而 Windows 安装目录常含空格（如
-///   `G:\Deepseek Harness Desktop\resources\preset-plugins\dsh-tauri`），拼进
+///   `G:\Deepseek Harness Desktop\resources\internal-plugins\dsh-tauri`），拼进
 ///   shell 后会被切碎成多个 spec，pnpm 报 `ERR_PNPM_SPEC_NOT_SUPPORTED` / 装成
 ///   错误依赖，导致启动自愈每轮都重装（死循环）。包一层双引号让 cmd 把整条
 ///   spec 视为一个参数；pnpm 解析后自行剥离引号，落盘 `package.json` 的值仍是
@@ -1390,10 +1390,10 @@ mod tests {
         // 内置插件：安装依赖为 link:<捆绑目录>（正斜杠规范形；pnpm 对
         // `file:D:/...` 的盘符绝对路径会按相对解析，必须用 `link:`）
         let p = preset("dsh-tauri", "dsh-tauri@0.2.0", true);
-        let dir = PathBuf::from("C:\\Apps\\dsh\\resources\\preset-plugins\\dsh-tauri");
+        let dir = PathBuf::from("C:\\Apps\\dsh\\resources\\internal-plugins\\dsh-tauri");
         assert_eq!(
             preset_spec_for_install(&p, Some(dir)).unwrap(),
-            "link:C:/Apps/dsh/resources/preset-plugins/dsh-tauri"
+            "link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri"
         );
     }
 
@@ -1826,8 +1826,8 @@ onlyBuiltDependencies:
         // 使 dsh CLI 的 shell:true 拼接后仍被 shell 视为单一 token（DEP0190：
         // Node 对 shell:true 只拼接不转义）
         assert_eq!(
-            shell_quote_spec("link:G:/Deepseek Harness Desktop/resources/preset-plugins/dsh-tauri"),
-            "\"link:G:/Deepseek Harness Desktop/resources/preset-plugins/dsh-tauri\""
+            shell_quote_spec("link:G:/Deepseek Harness Desktop/resources/internal-plugins/dsh-tauri"),
+            "\"link:G:/Deepseek Harness Desktop/resources/internal-plugins/dsh-tauri\""
         );
         // 制表符同样触发
         assert_eq!(shell_quote_spec("link:C:/x\ty"), "\"link:C:/x\ty\"");
@@ -1840,8 +1840,8 @@ onlyBuiltDependencies:
         // spec 作为一个 argv 传递、空格天然保留，绝不能加引号——字面 `"` 会成为
         // 包名的一部分，pnpm 报非法 spec → exit 1 → 内置插件每次启动重装都失败。
         assert_eq!(
-            shell_quote_spec("link:/Applications/Deepseek Harness Desktop.app/Contents/Resources/resources/preset-plugins/dsh-tauri-ui"),
-            "link:/Applications/Deepseek Harness Desktop.app/Contents/Resources/resources/preset-plugins/dsh-tauri-ui"
+            shell_quote_spec("link:/Applications/Deepseek Harness Desktop.app/Contents/Resources/resources/internal-plugins/dsh-tauri-ui"),
+            "link:/Applications/Deepseek Harness Desktop.app/Contents/Resources/resources/internal-plugins/dsh-tauri-ui"
         );
         assert_eq!(shell_quote_spec("link:/Users/me/my plugins/dsh-tauri"), "link:/Users/me/my plugins/dsh-tauri");
     }
@@ -1856,8 +1856,8 @@ onlyBuiltDependencies:
         );
         // 无空格的内置插件路径同样不被改动（保持与 internal.rs expected 一致）
         assert_eq!(
-            shell_quote_spec("link:C:/Apps/dsh/resources/preset-plugins/dsh-tauri"),
-            "link:C:/Apps/dsh/resources/preset-plugins/dsh-tauri"
+            shell_quote_spec("link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri"),
+            "link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri"
         );
     }
 
@@ -1865,7 +1865,7 @@ onlyBuiltDependencies:
     #[test]
     fn shell_quote_preserves_link_prefix_semantics() {
         // 引号只包 path 部分也不影响 pnpm 解析（落盘值仍为不带引号的 link: 规范形）
-        let quoted = shell_quote_spec("link:G:/Deepseek Harness Desktop/resources/preset-plugins/dsh-tauri");
+        let quoted = shell_quote_spec("link:G:/Deepseek Harness Desktop/resources/internal-plugins/dsh-tauri");
         assert!(quoted.starts_with('"'));
         assert!(quoted.ends_with('"'));
         assert!(quoted.contains("Deepseek Harness Desktop"));

--- a/src-tauri/src/service/plugin/internal.rs
+++ b/src-tauri/src/service/plugin/internal.rs
@@ -1,5 +1,5 @@
-//! 内置插件启动自愈：随安装包分发的内置插件（`preset-plugins.json` 标记
-//! `internal: true`，产物目录 `resources/preset-plugins/<id>` 由构建期
+//! 内置插件启动自愈：随安装包分发的内置插件（条目位于
+//! `internal-plugins.json`，产物目录 `resources/internal-plugins/<id>` 由构建期
 //! `scripts/prebuild.ts` 拉取）在服务启动前核对「是否已安装 + 安装路径是否仍
 //! 指向当前捆绑目录」：未安装 / 路径不正确 / 用户卸载后残留缺失 → 一律走常规
 //! 安装流程强制重装，保证桌面外壳依赖的桥接层（如 dsh-tauri）随包可用。
@@ -47,9 +47,15 @@ pub(crate) async fn ensure(app_handle: &AppHandle) -> Result<(), String> {
         .await;
     // 前端据此在「Loading internal plugins…」与「Loading plugins…」间切换；
     // 事件在服务进程启动前发出，于健康轮询期间到达，先于 dsh 自家的 boot 输出。
-    let _ = app_handle.emit("internal-plugins-phase", InternalPluginsPhase { phase: "loading" });
+    let _ = app_handle.emit(
+        "internal-plugins-phase",
+        InternalPluginsPhase { phase: "loading" },
+    );
     let outcome = ensure_inner(app_handle, &internal).await;
-    let _ = app_handle.emit("internal-plugins-phase", InternalPluginsPhase { phase: "done" });
+    let _ = app_handle.emit(
+        "internal-plugins-phase",
+        InternalPluginsPhase { phase: "done" },
+    );
     outcome
 }
 
@@ -154,55 +160,58 @@ mod tests {
 
     #[test]
     fn dep_spec_matches_itself() {
-        let expected = "link:C:/Apps/dsh/resources/preset-plugins/dsh-tauri";
+        let expected = "link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri";
         // 与自身一致
         assert!(dep_matches_spec(expected, expected));
         // 无 link:/file: 前缀（pnpm 某些场景直接落路径）
         assert!(dep_matches_spec(
-            "C:/Apps/dsh/resources/preset-plugins/dsh-tauri",
+            "C:/Apps/dsh/resources/internal-plugins/dsh-tauri",
             expected
         ));
         // 尾部斜杠差异
         assert!(dep_matches_spec(
-            "link:C:/Apps/dsh/resources/preset-plugins/dsh-tauri/",
+            "link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri/",
             expected
         ));
         // 反斜杠（Windows 原生形式）
         assert!(dep_matches_spec(
-            "link:C:\\Apps\\dsh\\resources\\preset-plugins\\dsh-tauri",
+            "link:C:\\Apps\\dsh\\resources\\internal-plugins\\dsh-tauri",
             expected
         ));
         // 历史遗留 file: 形式（协议切换前已安装的值）
         assert!(dep_matches_spec(
-            "file:C:/Apps/dsh/resources/preset-plugins/dsh-tauri",
+            "file:C:/Apps/dsh/resources/internal-plugins/dsh-tauri",
             expected
         ));
     }
 
     #[test]
     fn dep_spec_rejects_wrong_path_or_source() {
-        let expected = "link:C:/Apps/dsh/resources/preset-plugins/dsh-tauri";
+        let expected = "link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri";
         // 仍指向 npm 版本（用户手动从 npm 安装，非捆绑 link: 源）
         assert!(!dep_matches_spec("dsh-tauri@0.2.0", expected));
         // 指向其它位置（旧版本安装目录等）
         assert!(!dep_matches_spec("link:D:/elsewhere/dsh-tauri", expected));
         // 同名不同宿主盘符
-        assert!(!dep_matches_spec("link:D:/Apps/dsh/resources/preset-plugins/dsh-tauri", expected));
+        assert!(!dep_matches_spec(
+            "link:D:/Apps/dsh/resources/internal-plugins/dsh-tauri",
+            expected
+        ));
     }
 
     #[cfg(windows)]
     #[test]
     fn dep_spec_case_insensitive_on_windows() {
         // Windows 文件系统大小写不敏感，路径比较须忽略大小写
-        let expected = "link:C:/Apps/dsh/resources/preset-plugins/dsh-tauri";
+        let expected = "link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri";
         assert!(dep_matches_spec(
-            "link:c:/apps/DSH/resources/preset-plugins/Dsh-Tauri",
+            "link:c:/apps/DSH/resources/internal-plugins/Dsh-Tauri",
             expected
         ));
         // 实值仍带 Windows 扩展长度前缀（`\\?\`，dunce::simplified 归一化）时，
         // 与归一化掉前缀的期望值仍视为同一路径（幂等，避免不必要的重装）
         assert!(dep_matches_spec(
-            "link://?/C:/Apps/dsh/resources/preset-plugins/dsh-tauri",
+            "link://?/C:/Apps/dsh/resources/internal-plugins/dsh-tauri",
             expected
         ));
     }

--- a/src-tauri/src/service/plugin/mod.rs
+++ b/src-tauri/src/service/plugin/mod.rs
@@ -6,8 +6,8 @@
 //! 启动时加载。进程输出逐行通过 `preinstall-log` 事件实时推送给前端日志面板。
 //! 调用 dsh 前会先按需补齐捆绑 pnpm（老版本升级后可能缺失，安装流程内自愈）。
 //!
-//! 预设清单存放在随安装包分发的 `resources/preset-plugins.json`：社区新增推荐插件
-//! 只需在该 JSON 中追加一项并提交 PR，无需改动 Rust 代码；界面与安装逻辑自动生效。
+//! 社区预设与内部插件分别存放在随安装包分发的 `resources/preset-plugins.json`
+//! 和 `resources/internal-plugins.json`；新增条目无需改动 Rust 代码。
 //!
 //! **重新进入引导的判定**：该 JSON 随安装包发布、每次安装都被强制覆盖，旧文件不可比对，
 //! 因此引导结束（确认/跳过）时把文件内容指纹（FNV-1a）写入 app-data 的 `.store.dat`；
@@ -15,7 +15,7 @@
 //! 弹一次建立基线（见 [`preset::preinstall_pending`]）。
 //!
 //! 模块划分（参考 `service/cli/`、`service/download/`）：
-//! - [`preset`]：预设清单读取与解析（`resources/preset-plugins.json`）
+//! - [`preset`]：预设与内部插件清单读取、合并及资源目录定位
 //! - [`installed`]：profile 内已安装插件检测（解析 package.json 的依赖与 bundles）
 //! - [`internal`]：内置插件启动自愈（随包分发产物缺失/路径变更时强制重装）
 //! - [`verify`]：预装插件完整性自检（清单引用但 node_modules 产物缺失时 `pnpm install` 修复）
@@ -38,13 +38,15 @@ pub mod verify;
 pub mod watch;
 
 pub use cancel::cancel;
-pub use install::{install, remove, update};
 pub(crate) use install::harness_prefer_bundled_pnpm;
-pub use installed::{list, PreinstallPlugin};
+pub use install::{install, remove, update};
 pub(crate) use installed::ensure_profile_npmrc;
+pub use installed::{list, PreinstallPlugin};
 pub(crate) use internal::ensure as ensure_internal_plugins;
 pub use preset::repo_url_of;
-pub(crate) use preset::{current_preset_hash, preinstall_pending};
-pub use recovery::{detect as detect_recovery, uninstall as uninstall_recovery, PluginRecoveryInfo};
+pub(crate) use preset::{current_preset_hash, preinstall_pending, remove_legacy_bundled_plugins};
+pub use recovery::{
+    detect as detect_recovery, uninstall as uninstall_recovery, PluginRecoveryInfo,
+};
 pub(crate) use verify::ensure_preset_plugins;
 pub use watch::DshPlugin;

--- a/src-tauri/src/service/plugin/preset.rs
+++ b/src-tauri/src/service/plugin/preset.rs
@@ -1,7 +1,8 @@
-//! 预设插件清单：读取并解析随安装包分发的 `resources/preset-plugins.json`。
+//! 插件清单：分别读取随安装包分发的 `resources/preset-plugins.json` 与
+//! `resources/internal-plugins.json`。
 //!
-//! 社区新增推荐插件只需在该 JSON 中追加一项并提交 PR，无需改动 Rust 代码；
-//! 界面与安装逻辑自动生效。资源缺失/损坏时报错并回落为空清单，不阻断启动。
+//! 社区预设与内部插件分开维护；运行时合并为统一结构供安装、展示与自愈逻辑使用。
+//! 资源缺失/损坏时报错并回落为空清单，不阻断启动。
 
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -11,8 +12,10 @@ use crate::config;
 
 /// 预设插件清单文件名
 const PRESET_PLUGINS_FILE: &str = "preset-plugins.json";
+/// 内部插件清单文件名
+const INTERNAL_PLUGINS_FILE: &str = "internal-plugins.json";
 
-/// 预装插件静态信息，对应 `resources/preset-plugins.json` 中的条目
+/// 插件静态信息，对应预设或内部插件清单中的条目
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PreinstallPluginInfo {
@@ -20,8 +23,9 @@ pub struct PreinstallPluginInfo {
     pub id: String,
     /// 传给 `dsh plugin add` 的依赖形式（npm 包名或 git 依赖形式）
     pub spec: String,
-    /// 内置插件：产物由构建期 `scripts/prebuild.ts` 从上游仓库拉取到
-    /// `resources/preset-plugins/<id>/` 随安装包分发，安装固定走 `file:` 本地
+    /// 内置插件：条目来自 `resources/internal-plugins.json`，产物由构建期
+    /// `scripts/prebuild.ts` 从上游仓库拉取到 `resources/internal-plugins/<id>/`
+    /// 随安装包分发，安装固定走 `link:` 本地
     /// 依赖；启动时强制核对「已安装 + 路径指向当前捆绑目录」，不满足即自动
     /// 重装（用户卸载后重启应用同样恢复），因此不出现在首次引导的勾选清单里。
     #[serde(default)]
@@ -48,39 +52,45 @@ pub struct PreinstallPluginInfo {
     pub win_only: bool,
 }
 
-/// 在资源根目录下查找预设清单：先探测扁平布局（exe 同级），再探测
+/// 在资源根目录下查找清单：先探测扁平布局（exe 同级），再探测
 /// `resources/` 子目录布局（Tauri 2 的 `bundle.resources` 按相对路径保留前缀）。
-fn find_in_resource_root(root: &std::path::Path) -> Option<PathBuf> {
-    let flat = root.join(PRESET_PLUGINS_FILE);
+fn find_manifest_in_resource_root(root: &std::path::Path, file_name: &str) -> Option<PathBuf> {
+    let flat = root.join(file_name);
     if flat.exists() {
         return Some(flat);
     }
-    let nested = root.join("resources").join(PRESET_PLUGINS_FILE);
+    let nested = root.join("resources").join(file_name);
     nested.exists().then_some(nested)
 }
 
-/// 定位预设插件清单文件：优先使用随安装包分发的资源目录，回落到源码开发目录。
+/// 定位插件清单文件：优先使用随安装包分发的资源目录，回落到源码开发目录。
 ///
 /// 注意：Tauri 2 在 Windows 上 `resource_dir()` 恒等于 exe 所在目录，而安装包
 /// （NSIS/MSI）与开发产物都会把资源按 `resources/**` 前缀落盘到
 /// `{resource_dir}/resources/` 子目录，因此必须探测该子目录；`CARGO_MANIFEST_DIR`
 /// 是编译期路径，仅开发机有效（CI/发布版在本机不可用），只作最后兜底。
-fn preset_plugins_path(app_handle: &AppHandle) -> Option<PathBuf> {
+fn plugins_manifest_path(app_handle: &AppHandle, file_name: &str) -> Option<PathBuf> {
     if let Ok(dir) = app_handle.path().resource_dir() {
-        if let Some(candidate) = find_in_resource_root(&dir) {
+        if let Some(candidate) = find_manifest_in_resource_root(&dir, file_name) {
             return Some(candidate);
         }
     }
     let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("resources")
-        .join(PRESET_PLUGINS_FILE);
+        .join(file_name);
     source.exists().then_some(source)
 }
 
-/// 内置插件资源目录名（相对资源根的固定前缀）
-const BUNDLED_PLUGINS_DIR: &str = "preset-plugins";
+fn preset_plugins_path(app_handle: &AppHandle) -> Option<PathBuf> {
+    plugins_manifest_path(app_handle, PRESET_PLUGINS_FILE)
+}
 
-/// 在资源根目录下定位某内置插件的捆绑目录：与 [`find_in_resource_root`] 相同的
+/// 内置插件资源目录名（相对资源根的固定前缀）
+const BUNDLED_PLUGINS_DIR: &str = "internal-plugins";
+/// 旧版内置插件资源目录名，仅用于启动迁移清理
+const LEGACY_BUNDLED_PLUGINS_DIR: &str = "preset-plugins";
+
+/// 在资源根目录下定位某内置插件的捆绑目录：与 [`find_manifest_in_resource_root`] 相同的
 /// 布局探测——先 `resources/` 子目录（安装包/开发产物按 `bundle.resources` 前缀
 /// 落盘），再扁平布局；以目录内存在 `package.json` 判定产物有效（prebuild 恒写入）。
 fn find_bundled_in_root(root: &std::path::Path, id: &str) -> Option<PathBuf> {
@@ -92,7 +102,7 @@ fn find_bundled_in_root(root: &std::path::Path, id: &str) -> Option<PathBuf> {
 }
 
 /// 定位内置插件捆绑目录：优先随安装包分发的资源目录，回落到源码
-/// `resources/preset-plugins/<id>`（开发机未跑 prebuild 时作为源码兜底）。
+/// `resources/internal-plugins/<id>`（开发机未跑 prebuild 时作为源码兜底）。
 ///
 /// 用于安装（`install.rs` 生成 `file:` 依赖）与启动自愈（`internal.rs` 核对路径）。
 ///
@@ -118,6 +128,40 @@ pub(crate) fn bundled_plugin_dir(app_handle: &AppHandle, id: &str) -> Option<Pat
     source.join("package.json").exists().then_some(source)
 }
 
+/// 删除旧版随包资源目录 `resources/preset-plugins`，避免升级安装保留不再使用的
+/// 内部插件副本。仅删除目录，不影响同级 `preset-plugins.json` 社区预设清单。
+pub(crate) fn remove_legacy_bundled_plugins(app_handle: &AppHandle) -> Result<(), String> {
+    let mut candidates = Vec::new();
+    if let Ok(root) = app_handle.path().resource_dir() {
+        candidates.push(root.join(LEGACY_BUNDLED_PLUGINS_DIR));
+        candidates.push(root.join("resources").join(LEGACY_BUNDLED_PLUGINS_DIR));
+    }
+    candidates.push(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("resources")
+            .join(LEGACY_BUNDLED_PLUGINS_DIR),
+    );
+    candidates.sort();
+    candidates.dedup();
+
+    for path in candidates {
+        if !path.is_dir() {
+            continue;
+        }
+        std::fs::remove_dir_all(&path).map_err(|e| {
+            format!(
+                "LEGACY_PRESET_PLUGINS_REMOVE_FAILED: {}: {e}",
+                path.display()
+            )
+        })?;
+        log::info!(
+            "removed legacy bundled plugins directory: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 /// 开发模式内置插件源码根目录：读取 `<仓库根>/.env` 的 `DEV_INTERNAL_PLUGINS_DIR`。
 /// 仅 debug 构建生效（release 恒用随包目录，不受构建机环境影响）。
 ///
@@ -125,7 +169,9 @@ pub(crate) fn bundled_plugin_dir(app_handle: &AppHandle, id: &str) -> Option<Pat
 /// `CARGO_MANIFEST_DIR`（即 `src-tauri`）的上层目录得到，只在开发机成立。
 #[cfg(debug_assertions)]
 fn dev_internal_plugins_dir() -> Option<PathBuf> {
-    let env_file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join(".env");
+    let env_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join(".env");
     let content = std::fs::read_to_string(env_file).ok()?;
     parse_dev_internal_dir(&content)
 }
@@ -173,30 +219,46 @@ pub(crate) fn bundled_dep_spec(dir: &std::path::Path) -> String {
     format!("link:{}", normalized.trim_end_matches('/'))
 }
 
-/// 解析预设清单 JSON
-fn parse_presets(json: &str) -> Result<Vec<PreinstallPluginInfo>, String> {
-    serde_json::from_str(json).map_err(|e| format!("PRESET_PLUGINS_INVALID_JSON: {e}"))
+/// 解析插件清单 JSON，并由清单来源统一设置内部插件标记。
+fn parse_plugins(json: &str, internal: bool) -> Result<Vec<PreinstallPluginInfo>, String> {
+    let mut plugins: Vec<PreinstallPluginInfo> =
+        serde_json::from_str(json).map_err(|e| format!("PLUGIN_MANIFEST_INVALID_JSON: {e}"))?;
+    for plugin in &mut plugins {
+        plugin.internal = internal;
+    }
+    Ok(plugins)
 }
 
-/// 读取并解析预设插件清单；资源缺失/损坏时记录错误并返回空清单
-pub(crate) fn load_presets(app_handle: &AppHandle) -> Vec<PreinstallPluginInfo> {
-    let Some(path) = preset_plugins_path(app_handle) else {
-        log::warn!("PRESET_PLUGINS_MISSING: {PRESET_PLUGINS_FILE} not found in resource dir or source resources dir");
+/// 读取单个插件清单；资源缺失/损坏时记录错误并返回空清单。
+fn load_manifest(
+    app_handle: &AppHandle,
+    file_name: &str,
+    internal: bool,
+) -> Vec<PreinstallPluginInfo> {
+    let Some(path) = plugins_manifest_path(app_handle, file_name) else {
+        log::warn!("PLUGIN_MANIFEST_MISSING: {file_name} not found in resource dir or source resources dir");
         return Vec::new();
     };
 
     let raw = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) => {
-            log::error!("PRESET_PLUGINS_READ_FAILED: {}: {e}", path.display());
+            log::error!("PLUGIN_MANIFEST_READ_FAILED: {}: {e}", path.display());
             return Vec::new();
         }
     };
 
-    parse_presets(&raw).unwrap_or_else(|e| {
-        log::error!("PRESET_PLUGINS_PARSE_FAILED: {}: {e}", path.display());
+    parse_plugins(&raw, internal).unwrap_or_else(|e| {
+        log::error!("PLUGIN_MANIFEST_PARSE_FAILED: {}: {e}", path.display());
         Vec::new()
     })
+}
+
+/// 读取预设与内部插件清单并合并；内部属性由文件归属决定，不依赖 JSON 字段。
+pub(crate) fn load_presets(app_handle: &AppHandle) -> Vec<PreinstallPluginInfo> {
+    let mut plugins = load_manifest(app_handle, PRESET_PLUGINS_FILE, false);
+    plugins.extend(load_manifest(app_handle, INTERNAL_PLUGINS_FILE, true));
+    plugins
 }
 
 /// 预装清单中某 id 对应的仓库地址
@@ -234,7 +296,10 @@ pub(crate) fn preinstall_pending(app_handle: &AppHandle) -> bool {
     if !setting.preinstall_done {
         return true;
     }
-    match (setting.preset_hash.as_deref(), current_preset_hash(app_handle)) {
+    match (
+        setting.preset_hash.as_deref(),
+        current_preset_hash(app_handle),
+    ) {
         (None, Some(_)) => true,
         (Some(prev), Some(cur)) => prev != cur,
         _ => false,
@@ -245,12 +310,22 @@ pub(crate) fn preinstall_pending(app_handle: &AppHandle) -> bool {
 mod tests {
     use super::*;
 
-    fn load_presets_for_test() -> Vec<PreinstallPluginInfo> {
+    fn load_manifest_for_test(file_name: &str, internal: bool) -> Vec<PreinstallPluginInfo> {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("resources")
-            .join(PRESET_PLUGINS_FILE);
-        let raw = std::fs::read_to_string(path).expect("preset-plugins.json should exist");
-        parse_presets(&raw).expect("preset-plugins.json should be valid JSON")
+            .join(file_name);
+        let raw = std::fs::read_to_string(path).expect("plugin manifest should exist");
+        parse_plugins(&raw, internal).expect("plugin manifest should be valid JSON")
+    }
+
+    fn load_presets_for_test() -> Vec<PreinstallPluginInfo> {
+        load_manifest_for_test(PRESET_PLUGINS_FILE, false)
+    }
+
+    fn load_all_plugins_for_test() -> Vec<PreinstallPluginInfo> {
+        let mut plugins = load_presets_for_test();
+        plugins.extend(load_manifest_for_test(INTERNAL_PLUGINS_FILE, true));
+        plugins
     }
 
     #[test]
@@ -268,11 +343,23 @@ mod tests {
     }
 
     #[test]
-    fn preset_json_ids_are_unique() {
-        let presets = load_presets_for_test();
-        let ids: std::collections::HashSet<&str> =
-            presets.iter().map(|p| p.id.as_str()).collect();
-        assert_eq!(ids.len(), presets.len(), "preset ids must be unique");
+    fn plugin_manifest_ids_are_unique_across_files() {
+        let plugins = load_all_plugins_for_test();
+        let ids: std::collections::HashSet<&str> = plugins.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(
+            ids.len(),
+            plugins.len(),
+            "plugin ids must be unique across manifests"
+        );
+    }
+
+    #[test]
+    fn internal_manifest_marks_all_entries_internal() {
+        let plugins = load_manifest_for_test(INTERNAL_PLUGINS_FILE, true);
+        assert!(!plugins.is_empty());
+        assert!(plugins.iter().all(|plugin| plugin.internal));
+        assert!(plugins.iter().any(|plugin| plugin.id == "dsh-tauri"));
+        assert!(!load_presets_for_test().iter().any(|plugin| plugin.internal));
     }
 
     #[test]
@@ -289,7 +376,8 @@ mod tests {
         )
         .expect("write temp preset file");
 
-        let found = find_in_resource_root(&dir).expect("nested resources layout should be found");
+        let found = find_manifest_in_resource_root(&dir, PRESET_PLUGINS_FILE)
+            .expect("nested resources layout should be found");
         assert_eq!(found, nested.join(PRESET_PLUGINS_FILE));
 
         std::fs::remove_dir_all(&dir).ok();
@@ -306,37 +394,36 @@ mod tests {
         )
         .expect("write temp preset file");
 
-        let found = find_in_resource_root(&dir).expect("flat layout should be found");
+        let found = find_manifest_in_resource_root(&dir, PRESET_PLUGINS_FILE)
+            .expect("flat layout should be found");
         assert_eq!(found, dir.join(PRESET_PLUGINS_FILE));
 
         std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
-    fn internal_flag_parses_with_default_false() {
-        // 无 internal 字段 → 默认 false（老清单兼容）
-        let plain: PreinstallPluginInfo = serde_json::from_str(
-            r#"{"id":"x","spec":"y","name":"X","description":"","repoUrl":"u"}"#,
-        )
-        .expect("plain preset should parse");
-        assert!(!plain.internal);
-        // 显式 internal:true → 解析为内置插件
-        let internal: PreinstallPluginInfo = serde_json::from_str(
-            r#"{"id":"x","spec":"github:a/b","internal":true,"name":"X","description":"","repoUrl":"u"}"#,
-        )
-        .expect("internal preset should parse");
-        assert!(internal.internal);
+    fn manifest_source_overrides_internal_field() {
+        let raw =
+            r#"[{"id":"x","spec":"y","internal":true,"name":"X","description":"","repoUrl":"u"}]"#;
+        let preset = parse_plugins(raw, false).expect("preset manifest should parse");
+        assert!(!preset[0].internal);
+        let internal = parse_plugins(raw, true).expect("internal manifest should parse");
+        assert!(internal[0].internal);
     }
 
     #[test]
     fn bundled_dir_discovers_nested_layout() {
-        // 与 preset 文件一致：先探测 {root}/resources/preset-plugins/<id>
+        // 与 internal 文件一致：先探测 {root}/resources/internal-plugins/<id>
         let dir = std::env::temp_dir().join(format!("dsh-bundled-nested-{}", std::process::id()));
-        let nested = dir.join("resources").join(BUNDLED_PLUGINS_DIR).join("dsh-tauri");
+        let nested = dir
+            .join("resources")
+            .join(BUNDLED_PLUGINS_DIR)
+            .join("dsh-tauri");
         std::fs::create_dir_all(&nested).expect("create temp nested bundled dir");
         std::fs::write(nested.join("package.json"), "{}").expect("write bundle manifest");
 
-        let found = find_bundled_in_root(&dir, "dsh-tauri").expect("nested bundled dir should be found");
+        let found =
+            find_bundled_in_root(&dir, "dsh-tauri").expect("nested bundled dir should be found");
         assert_eq!(found, nested);
 
         std::fs::remove_dir_all(&dir).ok();
@@ -349,7 +436,8 @@ mod tests {
         std::fs::create_dir_all(&flat).expect("create temp flat bundled dir");
         std::fs::write(flat.join("package.json"), "{}").expect("write bundle manifest");
 
-        let found = find_bundled_in_root(&dir, "dsh-tauri").expect("flat bundled dir should be found");
+        let found =
+            find_bundled_in_root(&dir, "dsh-tauri").expect("flat bundled dir should be found");
         assert_eq!(found, flat);
 
         std::fs::remove_dir_all(&dir).ok();
@@ -359,7 +447,8 @@ mod tests {
     fn bundled_dir_requires_package_json() {
         // 无 package.json 的目录不是有效产物（prebuild 未执行）
         let dir = std::env::temp_dir().join(format!("dsh-bundled-empty-{}", std::process::id()));
-        std::fs::create_dir_all(dir.join("preset-plugins").join("dsh-tauri")).expect("create empty dir");
+        std::fs::create_dir_all(dir.join(BUNDLED_PLUGINS_DIR).join("dsh-tauri"))
+            .expect("create empty dir");
         assert!(find_bundled_in_root(&dir, "dsh-tauri").is_none());
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -367,8 +456,10 @@ mod tests {
     #[test]
     fn bundled_dep_spec_normalizes_windows_separators() {
         assert_eq!(
-            bundled_dep_spec(std::path::Path::new("C:\\Apps\\dsh\\resources\\preset-plugins\\dsh-tauri")),
-            "link:C:/Apps/dsh/resources/preset-plugins/dsh-tauri"
+            bundled_dep_spec(std::path::Path::new(
+                "C:\\Apps\\dsh\\resources\\internal-plugins\\dsh-tauri"
+            )),
+            "link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri"
         );
         // 尾部斜杠去除（Windows 盘符 C:\ 不会出现，路径恒为子目录）
         assert_eq!(
@@ -385,11 +476,11 @@ mod tests {
         // `//?/G:/...` 当相对路径解析、生成 `..\?\G:\...` 的坏联接而安装失败。
         // （dunce::simplified 在 Windows 上把 `\\?\` 归一回常规绝对路径）
         let dir = std::path::Path::new(
-            r"\\?\G:\Deepseek Harness Desktop\resources\preset-plugins\dsh-tauri",
+            r"\\?\G:\Deepseek Harness Desktop\resources\internal-plugins\dsh-tauri",
         );
         assert_eq!(
             bundled_dep_spec(dir),
-            "link:G:/Deepseek Harness Desktop/resources/preset-plugins/dsh-tauri"
+            "link:G:/Deepseek Harness Desktop/resources/internal-plugins/dsh-tauri"
         );
     }
 
@@ -426,7 +517,10 @@ mod tests {
     fn dev_internal_dir_unset_when_missing_key_or_empty_value() {
         // 其它键或注释：视为未设置
         assert_eq!(parse_dev_internal_dir("FOO=bar\n"), None);
-        assert_eq!(parse_dev_internal_dir("# DEV_INTERNAL_PLUGINS_DIR=C:/x\n"), None);
+        assert_eq!(
+            parse_dev_internal_dir("# DEV_INTERNAL_PLUGINS_DIR=C:/x\n"),
+            None
+        );
         // 显式置空：同样视为未设置（关闭覆盖）
         assert_eq!(parse_dev_internal_dir("DEV_INTERNAL_PLUGINS_DIR=\n"), None);
     }

--- a/src-tauri/src/service/plugin/preset.rs
+++ b/src-tauri/src/service/plugin/preset.rs
@@ -129,37 +129,51 @@ pub(crate) fn bundled_plugin_dir(app_handle: &AppHandle, id: &str) -> Option<Pat
 }
 
 /// 删除旧版随包资源目录 `resources/preset-plugins`，避免升级安装保留不再使用的
-/// 内部插件副本。仅删除目录，不影响同级 `preset-plugins.json` 社区预设清单。
+/// 内部插件副本。仅处理 Tauri 运行时资源根下的目录，绝不删除源码 checkout；逐个
+/// 尝试所有布局后再汇总错误，避免一个被占用的旧目录阻碍其余目录清理。
 pub(crate) fn remove_legacy_bundled_plugins(app_handle: &AppHandle) -> Result<(), String> {
-    let mut candidates = Vec::new();
-    if let Ok(root) = app_handle.path().resource_dir() {
-        candidates.push(root.join(LEGACY_BUNDLED_PLUGINS_DIR));
-        candidates.push(root.join("resources").join(LEGACY_BUNDLED_PLUGINS_DIR));
-    }
-    candidates.push(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("resources")
-            .join(LEGACY_BUNDLED_PLUGINS_DIR),
-    );
+    let Ok(root) = app_handle.path().resource_dir() else {
+        return Ok(());
+    };
+    let candidates = vec![
+        root.join(LEGACY_BUNDLED_PLUGINS_DIR),
+        root.join("resources").join(LEGACY_BUNDLED_PLUGINS_DIR),
+    ];
+    remove_legacy_candidates(candidates, |path| std::fs::remove_dir_all(path))
+}
+
+/// 对候选旧目录执行最佳努力清理；删除动作参数化是为了验证单项失败后仍继续处理。
+fn remove_legacy_candidates(
+    mut candidates: Vec<PathBuf>,
+    mut remove: impl FnMut(&std::path::Path) -> std::io::Result<()>,
+) -> Result<(), String> {
     candidates.sort();
     candidates.dedup();
+    let mut failures = Vec::new();
 
     for path in candidates {
         if !path.is_dir() {
             continue;
         }
-        std::fs::remove_dir_all(&path).map_err(|e| {
-            format!(
+        match remove(&path) {
+            Ok(()) => {
+                log::info!(
+                    "removed legacy bundled plugins directory: {}",
+                    path.display()
+                );
+            }
+            Err(e) => failures.push(format!(
                 "LEGACY_PRESET_PLUGINS_REMOVE_FAILED: {}: {e}",
                 path.display()
-            )
-        })?;
-        log::info!(
-            "removed legacy bundled plugins directory: {}",
-            path.display()
-        );
+            )),
+        }
     }
-    Ok(())
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("; "))
+    }
 }
 
 /// 开发模式内置插件源码根目录：读取 `<仓库根>/.env` 的 `DEV_INTERNAL_PLUGINS_DIR`。
@@ -220,6 +234,9 @@ pub(crate) fn bundled_dep_spec(dir: &std::path::Path) -> String {
 }
 
 /// 解析插件清单 JSON，并由清单来源统一设置内部插件标记。
+///
+/// 清单边界是可信的产品分类：即使条目误带或遗漏 `internal` 字段，也不能让社区
+/// 预设获得必装自愈权限，或让内部插件退出自愈流程，因此始终以文件来源覆盖该值。
 fn parse_plugins(json: &str, internal: bool) -> Result<Vec<PreinstallPluginInfo>, String> {
     let mut plugins: Vec<PreinstallPluginInfo> =
         serde_json::from_str(json).map_err(|e| format!("PLUGIN_MANIFEST_INVALID_JSON: {e}"))?;
@@ -230,6 +247,9 @@ fn parse_plugins(json: &str, internal: bool) -> Result<Vec<PreinstallPluginInfo>
 }
 
 /// 读取单个插件清单；资源缺失/损坏时记录错误并返回空清单。
+///
+/// 插件元数据不是桌面壳启动的硬依赖；降级为空列表可让核心服务继续启动，同时用
+/// 明确日志保留发布资源缺失或损坏的诊断信息，避免清单故障导致应用整体不可用。
 fn load_manifest(
     app_handle: &AppHandle,
     file_name: &str,
@@ -409,6 +429,37 @@ mod tests {
         assert!(!preset[0].internal);
         let internal = parse_plugins(raw, true).expect("internal manifest should parse");
         assert!(internal[0].internal);
+    }
+
+    #[test]
+    fn legacy_cleanup_continues_after_failure_and_aggregates_errors() {
+        let root = std::env::temp_dir().join(format!("dsh-legacy-cleanup-{}", std::process::id()));
+        let first = root.join("a");
+        let second = root.join("b");
+        std::fs::create_dir_all(&first).expect("create first legacy dir");
+        std::fs::create_dir_all(&second).expect("create second legacy dir");
+        let mut attempted = Vec::new();
+
+        let error = remove_legacy_candidates(vec![first.clone(), second.clone()], |path| {
+            attempted.push(path.to_path_buf());
+            if path == first {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "locked",
+                ))
+            } else {
+                std::fs::remove_dir_all(path)
+            }
+        })
+        .expect_err("one failed cleanup should be reported");
+
+        assert_eq!(attempted, vec![first.clone(), second.clone()]);
+        assert!(error.contains("LEGACY_PRESET_PLUGINS_REMOVE_FAILED"));
+        assert!(error.contains(&first.display().to_string()));
+        assert!(error.contains("locked"));
+        assert!(first.is_dir());
+        assert!(!second.exists());
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- move internal plugin entries from preset-plugins.json to internal-plugins.json
- bundle downloaded internal plugins under resources/internal-plugins
- remove the legacy resources/preset-plugins directory during startup
- update runtime manifest loading, tests, and documentation

## Verification
- cargo check
- cargo test service::plugin::preset::tests
- cargo test service::plugin::internal::tests
- cargo test service::plugin::install::tests::install_spec_
- plugin manifest JSON parse validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated catalog for five recommended built-in plugins.
  - Built-in plugins are now bundled separately from community preset plugins for clearer management.

- **Bug Fixes**
  - Legacy built-in plugin files are automatically cleaned up during startup.
  - Cleanup failures no longer prevent the application from launching.

- **Documentation**
  - Updated plugin setup, packaging, resource paths, and development guidance to reflect the new built-in plugin structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->