### PR TITLE
refactor(plugin): extract deprecated plugin list into deprecated-plugins.json

### DIFF
--- a/src-tauri/resources/deprecated-plugins.json
+++ b/src-tauri/resources/deprecated-plugins.json
@@ -1,0 +1,3 @@
+[
+  "dsh-session-context-menu"
+]

--- a/src-tauri/src/service/plugin/install/mod.rs
+++ b/src-tauri/src/service/plugin/install/mod.rs
@@ -46,7 +46,7 @@ pub(crate) use super::ensure_profile_npmrc;
 pub(crate) use super::errors;
 pub(crate) use super::installed::{installed_name, is_installed, profile_dir};
 pub(crate) use super::preset::{
-    bundled_dep_spec, bundled_plugin_dir, load_presets, PreinstallPluginInfo,
+    bundled_dep_spec, bundled_plugin_dir, load_deprecated_ids, load_presets, PreinstallPluginInfo,
 };
 pub(crate) use super::process::{
     acquire_operation_lock, acquire_process_lock, new_process_owner, run_plugin_process, PidGuard,

--- a/src-tauri/src/service/plugin/install/single.rs
+++ b/src-tauri/src/service/plugin/install/single.rs
@@ -3,6 +3,7 @@
 //! 卸载后核验 profile 清单，插件仍被引用时走离线卸载兜底（受保护包除外）。
 //! 另含启动期弃用插件自动卸载（`uninstall_deprecated_plugins`）。
 
+use std::collections::HashSet;
 use std::ffi::OsString;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -19,6 +20,7 @@ use super::errors;
 use super::installed_name;
 use super::is_actionable_plugin_ref;
 use super::is_installed;
+use super::load_deprecated_ids;
 use super::load_presets;
 use super::new_process_owner;
 use super::pnpm::ensure_pnpm;
@@ -78,35 +80,40 @@ pub async fn remove(app_handle: &AppHandle, id: &str) -> Result<(), String> {
 
 /// 计算需要自动卸载的弃用插件已安装包名（纯函数，便于单测）。
 ///
-/// 命中条件：清单中带 `deprecated` 标记、非内部插件（内部插件由启动自愈强制
-/// 安装，不适用弃用语义），且当前已安装（以实际 npm 包名 `installed_name` 为准）。
-/// 返回实际安装包名——离线卸载（`uninstall_recovery`）以它为键从 profile 清单与
-/// `node_modules` 精准移除（scoped 包名与预设 id 不一致时也能正确卸载）。
+/// 命中条件：id 登记在弃用清单（`resources/deprecated-plugins.json`，见
+/// [`super::super::preset::load_deprecated_ids`]）、非内部插件（内部插件由启动
+/// 自愈强制安装，不适用弃用语义），且当前已安装（以实际 npm 包名 `installed_name`
+/// 为准）。返回实际安装包名——离线卸载（`uninstall_recovery`）以它为键从 profile
+/// 清单与 `node_modules` 精准移除（scoped 包名与预设 id 不一致时也能正确卸载）。
 fn deprecated_installed_names(
     presets: &[PreinstallPluginInfo],
+    deprecated_ids: &HashSet<String>,
     installed: impl Fn(&str) -> bool,
 ) -> Vec<String> {
     presets
         .iter()
-        .filter(|p| p.deprecated && !p.internal)
+        .filter(|p| deprecated_ids.contains(&p.id) && !p.internal)
         .filter(|p| installed(installed_name(p)))
         .map(|p| installed_name(p).to_string())
         .collect()
 }
 
-/// 启动时自动卸载清单中带 `deprecated` 标记的插件。
+/// 启动时自动卸载弃用清单（`resources/deprecated-plugins.json`）登记的插件。
 ///
-/// 弃用是发布侧决策：某个社区插件下架/被替换后，在 `preset-plugins.json` 里给它
-/// 打上 `deprecated` 标记，桌面端每次启动核对「已安装 → 自动卸载」，无需用户手动
-/// 处理，也避免残留插件继续在 profile 里加载破坏启动。仅处理社区预设；未被引用
-/// 的条目跳过。已卸载/未安装的插件跳过，绝不误伤其它插件。
+/// 弃用是发布侧决策：某个社区插件下架/被替换后，把它的 id 追加进弃用清单，桌面端
+/// 每次启动核对「已安装 → 自动卸载」，无需用户手动处理，也避免残留插件继续在
+/// profile 里加载破坏启动。仅处理社区预设；未被引用的条目跳过。已卸载/未安装的
+/// 插件跳过，绝不误伤其它插件。
 ///
 /// 启动阶段走离线精准卸载（`uninstall_recovery`）：不依赖 node/pnpm/窗口，即使
 /// 插件产物已损坏也能移除，也不会触发服务停止或 pnpm 下载。最佳努力：任何失败
 /// 只记告警，不阻断启动（调用方仅打日志）。
 pub(crate) async fn uninstall_deprecated_plugins(app_handle: &AppHandle) -> Result<(), String> {
     let presets = load_presets(app_handle);
-    let names = deprecated_installed_names(&presets, |name| is_installed(app_handle, name));
+    let deprecated_ids = load_deprecated_ids(app_handle);
+    let names = deprecated_installed_names(&presets, &deprecated_ids, |name| {
+        is_installed(app_handle, name)
+    });
     if names.is_empty() {
         return Ok(());
     }
@@ -257,46 +264,45 @@ mod tests {
             default_checked: false,
             win_only: false,
             internal,
-            deprecated: false,
         }
     }
 
     #[test]
     fn deprecated_installed_only_picks_marked_and_installed() {
-        // 只把 `dsh-ok` 视为已安装，其余一律未安装（便于区分「标记但未安装」）。
+        // 弃用清单只登记 dsh-ok / dsh-scoped / dsh-not-installed 三个 id；
+        // 只把 `dsh-ok` 视为已安装，其余一律未安装（便于区分「登记但未安装」）。
+        let deprecated: HashSet<String> = ["dsh-ok", "dsh-scoped", "dsh-not-installed"]
+            .into_iter()
+            .map(String::from)
+            .collect();
         let installed = |name: &str| matches!(name, "dsh-ok" | "@scope/deprecated");
 
-        // 命中：deprecated 且已安装 → 返回实际安装包名（dsh-ok 未声明 package，回落 id）
-        let mut deprecated = preset("dsh-ok", "dshmarket", false);
-        deprecated.deprecated = true;
+        // 命中：登记且已安装 → 返回实际安装包名（dsh-ok 未声明 package，回落 id）
         assert_eq!(
-            deprecated_installed_names(&[deprecated], installed),
+            deprecated_installed_names(&[preset("dsh-ok", "dshmarket", false)], &deprecated, installed),
             vec!["dsh-ok".to_string()]
         );
 
         // scoped 包：返回真实安装包名（与预设 id 不一致）
         let mut scoped = preset("dsh-scoped", "github:x/y", false);
-        scoped.deprecated = true;
         scoped.package = Some("@scope/deprecated".into());
         assert_eq!(
-            deprecated_installed_names(&[scoped], installed),
+            deprecated_installed_names(&[scoped], &deprecated, installed),
             vec!["@scope/deprecated".to_string()]
         );
 
-        // 未标记 deprecated：即使已安装也不命中
+        // 未登记弃用：即使已安装也不命中
         let plain = preset("dsh-plain", "dsh-plain", false);
-        assert!(deprecated_installed_names(&[plain], installed).is_empty());
+        assert!(deprecated_installed_names(&[plain], &deprecated, installed).is_empty());
 
-        // 标记了但未安装：不命中
-        let mut absent = preset("dsh-not-installed", "dshmarket", false);
-        absent.deprecated = true;
-        assert!(deprecated_installed_names(&[absent], installed).is_empty());
+        // 登记了但未安装：不命中
+        let absent = preset("dsh-not-installed", "dshmarket", false);
+        assert!(deprecated_installed_names(&[absent], &deprecated, installed).is_empty());
 
-        // 内部插件即使标记 deprecated 也不命中（内部插件由启动自愈强制安装）
-        let mut internal = preset("dsh-internal", "dsh-tauri@0.2.0", true);
-        internal.deprecated = true;
+        // 内部插件即使登记弃用也不命中（内部插件由启动自愈强制安装）
+        let internal = preset("dsh-internal", "dsh-tauri@0.2.0", true);
         assert!(
-            deprecated_installed_names(&[internal], |name| matches!(name, "dsh-internal"))
+            deprecated_installed_names(&[internal], &deprecated, |name| matches!(name, "dsh-internal"))
                 .is_empty()
         );
     }

--- a/src-tauri/src/service/plugin/install/spec.rs
+++ b/src-tauri/src/service/plugin/install/spec.rs
@@ -118,7 +118,6 @@ mod tests {
             default_checked: false,
             win_only: false,
             internal,
-            deprecated: false,
         }
     }
 

--- a/src-tauri/src/service/plugin/installed.rs
+++ b/src-tauri/src/service/plugin/installed.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tauri::AppHandle;
 
-use super::preset::{load_presets, PreinstallPluginInfo};
+use super::preset::{load_deprecated_ids, load_presets, PreinstallPluginInfo};
 
 /// 用于强类型解析 profile 下 package.json 的辅助结构
 /// （字段 pub(crate)：供 watch 模块解析已安装插件清单复用）
@@ -97,6 +97,9 @@ pub(crate) fn installed_name(p: &PreinstallPluginInfo) -> &str {
 pub fn list(app_handle: &AppHandle) -> Vec<PreinstallPlugin> {
     let installed = list_installed(app_handle);
     let is_windows = cfg!(windows);
+    // 弃用插件（deprecated-plugins.json 登记）不再提供安装入口，启动时自动卸载，
+    // 不进入首次引导清单。
+    let deprecated_ids = load_deprecated_ids(app_handle);
 
     load_presets(app_handle)
         .into_iter()
@@ -104,8 +107,8 @@ pub fn list(app_handle: &AppHandle) -> Vec<PreinstallPlugin> {
         // 内置插件（internal:true）由启动自愈强制安装，不进入首次引导清单：
         // 对用户而言它们“必装”，给出可取消的勾选框反而造成歧义。
         .filter(|p| !p.internal)
-        // 弃用插件（deprecated:true）不再提供安装入口，启动时自动卸载，不进入清单。
-        .filter(|p| !p.deprecated)
+        // 弃用插件不再提供安装入口，启动时自动卸载，不进入清单。
+        .filter(|p| !deprecated_ids.contains(&p.id))
         .map(|p| {
             // 已安装检测以实际 npm 包名为准：预设可显式声明 package（scoped 包
             // 名与预设 id 不一致时），未声明则回落到 id。
@@ -266,7 +269,6 @@ mod tests {
             default_checked: true,
             win_only: false,
             internal: false,
-            deprecated: false,
         };
         // scoped 包名与预设 id 不同：以 package 为准
         assert_eq!(

--- a/src-tauri/src/service/plugin/mod.rs
+++ b/src-tauri/src/service/plugin/mod.rs
@@ -21,7 +21,7 @@
 //! - [`verify`]：预装插件完整性自检（清单引用但 node_modules 产物缺失时 `pnpm install` 修复）
 //! - [`install`]：对外安装/升级/卸载编排（目录模块 `install/`：编排入口、spec 准备、
 //!   子进程环境、pnpm 选版、allowBuilds 白名单、错误诊断与产物核验），
-//!   以及启动时对清单中带 `deprecated` 标记的社区插件自动卸载
+//!   以及启动时对 `resources/deprecated-plugins.json` 登记的社区插件自动卸载
 //! - [`errors`]：插件错误记录（安装/升级/卸载失败 + 页面运行期上报，持久化）
 //! - [`process`]：dsh 子进程启动与输出流逐行转发
 //! - [`cancel`]：Windows 下取消正在进行的安装

--- a/src-tauri/src/service/plugin/preset.rs
+++ b/src-tauri/src/service/plugin/preset.rs
@@ -1,10 +1,12 @@
 //! 插件清单：分别读取随安装包分发的 `resources/preset-plugins.json` 与
-//! `resources/internal-plugins.json`。
+//! `resources/internal-plugins.json`，弃用名单单独维护在
+//! `resources/deprecated-plugins.json`（只登记预设插件 id，不参与预设合并）。
 //!
 //! 社区预设与内部插件分开维护；运行时合并为统一结构供安装、展示与自愈逻辑使用。
 //! 资源缺失/损坏时报错并回落为空清单，不阻断启动。
 
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 
@@ -14,6 +16,8 @@ use crate::config;
 const PRESET_PLUGINS_FILE: &str = "preset-plugins.json";
 /// 内部插件清单文件名
 const INTERNAL_PLUGINS_FILE: &str = "internal-plugins.json";
+/// 弃用插件清单文件名（只登记预设插件 id）
+const DEPRECATED_PLUGINS_FILE: &str = "deprecated-plugins.json";
 
 /// 插件静态信息，对应预设或内部插件清单中的条目
 #[derive(Debug, Clone, Deserialize)]
@@ -50,11 +54,6 @@ pub struct PreinstallPluginInfo {
     /// 仅 Windows 平台列出
     #[serde(default)]
     pub win_only: bool,
-    /// 弃用标记：带该字段的社区预设不再提供安装入口；若此前已安装，应用启动时
-    /// 自动卸载（见 [`super::install::uninstall_deprecated_plugins`]）。适用于社区
-    /// 预设（`preset-plugins.json`）；内部插件由启动自愈强制安装，不走弃用语义。
-    #[serde(default)]
-    pub deprecated: bool,
 }
 
 /// 在资源根目录下查找清单：先探测扁平布局（exe 同级），再探测
@@ -286,6 +285,46 @@ pub(crate) fn load_presets(app_handle: &AppHandle) -> Vec<PreinstallPluginInfo> 
     plugins
 }
 
+/// 解析弃用插件清单 JSON（纯字符串数组），返回 id 集合（重复 id 自动去重）。
+fn parse_deprecated_ids(json: &str) -> Result<HashSet<String>, String> {
+    let ids: Vec<String> = serde_json::from_str(json)
+        .map_err(|e| format!("DEPRECATED_PLUGINS_MANIFEST_INVALID_JSON: {e}"))?;
+    Ok(ids.into_iter().collect())
+}
+
+/// 读取弃用插件清单（`resources/deprecated-plugins.json`），返回已登记的预设
+/// 插件 id 集合。
+///
+/// 弃用是发布侧决策：某社区插件下架/被替换后，把它的 id 追加进该文件，桌面端
+/// 每次启动核对「已安装 → 自动卸载」（见
+/// [`super::install::uninstall_deprecated_plugins`]）。与 `preset-plugins.json`
+/// 分开维护：预设清单只描述「可安装项」，弃用清单只描述「不再提供安装入口的
+/// 预设 id」，调整弃用名单不会让既有用户重新进入首次引导。资源缺失/损坏时
+/// 记录错误并回落为空集合，不阻断启动（与其它清单同一降级策略）。
+pub(crate) fn load_deprecated_ids(app_handle: &AppHandle) -> HashSet<String> {
+    let Some(path) = plugins_manifest_path(app_handle, DEPRECATED_PLUGINS_FILE) else {
+        log::warn!("DEPRECATED_PLUGINS_MANIFEST_MISSING: {DEPRECATED_PLUGINS_FILE} not found in resource dir or source resources dir");
+        return HashSet::new();
+    };
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!(
+                "DEPRECATED_PLUGINS_MANIFEST_READ_FAILED: {}: {e}",
+                path.display()
+            );
+            return HashSet::new();
+        }
+    };
+    parse_deprecated_ids(&raw).unwrap_or_else(|e| {
+        log::error!(
+            "DEPRECATED_PLUGINS_MANIFEST_PARSE_FAILED: {}: {e}",
+            path.display()
+        );
+        HashSet::new()
+    })
+}
+
 /// 预装清单中某 id 对应的仓库地址
 pub fn repo_url_of(app_handle: &AppHandle, id: &str) -> Option<String> {
     load_presets(app_handle)
@@ -427,15 +466,33 @@ mod tests {
     }
 
     #[test]
-    fn deprecated_flag_parses_and_defaults_to_false() {
-        // 显式 `deprecated: true` 被解析
-        let raw = r#"[{"id":"x","spec":"y","name":"X","description":"","repoUrl":"u","deprecated":true}]"#;
-        let parsed = parse_plugins(raw, false).expect("preset manifest should parse");
-        assert!(parsed[0].deprecated);
-        // 未声明该字段时回落为 false（老清单向后兼容）
-        let raw = r#"[{"id":"x","spec":"y","name":"X","description":"","repoUrl":"u"}]"#;
-        let parsed = parse_plugins(raw, false).expect("preset manifest should parse");
-        assert!(!parsed[0].deprecated);
+    fn deprecated_ids_parse_into_set() {
+        // 字符串数组解析为 id 集合；重复 id 去重
+        let raw = r#"["dsh-a","dsh-b","dsh-a"]"#;
+        let ids = parse_deprecated_ids(raw).expect("deprecated manifest should parse");
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains("dsh-a"));
+        assert!(ids.contains("dsh-b"));
+    }
+
+    #[test]
+    fn deprecated_ids_reject_non_string_entries() {
+        // 非法条目（非字符串）整体解析失败，调用方回落为空集合
+        let raw = r#"[42]"#;
+        assert!(parse_deprecated_ids(raw).is_err());
+        let raw = r#"{"id":"dsh-x"}"#;
+        assert!(parse_deprecated_ids(raw).is_err());
+    }
+
+    #[test]
+    fn deprecated_manifest_lists_session_context_menu() {
+        // 随包分发的弃用清单应登记 dsh-session-context-menu（已被内部插件替代）
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("resources")
+            .join(DEPRECATED_PLUGINS_FILE);
+        let raw = std::fs::read_to_string(path).expect("deprecated manifest should exist");
+        let ids = parse_deprecated_ids(&raw).expect("deprecated manifest should be valid JSON");
+        assert!(ids.contains("dsh-session-context-menu"));
     }
 
     #[test]

--- a/src-tauri/src/service/plugin/verify.rs
+++ b/src-tauri/src/service/plugin/verify.rs
@@ -338,7 +338,6 @@ mod tests {
             default_checked: false,
             win_only: false,
             internal: false,
-            deprecated: false,
         }
     }
 

--- a/src-tauri/src/service/plugin/watch.rs
+++ b/src-tauri/src/service/plugin/watch.rs
@@ -366,7 +366,6 @@ mod tests {
             win_only: false,
             package: None,
             internal: false,
-            deprecated: false,
         }]
     }
 
@@ -451,7 +450,6 @@ mod tests {
             win_only: false,
             package: None,
             internal: true,
-            deprecated: false,
         });
         let plugins = parse_plugins(&dir, &presets);
         assert_eq!(plugins.len(), 2);

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -294,7 +294,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     if let Err(e) = crate::service::plugin::ensure_profile_npmrc(&app_handle) {
         log::warn!("ensure profile .npmrc failed: {e}");
     }
-    // 弃用插件自动卸载：预设清单里带 `deprecated` 标记的社区插件若已安装，启动时
+    // 弃用插件自动卸载：`deprecated-plugins.json` 登记的社区插件若已安装，启动时
     // 自动移除（避免残留插件继续在 profile 里加载、甚至导致启动失败）。最佳努力：
     // 失败只告警，不阻断启动。
     if let Err(e) = crate::service::plugin::uninstall_deprecated_plugins(&app_handle).await {


### PR DESCRIPTION
## 背景

`preset-plugins.json` 中通过 `deprecated` 字段标记弃用插件（当前为 `dsh-session-context-menu`），本次把弃用标记从预设清单中抽离为独立的 `resources/deprecated-plugins.json`（只登记预设插件 id）：

- 预设清单只描述「可安装项」；弃用清单只描述「不再提供安装入口的预设 id」
- 调整弃用名单不再改变 `preset-plugins.json` 指纹，既有用户不会因此重新进入首次引导
- 启动时自动卸载逻辑改为从新文件读取弃用名单（行为不变）

## 改动

- **`src-tauri/resources/deprecated-plugins.json`**（新增）：登记弃用插件 id，当前为 `["dsh-session-context-menu"]`
- **`preset.rs`**：新增 `DEPRECATED_PLUGINS_FILE` 常量与 `load_deprecated_ids` / `parse_deprecated_ids`（缺失/损坏时降级为空集合，与其他清单同一策略）；从 `PreinstallPluginInfo` 移除 `deprecated` 字段
- **`install/single.rs`**：`deprecated_installed_names` 改为按弃用 id 集合判定；`uninstall_deprecated_plugins` 启动时从新文件加载名单
- **`installed.rs`**：首次引导列表过滤「id ∈ 弃用集合」的预设
- **`install/mod.rs`**：重新导出 `load_deprecated_ids`
- 测试：新增弃用清单解析/去重/非法条目校验 + 真实清单包含 `dsh-session-context-menu`；各测试构造字面量清理 `deprecated` 字段

## 验证

- `cargo check` 通过
- `cargo test` 全量 333 通过，0 失败（含 4 个弃用相关用例）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized management of deprecated plugins.
  * Added `dsh-session-context-menu` to the deprecated plugin list.

* **Bug Fixes**
  * Deprecated community plugins are now consistently excluded and removed during application startup.
  * Improved handling for scoped, uninstalled, internal, duplicate, invalid, or unavailable plugin entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->