### PR TITLE
ci(workflow): skip duplicate CI runs for unchanged content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 permissions:
   contents: read
+  # skip-duplicate-actions 要查询 Workflow Runs API（actions 作用域），
+  # 缺它会 403/超时；仅 contents: read 会被 GitHub 解释为无 actions 权限。
+  actions: read
 
 # 同一分支/PR 的新提交会取消上次仍在运行的 CI，避免浪费 runner 时间。
 concurrency:
@@ -21,9 +24,26 @@ env:
   CARGO_PROFILE_DEV_DEBUG: 0
 
 jobs:
+  # 门卫：内容哈希相同且已成功通过（或同一内容正在运行）时跳过，避免重复跑。
+  # push main 与 pull_request main 常常是同一个内容，用 skip_after_successful_duplicate
+  # 加 concurrent_skipping: same_content 精确去重；手动触发/schedule 永不跳过。
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5.3.2
+        with:
+          concurrent_skipping: same_content
+          skip_after_successful_duplicate: true
+          paths_ignore: '["**/docs/**", "**/*.md"]'
+
   # 前端（vitest + typecheck + lint）：
   frontend:
     name: Frontend (vitest + typecheck + lint)
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -57,6 +77,8 @@ jobs:
   # "更广泛"地覆盖应用实际发布的三个平台，而不是像前端那样按 Node 版本重复。
   rust-test:
     name: Rust tests
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- add a pre_job gate using fkirc/skip-duplicate-actions@v5.3.2
- skip frontend and rust-test when the same content hash already passed
- use concurrent_skipping: same_content to dedupe push main + pull_request runs on identical content
- ignore docs/markdown-only changes via paths_ignore
- add actions: read permission (required to query the Workflow Runs API)

## Validation
- yaml-lint
- actionlint 1.7.12
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated validation efficiency by avoiding redundant checks for duplicate changes.
  * Documentation-only updates no longer trigger unnecessary validation runs.
  * Frontend and Rust validation now runs only when required, helping reduce wait times for build and test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->