### PR TITLE
chore: release v0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.9.3-beta.1",
+  "version": "0.9.3",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.9.3-beta.1"
+version = "0.9.3"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.9.3-beta.1"
+version = "0.9.3"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.9.3-beta.1",
+  "version": "0.9.3",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.9.3` (`0.9.3-beta.1` → `0.9.3`).

### Chores

- update docs (55f0529)

### Other Changes

- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (b395fcc)
- Update README.en.md (fcce1fa)
- Update README.md (c61821d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Promoted the application from beta version 0.9.3-beta.1 to stable version 0.9.3.
  * Updated the displayed application and package version information consistently across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->