### PR TITLE
fix(recovery): retain official leaf refs during extraction

### DIFF
--- a/src-tauri/src/service/plugin/recovery/extract.rs
+++ b/src-tauri/src/service/plugin/recovery/extract.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-use super::is_actionable_plugin_ref;
+use super::is_package_name;
 
 /// 插件引用提取模式（编译一次复用，避免每次 `detect` 都重新编译正则）。
 static PLUGIN_REF_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
@@ -43,7 +43,7 @@ pub(super) fn extract_plugin_refs(text: &str) -> Vec<String> {
         for cap in re.captures_iter(text) {
             if let Some(m) = cap.get(1) {
                 let cand = m.as_str().trim();
-                if is_actionable_plugin_ref(cand) {
+                if is_package_name(cand) {
                     refs.insert(cand.to_string());
                 }
             }
@@ -54,7 +54,7 @@ pub(super) fn extract_plugin_refs(text: &str) -> Vec<String> {
         let rest = &text[m.end()..];
         for line in rest.lines().take(12) {
             let cand = line.trim().trim_end_matches(['.', ',', ' ']);
-            if is_actionable_plugin_ref(cand) {
+            if is_package_name(cand) {
                 refs.insert(cand.to_string());
             }
         }
@@ -128,6 +128,36 @@ mod tests {
         let refs = extract_plugin_refs(log);
         assert!(refs.contains(&"@omdsh-dev/dsh-better-sidebar".to_string()));
         assert!(refs.contains(&"dsh-web-ui-all".to_string()));
+    }
+
+    #[test]
+    fn extract_refs_keeps_valid_official_leaf() {
+        let log = r#"failed to import loader entry dshClientUi (@deepseek-ai/dsh-client-ui-chat)"#;
+        let refs = extract_plugin_refs(log);
+
+        assert_eq!(refs, vec!["@deepseek-ai/dsh-client-ui-chat"]);
+    }
+
+    #[test]
+    fn extract_boot_card_keeps_valid_official_leaf() {
+        let log = "Failed to load plugins\n@deepseek-ai/dsh-client-ui-chat\n";
+        let refs = extract_plugin_refs(log);
+
+        assert_eq!(refs, vec!["@deepseek-ai/dsh-client-ui-chat"]);
+    }
+
+    #[test]
+    fn extract_refs_rejects_malformed_log_candidates() {
+        let log = r#"
+failed to apply loader entry badTraversal (foo/../../target)
+cannot resolve profile bundle "@scope/pkg/extra"
+profile bundle "@scope/.." declares no dsh.bundle
+Failed to load plugins
+@scope/.hidden
+foo bar
+"#;
+
+        assert!(extract_plugin_refs(log).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/service/plugin/recovery/mod.rs
+++ b/src-tauri/src/service/plugin/recovery/mod.rs
@@ -225,9 +225,16 @@ mod tests {
         assert!(!is_package_name("@scope/foo."));
         assert!(is_package_name("foo.bar"));
         assert!(is_package_name("@scope/pkg.name"));
-        assert!(!is_actionable_plugin_ref("@deepseek-ai/dsh-base"));
         // dshmarket 是第三方市场插件，可卸载（不应被当作核心保护包）
         assert!(is_actionable_plugin_ref("dshmarket"));
         assert!(is_actionable_plugin_ref("dsh-better-sidebar"));
+    }
+
+    #[test]
+    fn official_packages_remain_non_actionable() {
+        assert!(is_package_name("@deepseek-ai/dsh-base"));
+        assert!(is_package_name("@deepseek-ai/dsh-client-ui-chat"));
+        assert!(!is_actionable_plugin_ref("@deepseek-ai/dsh-base"));
+        assert!(!is_actionable_plugin_ref("@deepseek-ai/dsh-client-ui-chat"));
     }
 }


### PR DESCRIPTION
## Summary

- retain syntactically valid package references, including `@deepseek-ai/*` leaves, while extracting plugin failure evidence
- let the existing unique-owner fallback map an official leaf failure back to its configured third-party root
- keep configured roots and every uninstall/removal boundary protected by `is_actionable_plugin_ref`

## Cause

`extract_plugin_refs` applied the actionability filter before ownership resolution. That discarded official leaf references before `resolve_recovery_plugins` could use its existing unique-owner fallback, so one-click recovery could not identify the responsible third-party root.

This changes evidence extraction only; official/core packages remain non-actionable and cannot be removed by recovery.

Related review finding: https://github.com/dsh-tauri-desk/deepseek-harness-desktop/pull/211#discussion_r3885634671

## Verification

- `cargo test --all-features --locked service::plugin::recovery::` (13 passed)
- `cargo test --all-features --locked` (338 passed)
- `cargo check --all-features --locked`
- targeted `rustfmt --edition 2021 --check` for both changed files
- `git diff HEAD^ HEAD --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin recovery detection for valid package names.
  * Prevented malformed or incomplete references from being treated as recoverable plugins.
  * Preserved correct uninstall behavior for official packages while allowing third-party packages to be removed when appropriate.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->