### PR TITLE
chore: release v0.9.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.8.5",
+  "version": "0.9.0-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.8.5"
+version = "0.9.0-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.8.5"
+version = "0.9.0-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.8.5",
+  "version": "0.9.0-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.9.0-beta.1` (`0.8.5` → `0.9.0-beta.1`).

### Features

- prepare internal plugins before tauri dev (f52a1c7)
- add persistent desktop zoom controls (125a5ff)

### Bug Fixes

- harden legacy plugin cleanup (60238e7)
- serialize desktop zoom operations (e3c3d09)
- fix missing parts of the document (f3e515a)
- readme (a92d695)
- **config**: constrain dialog content height (45a8ca8)
- bind direct pnpm repair to executable (2eb4efe)
- discover mise pnpm shims (0b04f92)
- **workflow**: macOS port probe false EADDRINUSE after socket close (5a341f0)
- **macos**: use native clipboard for run logs (3fcf95f)

### Refactors

- separate internal plugin resources (8296896)
- **port**: simplify port occupancy detection logic and remove socket2 dependencies (b1cca83)

### Documentation

- explain zoom transaction locking (aa7ab40)
- **plugins**: update built-in plugin examples (5c26efa)
- **readme**: refresh product preview gallery (1bab39b)

### Tests

- normalize discovered pnpm expectations (e604782)

### Styles

- format macOS zoom dependency (d3f6d05)

### Chores

- update internal-plugin (e92177c)
- update preset plugins (0f74e3e)
- update readme (1917c69)
- update readme (2435605)

### Other Changes

- Merge pull request #159 from Jstn-1g/fix/37-desktop-zoom (4a07f3b)
- Merge pull request #162 from dsh-tauri-desk/feat/predev-internal-plugins (c708759)
- Merge pull request #161 from dsh-tauri-desk/dsh/migrate-internal-plugins (c42fb5b)
- Merge pull request #157 from dsh-tauri-desk/dsh/change (727bc25)
- Merge pull request #156 from Jstn-1g/fix/152-mise-shim-discovery (1682a65)
- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (24750c7)
- Merge pull request #150 from dsh-tauri-desk/fix/ci-macos-port-probe-flaky (4802fc4)
- Merge pull request #148 from Jstn-1g/fix/145-native-clipboard (70ae6ac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.9.0-beta.1** across all release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->