### PR TITLE
Add dsh-whale-musume to preset plugins

### DIFF
--- a/src-tauri/resources/preset-plugins.json
+++ b/src-tauri/resources/preset-plugins.json
@@ -45,4 +45,12 @@
     "recommended": false,
     "defaultChecked": true
   }
+,{
+    "id": "dsh-whale-musume",
+    "spec": "github:Sutera-Diffusus/dsh-whale-musume",
+    "name": "Whale Musume",
+    "description": "A whale-girl desktop pet for the DSH web UI: pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements, drag physics, theme sync and a built-in settings panel. Local-first, zero telemetry.",
+    "repoUrl": "https://github.com/Sutera-Diffusus/dsh-whale-musume",
+    "recommended": false
+  }
 ]


### PR DESCRIPTION
Add [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) as a preset plugin: whale-girl desktop pet for the DSH web UI (pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements, built-in settings panel; local-first, zero telemetry; MIT; 102 unit tests). Installable via `dsh plugin --profile web add github:Sutera-Diffusus/dsh-whale-musume`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the dsh-whale-musume plugin to the preset plugin registry.
  * Included plugin details such as its description, repository link, and recommendation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->