### PR TITLE
fix(ci): validate release version identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,38 +64,10 @@ jobs:
 
       - name: Read release metadata
         id: meta
-        shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
           PUSH_TAG: ${{ github.ref_name }}
-          EVENT_SHA: ${{ github.sha }}
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-        run: |
-          if [ "$EVENT_NAME" = "push" ]; then
-            tag="$PUSH_TAG"
-            source_ref="$EVENT_SHA"
-            should_release=true
-          elif [ "$EVENT_NAME" = "pull_request" ]; then
-            tag="v$(node -p "require('./package.json').version")"
-            source_ref="$MERGE_SHA"
-            should_release=true
-          else
-            tag=""
-            source_ref="$EVENT_SHA"
-            should_release=false
-          fi
-
-          prerelease=false
-          if [[ "$tag" == *-* ]]; then
-            prerelease=true
-          fi
-
-          {
-            echo "tag=$tag"
-            echo "prerelease=$prerelease"
-            echo "should_release=$should_release"
-            echo "source_ref=$source_ref"
-          } >> "$GITHUB_OUTPUT"
+        run: node scripts/release-identity.mjs
 
       - name: Create release tag
         if: github.event_name == 'pull_request'

--- a/scripts/release-identity.mjs
+++ b/scripts/release-identity.mjs
@@ -1,0 +1,218 @@
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+// This runs before dependency installation, so keep SemVer validation dependency-free.
+const SEMVER_IDENTIFIER = '(?:0|[1-9]\\d*|\\d*[A-Z-][0-9A-Z-]*)'
+const SEMVER_PATTERN = new RegExp(
+  `^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)`
+  + `(?:-(${SEMVER_IDENTIFIER}(?:\\.${SEMVER_IDENTIFIER})*))?`
+  + '(?:\\+([0-9A-Z-]+(?:\\.[0-9A-Z-]+)*))?$',
+  'i',
+)
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i
+
+function releaseIdentityError(message, cause) {
+  const error = new Error(`RELEASE_IDENTITY: ${message}`)
+  if (cause !== undefined)
+    error.cause = cause
+  return error
+}
+
+function parseSemver(version, label = 'version') {
+  if (typeof version !== 'string')
+    throw releaseIdentityError(`${label} must be a string`)
+
+  const match = SEMVER_PATTERN.exec(version)
+  if (!match)
+    throw releaseIdentityError(`${label} is not strict SemVer 2.0: ${JSON.stringify(version)}`)
+
+  return {
+    version,
+    prerelease: match[1] ?? null,
+    build: match[2] ?? null,
+  }
+}
+
+function readJsonVersion(filePath, label) {
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''))
+  }
+  catch (error) {
+    throw releaseIdentityError(`cannot read ${label} at ${filePath}`, error)
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+    throw releaseIdentityError(`${label} must contain a JSON object`)
+
+  parseSemver(parsed.version, `${label} version`)
+  return parsed.version
+}
+
+function readCargoPackageVersion(content) {
+  if (typeof content !== 'string')
+    throw releaseIdentityError('Cargo.toml content must be a string')
+
+  let inPackageSection = false
+  let packageVersion = null
+
+  for (const line of content.replace(/^\uFEFF/, '').split(/\r?\n/)) {
+    if (line.trimStart().startsWith('[')) {
+      inPackageSection = /^\s*\[package\]\s*(?:#.*)?$/.test(line)
+      continue
+    }
+
+    if (!inPackageSection || /^\s*#/.test(line))
+      continue
+
+    const version = /^\s*version\s*=\s*(["'])([^"']+)\1\s*(?:#.*)?$/.exec(line)
+    if (!version)
+      continue
+
+    if (packageVersion !== null)
+      throw releaseIdentityError('Cargo.toml [package] contains multiple version fields')
+    packageVersion = version[2]
+  }
+
+  if (packageVersion === null)
+    throw releaseIdentityError('Cargo.toml [package] version is missing')
+
+  parseSemver(packageVersion, 'Cargo.toml [package] version')
+  return packageVersion
+}
+
+function readReleaseIdentity(repo = process.cwd()) {
+  const packageVersion = readJsonVersion(path.join(repo, 'package.json'), 'package.json')
+  const cargoPath = path.join(repo, 'src-tauri', 'Cargo.toml')
+  let cargoVersion
+  try {
+    cargoVersion = readCargoPackageVersion(readFileSync(cargoPath, 'utf8'))
+  }
+  catch (error) {
+    if (error instanceof Error && error.message.startsWith('RELEASE_IDENTITY:'))
+      throw error
+    throw releaseIdentityError(`cannot read Cargo.toml at ${cargoPath}`, error)
+  }
+  const tauriVersion = readJsonVersion(
+    path.join(repo, 'src-tauri', 'tauri.conf.json'),
+    'src-tauri/tauri.conf.json',
+  )
+
+  const versions = {
+    'package.json': packageVersion,
+    'src-tauri/Cargo.toml': cargoVersion,
+    'src-tauri/tauri.conf.json': tauriVersion,
+  }
+  if (new Set(Object.values(versions)).size !== 1) {
+    const details = Object.entries(versions)
+      .map(([file, version]) => `${file}=${version}`)
+      .join(', ')
+    throw releaseIdentityError(`release versions do not match: ${details}`)
+  }
+
+  return {
+    version: packageVersion,
+    semver: parseSemver(packageVersion),
+    versions,
+  }
+}
+
+function requireCommitSha(sha) {
+  if (typeof sha !== 'string' || !COMMIT_SHA_PATTERN.test(sha))
+    throw releaseIdentityError('source_ref must be a full 40-character commit SHA')
+  return sha.toLowerCase()
+}
+
+function deriveReleaseMetadata({ eventName, pushTag = '', sourceRef, identity }) {
+  if (!identity || typeof identity !== 'object')
+    throw releaseIdentityError('release identity is missing')
+
+  const semver = parseSemver(identity.version)
+  const normalizedSourceRef = requireCommitSha(sourceRef)
+  const expectedTag = `v${identity.version}`
+  let tag = ''
+  let shouldRelease = false
+
+  if (eventName === 'push') {
+    if (pushTag !== expectedTag) {
+      throw releaseIdentityError(
+        `pushed tag ${JSON.stringify(pushTag)} does not match checked-out version tag ${expectedTag}`,
+      )
+    }
+    tag = expectedTag
+    shouldRelease = true
+  }
+  else if (eventName === 'pull_request') {
+    tag = expectedTag
+    shouldRelease = true
+  }
+  else if (eventName !== 'workflow_dispatch') {
+    throw releaseIdentityError(`unsupported release event: ${JSON.stringify(eventName)}`)
+  }
+
+  return {
+    tag,
+    prerelease: semver.prerelease !== null,
+    should_release: shouldRelease,
+    source_ref: normalizedSourceRef,
+  }
+}
+
+function appendReleaseMetadata(outputPath, metadata) {
+  if (!outputPath)
+    throw releaseIdentityError('GITHUB_OUTPUT is missing')
+
+  appendFileSync(outputPath, [
+    `tag=${metadata.tag}`,
+    `prerelease=${metadata.prerelease}`,
+    `should_release=${metadata.should_release}`,
+    `source_ref=${metadata.source_ref}`,
+    '',
+  ].join('\n'), 'utf8')
+}
+
+function main() {
+  const repo = process.env.GITHUB_WORKSPACE || process.cwd()
+  const identity = readReleaseIdentity(repo)
+  let sourceRef
+  try {
+    sourceRef = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+  }
+  catch (error) {
+    throw releaseIdentityError('cannot resolve the checked-out release commit', error)
+  }
+
+  const metadata = deriveReleaseMetadata({
+    eventName: process.env.EVENT_NAME || process.env.GITHUB_EVENT_NAME,
+    pushTag: process.env.PUSH_TAG || process.env.GITHUB_REF_NAME || '',
+    sourceRef,
+    identity,
+  })
+  appendReleaseMetadata(process.env.GITHUB_OUTPUT, metadata)
+}
+
+const entryPoint = process.argv[1]
+if (entryPoint && import.meta.url === pathToFileURL(path.resolve(entryPoint)).href) {
+  try {
+    main()
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(message.startsWith('RELEASE_IDENTITY:') ? message : `RELEASE_IDENTITY: ${message}`)
+    process.exitCode = 1
+  }
+}
+
+export {
+  deriveReleaseMetadata,
+  parseSemver,
+  readCargoPackageVersion,
+  readReleaseIdentity,
+}

--- a/test/release-identity.test.ts
+++ b/test/release-identity.test.ts
@@ -1,0 +1,240 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+import * as releaseIdentityModule from '../scripts/release-identity.mjs'
+
+interface SemverIdentity {
+  version: string
+  prerelease: string | null
+  build: string | null
+}
+
+interface ReleaseIdentity {
+  version: string
+  semver: SemverIdentity
+}
+
+interface ReleaseIdentityModule {
+  parseSemver: (version: unknown) => SemverIdentity
+  readCargoPackageVersion: (content: unknown) => string
+  readReleaseIdentity: (repo?: string) => ReleaseIdentity
+  deriveReleaseMetadata: (input: {
+    eventName: string
+    pushTag?: string
+    sourceRef: string
+    identity: ReleaseIdentity
+  }) => {
+    tag: string
+    prerelease: boolean
+    should_release: boolean
+    source_ref: string
+  }
+}
+
+const releaseIdentityScript = fileURLToPath(new URL('../scripts/release-identity.mjs', import.meta.url))
+const releaseIdentity = releaseIdentityModule as ReleaseIdentityModule
+
+const sourceSha = '1'.repeat(40)
+const temporaryRepos: string[] = []
+
+function writeReleaseFiles(versions: {
+  packageJson: string
+  cargoToml: string
+  tauriConfig: string
+}) {
+  const repo = mkdtempSync(path.join(tmpdir(), 'release-identity-'))
+  temporaryRepos.push(repo)
+  mkdirSync(path.join(repo, 'src-tauri'))
+  writeFileSync(
+    path.join(repo, 'package.json'),
+    JSON.stringify({ name: 'desktop', version: versions.packageJson }),
+  )
+  writeFileSync(
+    path.join(repo, 'src-tauri', 'Cargo.toml'),
+    `[workspace.package]\nversion = "9.9.9"\n\n[package]\nname = "desktop"\nversion = "${versions.cargoToml}"\n`,
+  )
+  writeFileSync(
+    path.join(repo, 'src-tauri', 'tauri.conf.json'),
+    JSON.stringify({ productName: 'Desktop', version: versions.tauriConfig }),
+  )
+  return repo
+}
+
+function matchingIdentity(version: string): ReleaseIdentity {
+  return {
+    version,
+    semver: releaseIdentity.parseSemver(version),
+  }
+}
+
+afterEach(() => {
+  for (const repo of temporaryRepos.splice(0))
+    rmSync(repo, { recursive: true, force: true })
+})
+
+describe('release version identity', () => {
+  it.each([
+    ['1.2.3', null, null],
+    ['1.2.3-rc.1', 'rc.1', null],
+    ['1.2.3+build-alpha.7', null, 'build-alpha.7'],
+    ['1.2.3-rc.1+build.7', 'rc.1', 'build.7'],
+    ['9007199254740993.9007199254740995.9007199254740997', null, null],
+  ])('parses strict SemVer %s', (version, prerelease, build) => {
+    expect(releaseIdentity.parseSemver(version)).toEqual({ version, prerelease, build })
+  })
+
+  it.each(['v1.2.3', '01.2.3', '1.02.3', '1.2.03', '1.2', '1.2.3-01', '1.2.3+'])(
+    'rejects non-SemVer version %s',
+    (version) => {
+      expect(() => releaseIdentity.parseSemver(version)).toThrow(/^RELEASE_IDENTITY:/)
+    },
+  )
+
+  it('reads only the Cargo [package] version', () => {
+    const cargo = `
+[workspace.package]
+version = "8.0.0"
+
+[dependencies]
+version = "7.0.0"
+
+[package] # release identity
+name = "desktop"
+version = '1.2.3-rc.1' # current release
+
+[package.metadata.release]
+version = "6.0.0"
+`
+    expect(releaseIdentity.readCargoPackageVersion(cargo)).toBe('1.2.3-rc.1')
+  })
+
+  it('reads one coherent identity from all release files', () => {
+    const repo = writeReleaseFiles({
+      packageJson: '1.2.3+build.4',
+      cargoToml: '1.2.3+build.4',
+      tauriConfig: '1.2.3+build.4',
+    })
+    expect(releaseIdentity.readReleaseIdentity(repo)).toMatchObject({
+      version: '1.2.3+build.4',
+      semver: { prerelease: null, build: 'build.4' },
+    })
+  })
+
+  it.each([
+    { packageJson: '1.2.4', cargoToml: '1.2.3', tauriConfig: '1.2.3' },
+    { packageJson: '1.2.3', cargoToml: '1.2.4', tauriConfig: '1.2.3' },
+    { packageJson: '1.2.3', cargoToml: '1.2.3', tauriConfig: '1.2.4' },
+  ])('rejects mismatched release files with every value named', (versions) => {
+    const repo = writeReleaseFiles(versions)
+    expect(() => releaseIdentity.readReleaseIdentity(repo)).toThrow(
+      /release versions do not match: package\.json=1\.2\.[34], src-tauri\/Cargo\.toml=1\.2\.[34], src-tauri\/tauri\.conf\.json=1\.2\.[34]/,
+    )
+  })
+})
+
+describe('release event metadata', () => {
+  it.each([
+    ['push', 'v1.2.3', 'v1.2.3', true],
+    ['pull_request', '', 'v1.2.3', true],
+    ['workflow_dispatch', '', '', false],
+  ])('derives %s metadata from the checked-out source', (eventName, pushTag, tag, shouldRelease) => {
+    expect(releaseIdentity.deriveReleaseMetadata({
+      eventName,
+      pushTag,
+      sourceRef: sourceSha.toUpperCase(),
+      identity: matchingIdentity('1.2.3'),
+    })).toEqual({
+      tag,
+      prerelease: false,
+      should_release: shouldRelease,
+      source_ref: sourceSha,
+    })
+  })
+
+  it('uses parsed prerelease identity rather than a hyphen in build metadata', () => {
+    const prerelease = releaseIdentity.deriveReleaseMetadata({
+      eventName: 'pull_request',
+      sourceRef: sourceSha,
+      identity: matchingIdentity('1.2.3-rc.1+build-alpha'),
+    })
+    const stable = releaseIdentity.deriveReleaseMetadata({
+      eventName: 'pull_request',
+      sourceRef: sourceSha,
+      identity: matchingIdentity('1.2.3+build-alpha'),
+    })
+    expect(prerelease.prerelease).toBe(true)
+    expect(stable.prerelease).toBe(false)
+  })
+
+  it.each(['v1.2.4', '1.2.3'])(
+    'rejects pushed tag %s when it differs from the checked-out version tag',
+    (pushTag) => {
+      expect(() => releaseIdentity.deriveReleaseMetadata({
+        eventName: 'push',
+        pushTag,
+        sourceRef: sourceSha,
+        identity: matchingIdentity('1.2.3'),
+      })).toThrow(/does not match checked-out version tag v1\.2\.3/)
+    },
+  )
+
+  it.each(['1'.repeat(39), 'g'.repeat(40)])('rejects invalid source commit %s', (sourceRef) => {
+    expect(() => releaseIdentity.deriveReleaseMetadata({
+      eventName: 'pull_request',
+      sourceRef,
+      identity: matchingIdentity('1.2.3'),
+    })).toThrow(/source_ref must be a full 40-character commit SHA/)
+  })
+
+  it('writes workflow outputs from the checked-out commit', () => {
+    const repo = writeReleaseFiles({
+      packageJson: '1.2.3',
+      cargoToml: '1.2.3',
+      tauriConfig: '1.2.3',
+    })
+    const outputPath = path.join(repo, 'github-output.txt')
+    execFileSync('git', ['init', '--quiet'], { cwd: repo })
+    execFileSync('git', ['config', 'core.autocrlf', 'false'], { cwd: repo })
+    execFileSync('git', ['add', '.'], { cwd: repo })
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'user.name=Release Test',
+        '-c',
+        'user.email=release@example.test',
+        'commit',
+        '--quiet',
+        '-m',
+        'release',
+      ],
+      { cwd: repo },
+    )
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim()
+
+    execFileSync(process.execPath, [releaseIdentityScript], {
+      cwd: repo,
+      env: {
+        ...process.env,
+        EVENT_NAME: 'push',
+        PUSH_TAG: 'v1.2.3',
+        GITHUB_WORKSPACE: repo,
+        GITHUB_OUTPUT: outputPath,
+      },
+    })
+
+    expect(readFileSync(outputPath, 'utf8')).toBe([
+      'tag=v1.2.3',
+      'prerelease=false',
+      'should_release=true',
+      `source_ref=${head}`,
+      '',
+    ].join('\n'))
+  })
+})


### PR DESCRIPTION
## Summary

- require `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` to carry the same strict SemVer release version
- require a pushed tag to exactly match `v<checked-out version>` and derive `source_ref` from the checked-out `HEAD`
- move metadata derivation into a dependency-free `.mjs` module with fail-closed regression coverage for valid and invalid release identities

This prevents a release run from quietly combining mismatched version files, a mismatched tag, or a source reference that differs from the commit actually checked out for the build.

## Scope

This deliberately leaves the existing tag-update and manual-release target behavior unchanged. Those separate concerns are already represented in #171; this PR only validates release identity and source selection.

## Verification

- `pnpm test -- --run` — 47 passed across 5 files
- `pnpm lint`
- `pnpm typecheck`
- `node --check scripts/release-identity.mjs`
- direct positive CLI smoke for `v0.9.2`
- direct negative CLI smoke for a mismatched pushed tag; failed closed and wrote no output
- `git diff --check origin/main..HEAD`
- independent exact-head review and security diff scan of `53f938b1e4343804585f0421f9d3775bb9c3ce00` — no P0–P2 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release metadata validation for version numbers, commit references, tags, and source revisions.
  * Ensured release information remains consistent across project configuration files.
  * Release workflows now fail clearly when invalid or inconsistent metadata is detected.

* **Tests**
  * Added comprehensive coverage for release event handling, tag validation, version consistency, and workflow output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->