### PR TITLE
perf(ci): parallelize platform release builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,26 +1,11 @@
-name: Reusable Linux Release Build
+name: Reusable Linux Build
 
 on:
   workflow_call:
     inputs:
-      release_tag:
-        required: false
-        type: string
-        default: ''
-      prerelease:
-        required: false
-        type: boolean
-        default: false
-      test_release:
-        required: true
-        type: boolean
       source_ref:
         required: true
         type: string
-      source_name:
-        required: false
-        type: string
-        default: ''
     secrets:
       TAURI_SIGNING_PRIVATE_KEY:
         required: false
@@ -28,7 +13,7 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -41,7 +26,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_ref }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js and pnpm
@@ -74,43 +58,18 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build and Release
-        if: ${{ !inputs.test_release }}
-        uses: tauri-apps/tauri-action@v0
+      - name: Build packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        with:
-          tagName: ${{ inputs.release_tag }}
-          releaseName: 'DeepSeek Harness Desktop ${{ inputs.release_tag }}'
-          releaseDraft: true
-          prerelease: ${{ inputs.prerelease }}
-          includeUpdaterJson: true
-          args: --bundles appimage,deb
+        run: pnpm tauri build --bundles appimage,deb
 
-      - name: Build and Create Test Release
-        if: inputs.test_release
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tagName: ${{ format('test-{0}-{1}', inputs.source_name, github.run_number) }}
-          releaseName: 'DeepSeek Harness Desktop 手动测试版 (构建 #${{ github.run_number }})'
-          releaseBody: |
-            DeepSeek Harness Desktop 手动触发测试构建。
-            触发来源: `${{ inputs.source_name }}`
-            打包平台: `linux`
-          releaseDraft: true
-          prerelease: true
-          args: --bundles appimage,deb
-
-      - name: Upload Artifacts (Manual Trigger)
-        if: inputs.test_release
+      - name: Upload build outputs
         uses: actions/upload-artifact@v6
         with:
