### PR TITLE
chore: release v0.9.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.9.0-beta.3` (`0.9.0-beta.2` → `0.9.0-beta.3`).

### Bug Fixes

- **ci**: use supported concurrency syntax (7002016)
- **ci**: publish releases after artifact validation (411a32f)
- **ci**: preserve all serialized platform builds (31e06cd)
- **ci**: serialize release asset publishing (5848545)
- **ci**: restore release notes and prerelease handling (6cdcbd0)
- **plugin**: ignore recovered install errors (2d3b180)
- **plugin**: remove pnpm plugin links safely (8d917ab)
- reject hidden plugin recovery refs (b4c78fd)
- harden desktop security boundaries (baae483)

### Refactors

- **ci**: split platform release workflows (975c3f1)

### Styles

- **ci**: use plain YAML path scalars (6a2e95f)
- format Rust sources (168077a)

### Chores

- **plugin**: resolve latest internal plugin releases (fb7f54b)

### Other Changes

- Merge pull request #170 from dsh-tauri-desk/dsh/fix-coderabbit-release-review (f412169)
- Merge pull request #172 from dsh-tauri-desk/dsh/use-latest-internal-plugins (eb115f9)
- Merge pull request #169 from dsh-tauri-desk/dsh/fix-release-ci (48fc635)
- Merge pull request #168 from dsh-tauri-desk/fix/plugin-recovered-install-status (839cc30)
- Merge pull request #163 from WyattJHayes/main (951990f)
- Merge remote-tracking branch 'upstream/main' (195d9a5)
- Merge remote-tracking branch 'upstream/main' (d0268e5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application to version **0.9.0-beta.3**.
  * Synchronized the release version across the application and distribution metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->