### PR TITLE
fix: restore loopback Harness permissions

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,11 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the local desktop shell. The embedded remote Harness page does not receive native Tauri permissions and communicates with the shell through the restricted postMessage bridge. The service port is NOT fixed: it defaults to 3080/3081 but is user-configurable and advances to the next free port when the default is occupied (service/workflow::find_available_port).",
+  "description": "Capability for the main window and embedded Harness GUI. The remote Harness origin is restricted to loopback, while the shell validates every cross-origin postMessage before servicing bridge requests. The service port is NOT fixed: it defaults to 3080/3081 but is user-configurable and advances to the next free port when the default is occupied (service/workflow::find_available_port).",
   "windows": ["main"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*"]
+  },
   "permissions": [
     "core:default",
     "core:event:allow-listen",

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -475,11 +475,12 @@ mod tests {
 #[cfg(test)]
 mod security_tests {
     #[test]
-    fn remote_capability_does_not_cover_wildcard_loopback() {
+    fn remote_capability_allows_only_loopback_harness() {
         let capability = include_str!("../../capabilities/default.json");
-        assert!(!capability.contains("\"remote\""));
+        assert!(capability.contains("\"remote\""));
         let wildcard_loopback = ["http://127.0.0.1:", "*"].concat();
-        assert!(!capability.contains(wildcard_loopback.as_str()));
+        assert!(capability.contains(wildcard_loopback.as_str()));
+        assert!(!capability.contains("https://"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- restore the loopback-only remote capability required by the embedded Harness GUI
- restore clipboard image paste IPC and external link opening without granting non-loopback remote origins
- cover the loopback-only capability with a security regression test

## Validation
- cargo fmt --all -- --check`n- git diff --check`n- cargo test --locked (285 passed)

Fixes #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enabled remote access only for local loopback HTTP URLs.
  * Continued blocking HTTPS remote URLs by default.
  * Documented validation for messages received from the local remote interface.

* **Tests**
  * Updated security checks to verify the restricted loopback access configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->