### PR TITLE
chore(plugin): resolve latest internal plugin releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src-tauri/target
 src-tauri/gen
 src-tauri/resources/node
 src-tauri/resources/preset-plugins/
+src-tauri/resources/internal-plugins/
 *.log
 .DS_Store
 .idea

--- a/docs/BUILTIN_PLUGINS.md
+++ b/docs/BUILTIN_PLUGINS.md
@@ -42,7 +42,7 @@ Append an entry:
 Field reference:
 
 - `id` — unique preset id (the repo jump / lookup key; also the default npm package name used for install-state detection). Ids must be unique across the list (enforced by the `preset_json_ids_are_unique` unit test).
-- `spec` — the source. Either `github:owner/repo` (source form) or a bare npm package name `name[@version]` (published form, skips the build). This is what `prebuild.ts` feeds to git/pnpm.
+- `spec` — the source. Either `github:owner/repo` (source form) or an npm package spec `name[@version]` (published form, skips the build). Omit `@version` to resolve the registry's latest release at build time, which avoids manifest-only version bumps. This is what `prebuild.ts` feeds to git/pnpm.
 - `name`, `description`, `repoUrl` — display metadata. `repoUrl` is used for the repo-jump link in the UI.
 - `package` — optional. When the real npm package name differs from `id` (typical for scoped `@scope/name`), declare it here; it is used for install-state detection and self-heal matching. Defaults to `id`.
 - Chip flags `recommended` / `fix` / `defaultChecked` — not meaningful for internal plugins (they never appear in the checklist) but harmless to keep.

--- a/docs/BUILTIN_PLUGINS.zh.md
+++ b/docs/BUILTIN_PLUGINS.zh.md
@@ -42,7 +42,7 @@
 字段说明：
 
 - `id` — 预设唯一 id（仓库跳转 / 查找键；也是未显式声明 `package` 时的默认包名，用于“已安装”检测）。清单内 id 必须唯一（由 `preset_json_ids_are_unique` 单测保证）。
-- `spec` — 来源。要么 `github:owner/repo`（源码形态），要么裸 npm 包名 `name[@version]`（已发布产物形态，跳过构建）。这是 `prebuild.ts` 喂给 git/pnpm 的值。
+- `spec` — 来源。要么 `github:owner/repo`（源码形态），要么 npm 包规格 `name[@version]`（已发布产物形态，跳过构建）。省略 `@version` 时会在构建期解析 registry 中的最新正式版本，避免仅为升级插件而修改清单版本号。这是 `prebuild.ts` 喂给 git/pnpm 的值。
 - `name`、`description`、`repoUrl` — 展示元数据；`repoUrl` 供界面“仓库跳转”链接使用。
 - `package` — 可选。当真实 npm 包名与 `id` 不一致（常见于 scoped 包 `@scope/name`）时在这里声明；用于“已安装”检测与自愈对账。缺省回落 `id`。
 - chip 标记 `recommended` / `fix` / `defaultChecked` — 对内置插件无意义（它们不进清单），保留也无妨。

--- a/src-tauri/resources/internal-plugins.json
+++ b/src-tauri/resources/internal-plugins.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "dsh-tauri",
-    "spec": "dsh-tauri@0.4.8",
+    "spec": "dsh-tauri",
     "name": "DSH Tauri",
     "description": "Message bridge for the DeepSeek Harness desktop shell",
     "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri",
@@ -9,7 +9,7 @@
   },
   {
     "id": "dsh-tauri-ui",
-    "spec": "dsh-tauri-ui@0.4.8",
+    "spec": "dsh-tauri-ui",
     "name": "DSH Tauri UI",
     "description": "Customized Tauri UI plugin for the DeepSeek Harness desktop shell (skeleton): registers the shell.overlay seat for the future desktop chrome",
     "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-ui",
@@ -17,7 +17,7 @@
   },
   {
     "id": "dsh-tauri-worktree",
-    "spec": "dsh-tauri-worktree@0.4.8",
+    "spec": "dsh-tauri-worktree",
     "name": "DSH Tauri Worktree",
     "description": "Per-session isolated Git Worktree for the desktop shell: switch a conversation to its own isolated worktree, then check changes back into a local dsh/ branch or discard them.",
     "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-worktree",
@@ -25,7 +25,7 @@
   },
   {
     "id": "dsh-tauri-panel",
-    "spec": "dsh-tauri-panel@0.4.8",
+    "spec": "dsh-tauri-panel",
     "name": "DSH Tauri Panel",
     "description": "Sidebar shell for the desktop: compact logo row (32px), a panel area holding the New Session item plus third-party panel items (sidebar.panel.action slot), and the panel.protocol service (open/render/close panel content) consumed by dsh-tauri-panel-extension.",
     "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-plugins/tree/main/packages/dsh-tauri-panel",
@@ -33,7 +33,7 @@
   },
   {
     "id": "dsh-tauri-panel-extension",
-    "spec": "dsh-tauri-panel-extension@0.4.8",
+    "spec": "dsh-tauri-panel-extension",
     "name": "DSH Tauri Panel Extension",
     "description": "Skills and MCP management in the DeepSeek Harness desktop extension panel.",
     "repoUrl": "https://github.com/dsh-tauri-desk/dsh-tauri-plugins/tree/main/packages/dsh-tauri-panel-extension",


### PR DESCRIPTION
## Summary
- remove pinned versions from all internal npm plugin specs so release builds resolve the registry's latest published versions
- ignore generated internal plugin bundles in the worktree
- document the unversioned npm spec behavior in English and Chinese guides

## Validation
- `pnpm prebuild` (resolved and bundled all five plugins at 0.4.9)
- `pnpm typecheck`
- `pnpm lint scripts/prebuild.ts`
- `git diff --check`
- `cargo test service::plugin` *(environment failure: MSVC build environment is unavailable, so native dependencies such as zstd-sys/bzip2-sys could not compile)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Built-in plugins can now omit an npm version, allowing the build process to use the latest stable release automatically.

- **Documentation**
  - Updated the built-in plugin documentation in English and Chinese to explain version omission and automatic release resolution.
  - Updated the default built-in plugin configuration to use unversioned package specifications for supported plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->