### PR TITLE
chore: release v0.9.3-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.9.3-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.9.2"
+version = "0.9.3-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.9.2"
+version = "0.9.3-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.9.2",
+  "version": "0.9.3-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.9.3-beta.1` (`0.9.2` → `0.9.3-beta.1`).

### Features

- **desktop**: add launch at login (#190) (5cf4f66)
- **plugin**: auto-uninstall deprecated preset plugins on startup (#201) (a9e7043)

### Bug Fixes

- **webview**: allow embedded microphone permissions (#216) (e213085)
- **service**: surface unexpected Harness exits (#213) (aee12b8)
- **service**: address CodeRabbit review comments from #210 (#211) (c535626)
- **plugin**: verify declared entry and rebuild missing build artifacts (#199) (9bc76af)
- harden plugin readiness cleanup (#207) (d0b0c98)
- **plugin**: respect explicit Git update targets (#206) (3cc40e4)
- **plugin**: invalidate update cache on locked revision changes (#200) (5dc271d)
- recover plugin readiness after delayed reinstall (#204) (9522055)
- **plugin**: force HTTPS for git-hosted plugin installs (#203) (979b3c0)
- **ci**: validate release version identity (#193) (e517dde)
- never close the dsh log pipe on non-UTF-8 lines (#197) (ec316cc)
- **workflow**: strip \\\\?\\ prefix from DSH_NODE to fix pnpm shim on Windows (#198) (16a7965)

### Refactors

- **plugin**: extract deprecated plugin list into deprecated-plugins.json (#212) (98bc573)
- **service**: split oversized modules into cohesive submodules (#210) (0eddaf4)
- **workflow**: encapsulate dsh package patches into service/patch (#209) (cf01034)

### Documentation

- **readme**: update plugin list, add session plugins and adjust right-click menu plugin entries (3303332)
- abandoning the old right-click menu plugin, updating documents and test cases, and adding a community QR code (51c7bd1)

### Chores

- change zh text (1ae3b5b)

### Other Changes

- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (faece32)
- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (559e43c)
- Update README.md (da6ea91)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.9.3-beta.1** across all release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->