### PR TITLE
fix(ci): provide repository context to finalize gh commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,8 @@ jobs:
       - name: Upload assets and publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # finalize 未 checkout，gh 无法从 .git 推断仓库，需显式指定。
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('test-{0}-{1}', github.ref_name, github.run_number) || needs.prepare.outputs.tag }}
           PRERELEASE: ${{ github.event_name == 'workflow_dispatch' || needs.prepare.outputs.prerelease == 'true' }}
         run: |


### PR DESCRIPTION
## Problem

The `finalize` job in `release.yml` has no checkout, so `gh release view/create/upload/edit` fail with "not a git repository" because `gh` infers the repo from `.git`. This broke the v0.9.0-beta.4 release run.

## Fix

Set `GH_REPO` to `github.repository` in the finalize step so every `gh` command knows the target repository.

## Validation

- yaml-lint
- actionlint 1.7.12
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by ensuring release commands target the correct repository during finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->