-          name: deepseek-harness-desktop-linux
+          name: release-linux
           path: |
             src-tauri/target/release/bundle/appimage/*.AppImage
             src-tauri/target/release/bundle/deb/*.deb
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,19 +1,8 @@
-name: Reusable macOS Release Build
+name: Reusable macOS Build
 
 on:
   workflow_call:
     inputs:
-      release_tag:
-        required: false
-        type: string
-        default: ''
-      prerelease:
-        required: false
-        type: boolean
-        default: false
-      test_release:
-        required: true
-        type: boolean
       platform_filter:
         required: false
         type: string
@@ -21,10 +10,6 @@ on:
       source_ref:
         required: true
         type: string
-      source_name:
-        required: false
-        type: string
-        default: ''
     secrets:
       TAURI_SIGNING_PRIVATE_KEY:
         required: false
@@ -42,23 +27,19 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     name: Build (${{ matrix.id }})
     strategy:
       fail-fast: false
-      # 两个架构会更新同一 Release 和 latest.json，必须串行发布。
-      max-parallel: 1
       matrix:
         include:
           - id: macos-aarch64
-            args: --target aarch64-apple-darwin
-            rust-target: aarch64-apple-darwin
+            target: aarch64-apple-darwin
           - id: macos-x86_64
-            args: --target x86_64-apple-darwin
-            rust-target: x86_64-apple-darwin
+            target: x86_64-apple-darwin
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
@@ -66,12 +47,11 @@ jobs:
         id: check
         shell: bash
         env:
-          IS_TEST_RELEASE: ${{ inputs.test_release }}
           PLATFORM_FILTER: ${{ inputs.platform_filter }}
           PLATFORM_ID: ${{ matrix.id }}
         run: |
           should_run=true
-          if [ "$IS_TEST_RELEASE" = "true" ] && [ "$PLATFORM_FILTER" != "all" ] && [ "$PLATFORM_FILTER" != "$PLATFORM_ID" ]; then
+          if [ "$PLATFORM_FILTER" != "all" ] && [ "$PLATFORM_FILTER" != "$PLATFORM_ID" ]; then
             should_run=false
           fi
           echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
@@ -81,7 +61,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_ref }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js and pnpm
@@ -93,7 +72,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          targets: ${{ matrix.rust-target }}
+          targets: ${{ matrix.target }}
 
       - name: Install frontend dependencies
         if: steps.check.outputs.should_run == 'true'
@@ -118,11 +97,9 @@ jobs:
             exit 1
           fi
 
-      - name: Build and Release
-        if: steps.check.outputs.should_run == 'true' && !inputs.test_release
-        uses: tauri-apps/tauri-action@v0
+      - name: Build package
+        if: steps.check.outputs.should_run == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -130,40 +107,13 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        with:
-          tagName: ${{ inputs.release_tag }}
-          releaseName: 'DeepSeek Harness Desktop ${{ inputs.release_tag }}'
-          releaseDraft: true
-          prerelease: ${{ inputs.prerelease }}
-          includeUpdaterJson: true
-          args: ${{ matrix.args }}
-
-      - name: Build and Create Test Release
-        if: steps.check.outputs.should_run == 'true' && inputs.test_release
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        with:
-          tagName: ${{ format('test-{0}-{1}', inputs.source_name, github.run_number) }}
-          releaseName: 'DeepSeek Harness Desktop 手动测试版 (构建 #${{ github.run_number }})'
-          releaseBody: |
-            DeepSeek Harness Desktop 手动触发测试构建。
-            触发来源: `${{ inputs.source_name }}`
-            打包平台: `${{ inputs.platform_filter }}`
-          releaseDraft: true
-          prerelease: true
-          args: ${{ matrix.args }}
+        run: pnpm tauri build --target ${{ matrix.target }}
 
       - name: Verify signature and notarization
         if: steps.check.outputs.should_run == 'true'
         shell: bash
         run: |
-          app_path="$(find src-tauri/target -type d -path '*/release/bundle/macos/*.app' -print -quit)"
+          app_path="$(find "src-tauri/target/${{ matrix.target }}/release/bundle/macos" -type d -name '*.app' -print -quit)"
           if [ -z "$app_path" ]; then
             echo '::error::Built macOS app bundle was not found'
             exit 1
@@ -172,11 +122,11 @@ jobs:
           xcrun stapler validate "$app_path"
           spctl --assess --type execute --verbose=4 "$app_path"
 
-      - name: Upload Artifacts (Manual Trigger)
-        if: steps.check.outputs.should_run == 'true' && inputs.test_release
+      - name: Upload build output
+        if: steps.check.outputs.should_run == 'true'
         uses: actions/upload-artifact@v6
         with:
-          name: deepseek-harness-desktop-${{ matrix.id }}
-          path: src-tauri/target/${{ matrix.rust-target }}/release/bundle/dmg/*.dmg
+          name: release-${{ matrix.id }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,26 +1,11 @@
-name: Reusable Windows Release Build
+name: Reusable Windows Build
 
 on:
   workflow_call:
     inputs:
-      release_tag:
-        required: false
-        type: string
-        default: ''
-      prerelease:
-        required: false
-        type: boolean
-        default: false
-      test_release:
-        required: true
-        type: boolean
       source_ref:
         required: true
         type: string
-      source_name:
-        required: false
-        type: string
-        default: ''
     secrets:
       TAURI_SIGNING_PRIVATE_KEY:
         required: false
@@ -28,7 +13,7 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -40,7 +25,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_ref }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js and pnpm
@@ -66,43 +50,18 @@ jobs:
             console.log('MSI version override ->', cleanVer);
           "
 
-      - name: Build and Release
-        if: ${{ !inputs.test_release }}
-        uses: tauri-apps/tauri-action@v0
+      - name: Build packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        with:
-          tagName: ${{ inputs.release_tag }}
-          releaseName: 'DeepSeek Harness Desktop ${{ inputs.release_tag }}'
-          releaseDraft: true
-          prerelease: ${{ inputs.prerelease }}
-          includeUpdaterJson: true
-          args: --config release-msi-version.tmp.json
+        run: pnpm tauri build --config release-msi-version.tmp.json
 
-      - name: Build and Create Test Release
-        if: inputs.test_release
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tagName: ${{ format('test-{0}-{1}', inputs.source_name, github.run_number) }}
-          releaseName: 'DeepSeek Harness Desktop 手动测试版 (构建 #${{ github.run_number }})'
-          releaseBody: |
-            DeepSeek Harness Desktop 手动触发测试构建。
-            触发来源: `${{ inputs.source_name }}`
-            打包平台: `windows`
-          releaseDraft: true
-          prerelease: true
-          args: --config release-msi-version.tmp.json
-
-      - name: Upload Artifacts (Manual Trigger)
-        if: inputs.test_release
+      - name: Upload build outputs
         uses: actions/upload-artifact@v6
         with:
-          name: deepseek-harness-desktop-windows
+          name: release-windows
           path: |
             src-tauri/target/release/bundle/nsis/*.exe
             src-tauri/target/release/bundle/msi/*.msi
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,8 +146,8 @@ jobs:
           EOF
           gh release edit "$RELEASE_TAG" --notes-file release_notes.md
 
-  # 每个平台维护独立 reusable workflow；手动构建在 job 层过滤未选择的平台。
-  publish-macos:
+  # 三个平台只构建 Actions artifacts，互不写 GitHub Release，因此可以完全并行。
+  build-macos:
     name: Build macOS Artifacts
     needs: prepare
     if: >-
@@ -157,12 +157,8 @@ jobs:
        startsWith(inputs.platform_filter, 'macos-'))
     uses: ./.github/workflows/build-macos.yml
     with:
-      release_tag: ${{ needs.prepare.outputs.tag }}
-      prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
-      test_release: ${{ github.event_name == 'workflow_dispatch' }}
       platform_filter: ${{ github.event_name == 'workflow_dispatch' && inputs.platform_filter || 'all' }}
       source_ref: ${{ needs.prepare.outputs.source_ref }}
-      source_name: ${{ github.ref_name }}
     secrets:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -172,70 +168,78 @@ jobs:
       APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-  publish-windows:
+  build-windows:
     name: Build Windows Artifacts
-    needs: [prepare, publish-macos]
-    # 平台串行发布，避免 tauri-action 并发更新同一 Release/latest.json；
-    # always() 允许手动只选 Windows 时跨过 skipped 的 macOS job。
+    needs: prepare
     if: >-
-      always() && needs.prepare.result == 'success' &&
-      (needs.publish-macos.result == 'success' || needs.publish-macos.result == 'skipped') &&
+      needs.prepare.result == 'success' &&
       (github.event_name != 'workflow_dispatch' ||
        inputs.platform_filter == 'all' ||
        inputs.platform_filter == 'windows')
     uses: ./.github/workflows/build-windows.yml
     with:
-      release_tag: ${{ needs.prepare.outputs.tag }}
-      prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
-      test_release: ${{ github.event_name == 'workflow_dispatch' }}
       source_ref: ${{ needs.prepare.outputs.source_ref }}
-      source_name: ${{ github.ref_name }}
     secrets:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
-  publish-linux:
+  build-linux:
     name: Build Linux Artifacts
-    needs: [prepare, publish-windows]
+    needs: prepare
     if: >-
-      always() && needs.prepare.result == 'success' &&
-      (needs.publish-windows.result == 'success' || needs.publish-windows.result == 'skipped') &&
+      needs.prepare.result == 'success' &&
       (github.event_name != 'workflow_dispatch' ||
        inputs.platform_filter == 'all' ||
        inputs.platform_filter == 'linux')
     uses: ./.github/workflows/build-linux.yml
     with:
-      release_tag: ${{ needs.prepare.outputs.tag }}
-      prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
-      test_release: ${{ github.event_name == 'workflow_dispatch' }}
       source_ref: ${{ needs.prepare.outputs.source_ref }}
-      source_name: ${{ github.ref_name }}
     secrets:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
-  # 所有被选平台（含 macOS 签名/公证）成功后，才把草稿 Release 对用户可见。
+  # 单一 writer 下载全部成功构建的产物，一次性上传并发布 Release。
   finalize:
     name: Publish GitHub Release
-    needs: [prepare, publish-macos, publish-windows, publish-linux]
+    needs: [prepare, build-macos, build-windows, build-linux]
     if: >-
       always() && needs.prepare.result == 'success' &&
       ((github.event_name != 'workflow_dispatch' &&
-        needs.publish-macos.result == 'success' &&
-        needs.publish-windows.result == 'success' &&
-        needs.publish-linux.result == 'success') ||
+        needs.build-macos.result == 'success' &&
+        needs.build-windows.result == 'success' &&
+        needs.build-linux.result == 'success') ||
        (github.event_name == 'workflow_dispatch' &&
-        (needs.publish-macos.result == 'success' || needs.publish-macos.result == 'skipped') &&
-        (needs.publish-windows.result == 'success' || needs.publish-windows.result == 'skipped') &&
-        (needs.publish-linux.result == 'success' || needs.publish-linux.result == 'skipped')))
+        (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped') &&
+        (needs.build-windows.result == 'success' || needs.build-windows.result == 'skipped') &&
+        (needs.build-linux.result == 'success' || needs.build-linux.result == 'skipped')))
     runs-on: ubuntu-latest
     steps:
-      - name: Publish completed release
+      - name: Download build outputs
+        uses: actions/download-artifact@v7
+        with:
+          pattern: release-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Verify downloaded assets
+        run: |
+          find release-assets -type f -print
+          [ -n "$(find release-assets -type f -print -quit)" ] || {
+            echo '::error::No release assets were downloaded'
+            exit 1
+          }
+
+      - name: Upload assets and publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('test-{0}-{1}', github.ref_name, github.run_number) || needs.prepare.outputs.tag }}
           PRERELEASE: ${{ github.event_name == 'workflow_dispatch' || needs.prepare.outputs.prerelease == 'true' }}
         run: |
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" --draft --title "DeepSeek Harness Desktop $RELEASE_TAG"
+          fi
+          mapfile -d '' assets < <(find release-assets -type f -print0)
+          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
           if [ "$PRERELEASE" = "true" ]; then
             gh release edit "$RELEASE_TAG" --draft=false --prerelease --latest=false
           else


### PR DESCRIPTION
## Summary
- build macOS, Windows, and Linux packages in parallel reusable workflows
- upload platform outputs as GitHub Actions artifacts only
- use one finalize job to upload all assets and publish the Release
- preserve macOS signing/notarization verification before publication

## Notes
- this repository does not currently emit updater .sig files or latest.json; the single-writer finalize stage is ready for manifest generation when updater artifacts are enabled

## Validation
- pnpm run lint
- pnpm run typecheck
- pnpm run test -- --run
- yaml-lint
- actionlint 1.7.12
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release Improvements**
  * Platform builds now run independently and produce downloadable artifacts for Linux, macOS, and Windows.
  * Release assets are collected and verified centrally before publication.
  * Releases are created only when needed, while existing draft and publication workflows remain supported.
  * Build workflows now use read-only repository access and no longer publish releases directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->