### PR TITLE
fix: never close the dsh log pipe on non-UTF-8 lines (harness crash-loop → stuck on 'Loading plugins')

### DIFF
--- a/src-tauri/src/service/workflow/utils.rs
+++ b/src-tauri/src/service/workflow/utils.rs
@@ -101,39 +101,59 @@ where
     if let Some(stdout) = stdout {
         let log_path = log_path.clone();
         thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(line) => {
-                        log::info!(target: "dsh", "{}", line);
-                        append_log(&log_path, &line);
-                    }
-                    Err(e) => {
-                        log::error!("Failed to read dsh stdout: {}", e);
-                        break;
-                    }
-                }
-            }
+            drain_subprocess_output(BufReader::new(stdout), log_path, log::Level::Info);
         });
     }
 
     // 在独立线程中读取 stderr
     if let Some(stderr) = stderr {
         thread::spawn(move || {
-            let reader = BufReader::new(stderr);
-            for line in reader.lines() {
-                match line {
-                    Ok(line) => {
-                        log::warn!(target: "dsh", "{}", line);
-                        append_log(&log_path, &line);
-                    }
-                    Err(e) => {
-                        log::error!("Failed to read dsh stderr: {}", e);
-                        break;
-                    }
-                }
-            }
+            drain_subprocess_output(BufReader::new(stderr), log_path, log::Level::Warn);
         });
+    }
+}
+
+/// 逐行读取子进程输出并写入日志。
+///
+/// 任何一行是非法 UTF-8 时**必须**用 lossy 替换继续读下去，不能中断：管道
+/// 读端一旦被关闭，dsh 主进程下一次写 stderr 就会收到 EPIPE，Node 以退出码 1
+/// 静默崩溃（插件子进程——python MCP 服务器等——在中文本地化 Windows 下按
+/// ANSI 代码页输出 GBK 日志是常态），桌面端表现为 Harness 反复崩溃、WebView
+/// 永久卡在 "Loading plugins"。同样的非法字节在日志里以 U+FFFD 呈现，不影响
+/// 其余行的可读性。真正需要停手的只有 EOF 与管道自身的 I/O 错误。
+fn drain_subprocess_output<R: Read + Send + 'static>(
+    mut reader: BufReader<R>,
+    log_path: PathBuf,
+    level: log::Level,
+) {
+    loop {
+        let mut bytes = Vec::new();
+        match reader.read_until(b'\n', &mut bytes) {
+            Ok(0) => break, // EOF
+            Ok(_) => {
+                // 去除行尾 \n / \r\n（与旧 lines() 行为一致）
+                let bytes = bytes.strip_suffix(b"\n").unwrap_or(&bytes);
+                let bytes = bytes.strip_suffix(b"\r").unwrap_or(bytes);
+                let line = String::from_utf8_lossy(bytes);
+                match level {
+                    log::Level::Warn => log::warn!(target: "dsh", "{}", line),
+                    _ => log::info!(target: "dsh", "{}", line),
+                }
+                append_log(&log_path, &line);
+            }
+            Err(e) => {
+                log::error!("Failed to read dsh {}: {}", log_level_name(level), e);
+                break;
+            }
+        }
+    }
+}
+
+/// `log::Level` 的小写名称（内部日志用词与旧实现一致）。
+fn log_level_name(level: log::Level) -> &'static str {
+    match level {
+        log::Level::Warn => "stderr",
+        _ => "stdout",
     }
 }
 
