### PR TITLE
fix(workflow): strip Windows verbatim prefix from DSH_NODE to fix pnpm shim

### DIFF
--- a/src-tauri/src/service/cli/shim.rs
+++ b/src-tauri/src/service/cli/shim.rs
@@ -40,9 +40,13 @@ rem must not re-derive it from PATH (which can miss nodes the app found).
 rem Pure batch version check (for /f tokens + numeric compare), no powershell
 rem child: avoids console flashes when invoked without a console and skips the
 rem per-call powershell startup cost.
-if defined DSH_NODE (
-  if exist "%DSH_NODE%" goto :node_dsh
-)
+if not defined DSH_NODE goto :skip_dsh_node
+set "NODE=%DSH_NODE%"
+rem Windows canonical paths may carry a \\?\ verbatim prefix that cmd.exe
+rem cannot launch directly; strip it before checking/using the path.
+if "%NODE:~0,4%"=="\\?\" set "NODE=%NODE:~4%"
+if exist "%NODE%" goto :launch
+:skip_dsh_node
 where node >nul 2>nul
 if errorlevel 1 goto :use_bundled
 for /f "tokens=1,2 delims=v." %%a in ('node --version 2^>nul ^| findstr /b "v"') do set "NODE_MAJOR=%%a" & set "NODE_MINOR=%%b"
@@ -71,8 +75,12 @@ const PS1_NODE_RESOLVE: &str = r#"
 # own child processes), then a version-compatible local node, then the
 # bundled runtime — see the CMD shim for why DSH_NODE wins first.
 $node = $null
-if ($env:DSH_NODE -and (Test-Path -LiteralPath $env:DSH_NODE)) {
+if ($env:DSH_NODE) {
     $node = $env:DSH_NODE
+    # Windows canonical paths may carry a \\?\ verbatim prefix; strip it so
+    # PowerShell/cmd can launch the path directly.
+    if ($node.StartsWith('\\?\')) { $node = $node.Substring(4) }
+    if (-not (Test-Path -LiteralPath $node)) { $node = $null }
 }
 if (-not $node) {
     $localNode = Get-Command node -ErrorAction SilentlyContinue
@@ -1109,6 +1117,11 @@ mod tests {
             node_ok_at < node_dsh_label_at,
             "the :node_dsh label must come after :node_ok"
         );
+        // Windows canonical paths may carry a \\?\ verbatim prefix; the shim
+        // must strip it before launching node (issue: pnpm --version fails
+        // with "The system cannot find the path specified.").
+        assert!(content.contains("NODE:~0,4%"));
+        assert!(content.contains("NODE:~4%"));
     }
 
     #[test]
@@ -1120,6 +1133,9 @@ mod tests {
             dsh_node_at < local_at,
             "DSH_NODE must be checked before the local node search"
         );
+        // Same verbatim-prefix stripping as the CMD shim.
+        assert!(content.contains("StartsWith"));
+        assert!(content.contains("Substring(4)"));
     }
 
     #[test]

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -839,9 +839,12 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     // 不一致（相对 PATH 条目 / junction / 子进程 PATH 布局差异），导致 pnpm
     // shim 报 "Node.js runtime not found"（issue #121，与 build_plugin_envs
     // 的注入保持一致）。先规范化为绝对路径：相对路径在子进程 CWD 下会解析
-    // 到错误位置；已存在（上面校验过）的 node 可安全 canonicalize。
+    // 到错误位置；已存在（上面校验过）的 node 可安全 canonicalize。用
+    // dunce::canonicalize 而不是 std::fs::canonicalize：后者在 Windows 上会
+    // 返回 `\\?\` verbatim 前缀，cmd.exe 无法直接启动这种路径，导致 pnpm/dsh
+    // shim 报 "The system cannot find the path specified."。
     let node_abs =
-        std::fs::canonicalize(&node_binary_path).unwrap_or_else(|_| node_binary_path.clone());
+        dunce::canonicalize(&node_binary_path).unwrap_or_else(|_| node_binary_path.clone());
     envs.insert(
         "DSH_NODE".to_string(),
         node_abs.to_string_lossy().into_owned(),


### PR DESCRIPTION
## Problem

On Windows, the desktop app injects `DSH_NODE` into the harness service child environment. The value is produced with `std::fs::canonicalize`, which returns a `\\?\C:\...` verbatim path. The generated `pnpm.cmd` / `dsh.cmd` shims then try to launch `"%NODE%"` with that `\\?\`-prefixed path, and `cmd.exe` cannot start it:

```
The system cannot find the path specified.
```

This makes dsh-market's `pnpm --version` probe fail even though pnpm works fine from a normal terminal. Installing pnpm or setting `PNPM_HOME` does not help because the failure happens before pnpm runs.

## Fix

- `workflow/mod.rs`: use `dunce::canonicalize` instead of `std::fs::canonicalize` when building `DSH_NODE`, so the injected path is a normal Windows path without the `\\?\` verbatim prefix (matches `build_plugin_envs` in `install.rs`).
- `cli/shim.rs`: harden the generated CMD and PowerShell shims to strip a leading `\\?\` from `DSH_NODE` before launching node, as defense in depth for any other code path that may still inject a verbatim path.

## Verification

- Reproduced the original failure with `DSH_NODE=\\?\C:\Program Files\nodejs\node.exe` + `DSH_PREFER_BUNDLED_PNPM=1`.
- After the shim change, the same environment runs `pnpm --version` successfully (bundled pnpm 11.7.0).
- `cargo test -p deepseek-harness-desktop --lib shim` passes (29 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility when locating and launching Node.js.
  * Normalized Node.js paths to prevent failures caused by Windows verbatim path prefixes.
  * Added fallback handling when configured paths are invalid, using local or bundled Node.js where available.
  * Verified behavior across both Command Prompt and PowerShell launchers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->