### PR TITLE
chore: release v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.9.0-beta.5",
+  "version": "0.9.0",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.9.0-beta.5"
+version = "0.9.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.9.0-beta.5"
+version = "0.9.0"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.9.0-beta.5",
+  "version": "0.9.0",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.9.0` (`0.9.0-beta.5` → `0.9.0`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Promoted the application from version 0.9.0-beta.5 to the stable 0.9.0 release.
  * Updated the displayed application version consistently across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->