@@ -219,6 +239,69 @@ mod tests {
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(path, content).unwrap();
+    }
+
+    /// 回归：非法 UTF-8 行（中文 Windows 下 python 插件输出 GBK 的典型形态）
+    /// 绝不能让读取器中断——旧实现 break 会关闭管道读端，dsh 下次写 stderr
+    /// 收到 EPIPE 以退出码 1 崩溃，表现为 Harness 崩溃循环 + WebView 卡在
+    /// "Loading plugins"。
+    #[test]
+    fn drain_keeps_reading_after_invalid_utf8_lines() {
+        let dir = std::env::temp_dir().join(format!("dsh_drain_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("out.log");
+
+        // "因为测试" 的 GBK 编码（与系统 ANSI 代码页 936 输出一致）
+        let mut data = b"first line\n".to_vec();
+        data.extend_from_slice(b"\xd2\xf2\xce\xaa\xb2\xe2\xca\xd4\n");
+        data.extend_from_slice(b"second line\n");
+
+        drain_subprocess_output(
+            std::io::BufReader::new(std::io::Cursor::new(data)),
+            log.clone(),
+            log::Level::Warn,
+        );
+
+        let content = fs::read_to_string(&log).unwrap();
+        assert!(
+            content.contains("first line"),
+            "first line must be logged, got: {content:?}"
+        );
+        assert!(
+            content.contains("second line"),
+            "reader must NOT stop at invalid UTF-8 (old code broke and closed the pipe); got: {content:?}"
+        );
+        // 非法字节以 U+FFFD 呈现，行内容不丢失
+        assert!(content.contains('\u{FFFD}'));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `log::Level` 与日志名称的映射。
+    #[test]
+    fn log_level_name_maps_streams() {
+        assert_eq!(log_level_name(log::Level::Warn), "stderr");
+        assert_eq!(log_level_name(log::Level::Info), "stdout");
+        assert_eq!(log_level_name(log::Level::Debug), "stdout");
+    }
+
+    /// 行尾处理与旧 `lines()` 行为一致：\n 与 \r\n 均被剥离。
+    #[test]
+    fn drain_strips_line_endings() {
+        let dir = std::env::temp_dir().join(format!("dsh_drain_crlf_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("out.log");
+
+        drain_subprocess_output(
+            std::io::BufReader::new(std::io::Cursor::new(b"a\r\nb\n".to_vec())),
+            log.clone(),
+            log::Level::Info,
+        );
+
+        let content = fs::read_to_string(&log).unwrap();
+        assert_eq!(content, "a\nb\n");
+        let _ = fs::remove_dir_all(&dir);
     }
 
     /// 模拟连续 5 次启动，验证磁盘上始终只保留最近 `keep` 份日志，


### PR DESCRIPTION
## 问题

中文 Windows（ANSI 代码页 936）下，Harness 反复以退出码 1 崩溃，WebView 永久卡在官方 boot 页 **"Loading plugins…"**；`desktop.log` 中可稳定观察到每次启动都出现：

```
ERROR main::service::workflow::utils: Failed to read dsh stderr: stream did not contain valid UTF-8
WARN  main::service::workflow: Owned Harness process <pid> exited with code 1
```

## 根因

1. 插件子进程（python MCP 服务器，如 jadx / frida）在无 UTF-8 环境变量时按系统 ANSI 代码页输出 **GBK 字节**（`░` 图案、中文日志等），写进 dsh 的 stderr 管道。
2. `spawn_output_readers()` 用 `BufRead::lines()`（严格 UTF-8）逐行读取，遇到非法行走 `Err` 分支：`log::error!` 后 **`break`**。读取线程退出时 `BufReader<File>` 被 drop，**管道读端被关闭**。
3. dsh（node）主进程此后任意一次 `process.stderr.write` 都会收到 **EPIPE**；`process.stderr` 上无 error 监听器时 node **以退出码 1 静默崩溃**（实测：读端关闭后 ~25ms 内 exit 1）。
4. 崩溃时机取决于"下一次 stderr 写入"何时发生（实测 0.8s～100s 不等），表现为 Harness 崩溃循环，前端健康检查拿到 `HARNESS_NOT_READY`，界面永远停在 Loading plugins。

## 修复

`spawn_output_readers` 改为按字节读取（`read_until(b'\n')`）+ `String::from_utf8_lossy` 解码：非法行以 U+FFFD 呈现并**继续读取**，管道读端永不关闭；只有 EOF 或真实 I/O 错误才停止。stdout/stderr 两条读取路径共用新的 `drain_subprocess_output`，行为与旧 `lines()` 一致（剥离 `\n`/`\r\n`）。

## 测试

新增回归测试（旧实现会失败：遇到 GBK 行即 break，后续行丢失）：

- `drain_keeps_reading_after_invalid_utf8_lines` — 合法行 + GBK 行 + 合法行，断言读取不中断且非法字节以 U+FFFD 呈现；
- `drain_strips_line_endings` — `\n` / `\r\n` 剥离与旧行为一致；
- `log_level_name_maps_streams` — 日志用词映射。

`cargo test --lib workflow::utils`：**7 passed, 0 failed**。

## 验证

在清空 UTF-8 环境变量（等价桌面真实环境）下用修复后的读取器启动：GBK 输出依旧触发 lossy 替换，但 dsh 进程持续存活、`dsh web` 正常、前端健康检查通过（`healthy - 200 OK`），不再出现 `exited with code 1`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of subprocess output containing invalid or unexpected text encoding.
  * Processing now continues when malformed characters are encountered, with safe replacement characters shown instead.
  * Standardized removal of line endings for cleaner output.
  * Improved reporting of output stream and I/O errors for more reliable diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->