### PR TITLE
feat(core): 预览版不推送更新提示，核心列表可见可装并带「预览版」标签

### DIFF
--- a/src-tauri/src/bridge/core.rs
+++ b/src-tauri/src/bridge/core.rs
@@ -6,8 +6,9 @@
 use crate::service::core;
 use tauri::AppHandle;
 
-/// 核心列表：本地 CLI 核心 + 预打包各版本（含 active 标记与 cli path）。
-/// 版本行数据源为 GitHub tags，拉取失败时降级为磁盘扫描（离线/限流仍可用）。
+/// 核心列表：本地 CLI 核心 + 预打包各版本（含 active 标记、cli path 与
+/// preview 预览版标记）。版本行数据源为 GitHub releases（含 Pre-release label），
+/// 拉取失败时降级为 git tags / 磁盘扫描（离线/限流仍可用）。
 #[tauri::command]
 pub async fn get_cores(app_handle: AppHandle) -> Vec<core::HarnessCore> {
     core::list(&app_handle).await

--- a/src-tauri/src/service/core/source.rs
+++ b/src-tauri/src/service/core/source.rs
@@ -57,6 +57,10 @@ pub struct HarnessCore {
     pub present: bool,
     /// 当前是否使用中的核心
     pub active: bool,
+    /// 是否预览版（GitHub Release 标记 Pre-release，或 tag 命名含预览标记，见
+    /// `download::is_preview_tag`）：预览版不参与自动更新提示，但可在核心列表
+    /// 手动下载安装，并以「预览版」标签展示。
+    pub preview: bool,
     pub error: Option<String>,
 }
 

--- a/src-tauri/src/service/core/version.rs
+++ b/src-tauri/src/service/core/version.rs
@@ -61,10 +61,13 @@ fn read_manifest_dsh_version(dir: &Path) -> Option<String> {
 
 /// 核心列表：本地核心 + deepseek-harness-pkg 各发布版本（按版本去重）。
 ///
-/// 版本行数据源为 GitHub tags（`fetch_dsh_pkg_tags`，最新在前）。pkg 仓库会对同一
-/// 版本打多个 tag（含测试打包），这里按版本去重——同一版本只保留**最后一个** tag。
-/// 激活的预打包版本不置顶，而是作为普通版本行按自然顺序排列并标记 `active`。
-/// tags 拉取失败（离线/限流）时降级为磁盘扫描，只列出本地、激活与已下载的历史版本。
+/// 版本行数据源为 GitHub releases（`fetch_dsh_pkg_releases`，最新在前，含
+/// Pre-release label）：预览版（label 或 tag 命名，见 `download::is_preview_tag`）
+/// 照常列出供手动下载安装，仅带「预览版」标记、不参与更新提示。pkg 仓库会对
+/// 同一版本打多个 tag（含测试打包），这里按版本去重——同一版本只保留**最后一个**
+/// tag，预览标记以保留的 tag 为准。releases 拉取失败（离线/限流）时回退 git
+/// tags（无 label，预览标记按 tag 命名兜底），再失败降级为磁盘扫描，只列出
+/// 本地、激活与已下载的历史版本。
 pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
     let source = active_source(app_handle);
     let local = local_core(app_handle);
@@ -88,6 +91,7 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
             .unwrap_or_default(),
         present: local.is_some(),
         active: source == CoreSource::Local,
+        preview: false,
         error: None,
     }];
 
@@ -107,33 +111,47 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
     // 始终如实呈现为"已安装"，即便本次以本地核心运行，也不会把它标成"未下载"。
     let installed_version = config::get_dsh_version(app_handle);
 
-    // 版本行：GitHub tags（最新在前）→ 按版本去重，同版本只保留最后一个 tag
-    let tags = match download::fetch_dsh_pkg_tags().await {
-        Ok(tags) => tags,
+    // 版本行：GitHub releases（最新在前，含 Pre-release label）→ 按版本去重，
+    // 同版本只保留最后一个 tag。releases 拉取失败（离线/限流）时回退 git tags，
+    // 预览标记按 tag 命名兜底（见 `download::is_preview_tag`）。
+    let release_metas = match download::fetch_dsh_pkg_releases().await {
+        Ok(metas) => metas,
         Err(e) => {
             log::warn!(
-                "Failed to fetch dsh pkg tags ({}), showing only on-disk versions",
+                "Failed to fetch dsh pkg releases ({}), falling back to git tags",
                 e
             );
-            Vec::new()
+            download::fetch_dsh_pkg_tags()
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(tag, _)| download::DshPkgReleaseMeta {
+                    tag,
+                    prerelease: false,
+                })
+                .collect()
         }
     };
-    let mut version_tags: Vec<(String, String)> = Vec::new(); // (version, tag)，保持首次出现顺序
-    for (tag, _commit) in &tags {
-        let Some(version) = download::parse_version_from_tag(tag) else {
+    let mut version_tags: Vec<(String, String, bool)> = Vec::new(); // (version, tag, preview)，保持首次出现顺序
+    for meta in &release_metas {
+        let Some(version) = download::parse_version_from_tag(&meta.tag) else {
             continue;
         };
-        if let Some(entry) = version_tags.iter_mut().find(|(v, _)| v == &version) {
-            // 同版本重复（测试打包）：保留最后一个 tag
-            entry.1 = tag.clone();
+        // 预览标记：GitHub Pre-release label 优先，tag 命名兜底（漏标 label 的
+        // 预览版也按命名识别）
+        let preview = meta.prerelease || download::is_preview_tag(&meta.tag);
+        if let Some(entry) = version_tags.iter_mut().find(|(v, _, _)| v == &version) {
+            // 同版本重复（测试打包）：保留最后一个 tag，预览标记以保留的 tag 为准
+            entry.1 = meta.tag.clone();
+            entry.2 = preview;
         } else {
-            version_tags.push((version, tag.clone()));
+            version_tags.push((version, meta.tag.clone(), preview));
         }
     }
 
     // 激活行就地标记：按版本匹配激活核心（不置顶，作为普通版本行标 active）
     let mut active_rendered = false;
-    for (version, tag) in &version_tags {
+    for (version, tag, preview) in &version_tags {
         let is_active = active_version.as_deref() == Some(version.as_str());
         // 已安装的预打包核心：即使本次以本地核心运行（source=Local）也要如实标为
         // "已安装"，避免本地核心出现后预打包被当作未下载/消失（issue #54）。
@@ -165,6 +183,7 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
             dir,
             present,
             active: is_active,
+            preview: *preview,
             error: None,
         });
     }
@@ -185,6 +204,10 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
             dir: active_dir.to_string_lossy().into_owned(),
             present: true,
             active: source == CoreSource::App,
+            // 无远程元数据（离线/限流）：预览标记按 tag 命名兜底
+            preview: active_tag
+                .as_deref()
+                .is_some_and(download::is_preview_tag),
             error: None,
         });
     }
@@ -192,7 +215,10 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
     // 磁盘扫描：tags 拉取失败/限流，或存在已下载但不在 tags 列表的版本（被移除的
     // 测试打包）时，把已下载的 `dsh-*` 槽位补进列表；同样按版本去重。
     // 激活版本已由版本行（或底部激活行）呈现，先放入 seen 避免扫描再补一条重复行。
-    let mut seen_versions: HashSet<String> = version_tags.iter().map(|(v, _)| v.clone()).collect();
+    let mut seen_versions: HashSet<String> = version_tags
+        .iter()
+        .map(|(v, _, _)| v.clone())
+        .collect();
     if let Some(v) = &active_version {
         seen_versions.insert(v.clone());
     }
@@ -230,11 +256,13 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
                 id: format!("app-{tag}"),
                 source: CoreSource::App,
                 version,
-                tag,
+                tag: tag.clone(),
                 path: dir.to_string_lossy().into_owned(),
                 dir: dir.to_string_lossy().into_owned(),
                 present: true,
                 active: false,
+                // 无远程元数据（离线/限流）：预览标记按 tag 命名兜底
+                preview: download::is_preview_tag(&tag),
                 error: None,
             });
         }
@@ -467,6 +495,7 @@ fn row_for_tag(app_handle: &AppHandle, tag: &str, dir: &Path) -> HarnessCore {
         dir: dir_str,
         present: true,
         active,
+        preview: download::is_preview_tag(tag),
         error: None,
     }
 }
@@ -508,32 +537,53 @@ mod tests {
     #[test]
     fn list_dedupes_versions_keeping_last_tag() {
         // 模拟 pkg 仓库的测试打包：同一版本打多个 tag（最新在前），去重后每个版本
-        // 只保留最后一个 tag，且顺序保持首次出现顺序（版本新→旧）。
-        let tags = vec![
-            ("dsh-0.1.1-rc.1-32342588166".to_string(), "c1".to_string()),
-            ("dsh-0.1.0-rc.8-32331963388".to_string(), "c2".to_string()),
-            // 同版本重复：后续 tag（测试打包）应被去重掉，保留最后一个
-            ("dsh-0.1.0-rc.8-32342588166".to_string(), "c3".to_string()),
-            ("dsh-0.1.0-rc.8-32342588167".to_string(), "c4".to_string()),
-            ("dsh-0.1.0-rc.7-31773193667".to_string(), "c5".to_string()),
-            ("dsh-0.1.0-rc.7-31773193668".to_string(), "c6".to_string()),
+        // 只保留最后一个 tag，且顺序保持首次出现顺序（版本新→旧）。预览标记
+        // （Pre-release label 或 tag 命名）以保留的 tag 为准：同版本先去重、再取
+        // 保留 tag 自己的标记。
+        let metas = vec![
+            // 最新：预览版（label + 命名一致）
+            ("dsh-0.2.0-preview.1-32490000001".to_string(), true),
+            ("dsh-0.1.1-rc.1-32342588166".to_string(), false),
+            ("dsh-0.1.0-rc.8-32331963388".to_string(), false),
+            // 同版本重复（测试打包）：后到的是预览 label，但再后到的是普通 release
+            ("dsh-0.1.0-rc.8-32342588166".to_string(), true),
+            ("dsh-0.1.0-rc.8-32342588167".to_string(), false),
+            ("dsh-0.1.0-rc.7-31773193667".to_string(), false),
+            ("dsh-0.1.0-rc.7-31773193668".to_string(), false),
+            // 漏标 Pre-release label 的预览版：按 tag 命名兜底识别
+            ("dsh-0.1.0-beta.1-32490000002".to_string(), false),
         ];
-        let mut version_tags: Vec<(String, String)> = Vec::new();
-        for (tag, _commit) in &tags {
-            let Some(version) = download::parse_version_from_tag(tag) else {
+        let mut version_tags: Vec<(String, String, bool)> = Vec::new();
+        for meta in &metas {
+            let Some(version) = download::parse_version_from_tag(&meta.0) else {
                 continue;
             };
-            if let Some(entry) = version_tags.iter_mut().find(|(v, _)| v == &version) {
-                entry.1 = tag.clone();
+            let preview = meta.1 || download::is_preview_tag(&meta.0);
+            if let Some(entry) = version_tags.iter_mut().find(|(v, _, _)| v == &version) {
+                entry.1 = meta.0.clone();
+                entry.2 = preview;
             } else {
-                version_tags.push((version, tag.clone()));
+                version_tags.push((version, meta.0.clone(), preview));
             }
         }
-        let versions: Vec<&str> = version_tags.iter().map(|(v, _)| v.as_str()).collect();
-        let kept_tags: Vec<&str> = version_tags.iter().map(|(_, t)| t.as_str()).collect();
-        assert_eq!(versions, vec!["0.1.1-rc.1", "0.1.0-rc.8", "0.1.0-rc.7"]);
+        let versions: Vec<&str> = version_tags.iter().map(|(v, _, _)| v.as_str()).collect();
+        let kept_tags: Vec<&str> = version_tags.iter().map(|(_, t, _)| t.as_str()).collect();
+        let previews: Vec<bool> = version_tags.iter().map(|(_, _, p)| *p).collect();
+        assert_eq!(
+            versions,
+            vec![
+                "0.2.0-preview.1",
+                "0.1.1-rc.1",
+                "0.1.0-rc.8",
+                "0.1.0-rc.7",
+                "0.1.0-beta.1"
+            ]
+        );
         // rc.8 / rc.7 都保留了最后一个 tag
-        assert_eq!(kept_tags[1], "dsh-0.1.0-rc.8-32342588167");
-        assert_eq!(kept_tags[2], "dsh-0.1.0-rc.7-31773193668");
+        assert_eq!(kept_tags[2], "dsh-0.1.0-rc.8-32342588167");
+        assert_eq!(kept_tags[3], "dsh-0.1.0-rc.7-31773193668");
+        // 预览标记以保留的 tag 为准：rc.8 最终保留普通 release → 非预览；
+        // 预览版（label 或命名）→ 预览
+        assert_eq!(previews, vec![true, false, false, false, true]);
     }
 }

--- a/src-tauri/src/service/download/github.rs
+++ b/src-tauri/src/service/download/github.rs
@@ -4,6 +4,11 @@
 //! 所有访问 api.github.com 的调用统一经 `download::utils::github_api` 冷却器收敛；
 //! API 限流/不可用时逐级兜底到 releases.atom / expanded_assets HTML /
 //! tag 内嵌 build-id，保证更新提示与完整性校验不因 403 而失效。
+//!
+//! 预览版（GitHub Release 标记 Pre-release、或 tag 命名含预览标记，见
+//! [`is_preview_tag`]）**不参与更新判定**：`/releases/latest` 按 label 自动排除，
+//! releases.atom 兜底按 tag 命名跳过；但核心列表（`fetch_dsh_pkg_releases`）
+//! 仍会列出预览版供用户手动下载安装。
 
 use crate::config;
 
@@ -84,9 +89,43 @@ fn commit_fallback_from_tag(tag: &str) -> String {
     tag.rsplit('-').next().unwrap_or(tag).to_string()
 }
 
-/// 从 releases.atom（github.com，非 api.github.com）解析最新 release tag。
+/// 从 releases.atom 正文中取出**第一条非预览版** release tag。
 ///
-/// 用作 API 限流/不可用时的兜底来源，仅在 API 完全不可达时调用。
+/// GitHub 的 releases.atom（github.com，非 api.github.com，不受未认证限流约束）
+/// 会包含 Pre-release 与手动测试 release，但 entry 里不含 Pre-release label——
+/// 只能按 tag 命名兜底（[`is_preview_tag`]）跳过预览版，取最新一条非预览版作为
+/// 「最新可用 release」。纯函数，便于单元测试。
+fn first_non_preview_tag_from_atom(body: &str) -> Option<String> {
+    let mut rest = body;
+    while let Some(start) = rest.find("<entry>") {
+        let end = rest[start..]
+            .find("</entry>")
+            .map(|e| start + e)
+            .unwrap_or(rest.len());
+        let entry = &rest[start..end];
+        let tag = entry
+            .split("releases/tag/")
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .filter(|t| !t.is_empty());
+        if let Some(tag) = tag {
+            if is_preview_tag(tag) {
+                log::debug!("DSH_ATOM: skip preview release {tag}");
+            } else {
+                return Some(tag.to_string());
+            }
+        }
+        rest = &rest[end..];
+    }
+    None
+}
+
+/// 从 releases.atom（github.com，非 api.github.com）解析最新**非预览版** release tag。
+///
+/// 用作 API 限流/不可用时的兜底来源，仅在 API 完全不可达时调用。逐条扫描
+/// atom 条目：预览版（Pre-release label 发布、tag 命名含预览标记）一律跳过，
+/// 只取最新一条非预览版——避免限流窗口内把预览版误当「最新 release」推给用户
+/// （见 [`is_preview_tag`]）。
 async fn fetch_latest_dsh_tag_from_atom() -> Result<String, String> {
     let client = github_client()?;
     let body = client
@@ -99,18 +138,8 @@ async fn fetch_latest_dsh_tag_from_atom() -> Result<String, String> {
         .text()
         .await
         .map_err(|e| format!("DSH_ATOM: {e}"))?;
-    // 取第一条 <entry> 作为最新 release，从中提取 releases/tag/<TAG>
-    let entry = body
-        .find("<entry>")
-        .and_then(|p| body[p..].find("</entry>").map(|e| &body[p..p + e]))
-        .unwrap_or(&body);
-    entry
-        .split("releases/tag/")
-        .nth(1)
-        .and_then(|s| s.split('"').next())
-        .filter(|t| !t.is_empty())
-        .map(|t| t.to_string())
-        .ok_or_else(|| "DSH_ATOM: missing tag in atom feed".to_string())
+    first_non_preview_tag_from_atom(&body)
+        .ok_or_else(|| "DSH_ATOM: no non-preview release in atom feed".to_string())
 }
 
 /// 从 expanded_assets HTML 片段中解析指定资产文件名后的 `sha256:<64hex>` 摘要。
@@ -173,6 +202,9 @@ async fn fetch_dsh_digest_from_expanded_assets(
 ///
 /// 修复前：api.github.com 一限流 `fetch_latest_dsh_pkg_info` 直接返回 Err，
 /// `check_dsh_update` 静默跳过，导致上游 rc.8 发布后桌面端迟迟不出现更新提示。
+///
+/// 预览版（Pre-release label 或 tag 命名，见 [`is_preview_tag`]）不返回：
+/// 返回 Err 由调用方保持本地安装、不提示更新，避免把预览版推给用户自动更新。
 pub async fn fetch_latest_dsh_pkg_info() -> Result<LatestDshPkg, String> {
     let client = github_client()?;
     let expected_name = config::get_dsh_download_url()?
@@ -209,6 +241,19 @@ pub async fn fetch_latest_dsh_pkg_info() -> Result<LatestDshPkg, String> {
             .to_string(),
         None => fetch_latest_dsh_tag_from_atom().await?,
     };
+
+    // 2b. 预览版不参与更新判定：`/releases/latest` 已按 label 排除 Pre-release，
+    //     这里按 tag 命名再兜底拦一道（发布时漏标 Pre-release label 的预览版
+    //     同样不会推给用户自动更新）。返回 Err 由调用方保持本地安装、不提示。
+    if is_preview_tag(&tag_name) {
+        log::info!(
+            "DSH_SKIP_PREVIEW: latest release {} is a preview, ignoring for update",
+            tag_name
+        );
+        return Err(format!(
+            "DSH_PREVIEW_RELEASE: {tag_name} is a preview release, not an update"
+        ));
+    }
 
     // 3. commit：优先 API /commits/{tag}，失败用 tag 内嵌 build-id 兜底
     let commit = match fetch_tag_commit(&client, &tag_name).await {
@@ -380,6 +425,29 @@ pub fn parse_version_from_tag(tag: &str) -> Option<String> {
     (!version.is_empty()).then(|| version.to_string())
 }
 
+/// 是否「预览版」tag：预览版不参与自动更新判定（不提示用户更新），但核心列表
+/// 仍会列出、可手动下载安装（见 [`fetch_dsh_pkg_releases`]）。
+///
+/// GitHub API 的 `/releases/latest` 已按 label 排除 Pre-release；但 releases.atom
+/// 兜底（feed 无 label 字段）与核心列表的 git tags 兜底需要按 tag 命名判定。
+/// 判定规则：tag 版本解析成功（`dsh-<version>-<build-id>`）且版本号的 pre-release
+/// 段含**非 rc** 的预览标记（`preview`/`beta`/`alpha`/`canary`/`next`）→ 预览版。
+/// rc（如 `0.1.1-rc.2`）不算预览版：pkg 仓库的 rc 发布会正常推送用户更新。
+pub fn is_preview_tag(tag: &str) -> bool {
+    let Some(version) = parse_version_from_tag(tag) else {
+        return false;
+    };
+    let Ok(parsed) = semver::Version::parse(&version) else {
+        return false;
+    };
+    const PREVIEW_MARKERS: [&str; 5] = ["preview", "beta", "alpha", "canary", "next"];
+    parsed
+        .pre
+        .as_str()
+        .split('.')
+        .any(|id| PREVIEW_MARKERS.iter().any(|m| id.starts_with(m)))
+}
+
 /// 安装记录（`dsh_pkg_commit` / `dsh_pkg_tag`）是否对应「最新 release 的同一发布」。
 ///
 /// commit 存在两种合法形态：完整 git SHA（api.github.com 正常时解析，如
@@ -498,6 +566,47 @@ pub fn resolve_update(
     }
 }
 
+/// 单个 pkg release 的列表元数据（核心面板多版本列表用）。
+#[derive(Debug, Clone)]
+pub struct DshPkgReleaseMeta {
+    pub tag: String,
+    /// GitHub Release 是否标记为 Pre-release（预览版）
+    pub prerelease: bool,
+}
+
+/// 拉取 pkg 仓库的 release 列表（最新在前），含 GitHub 的 Pre-release label。
+///
+/// 核心面板的多版本列表以此作为远程数据源（替代 git tags）：git tags 不含
+/// Pre-release label，无法区分预览版；releases 列表还能天然排除 draft（未发布
+/// 对匿名请求不可见）。失败时调用方回退 git tags，预览标记按 tag 命名
+/// （[`is_preview_tag`]）兜底。
+pub async fn fetch_dsh_pkg_releases() -> Result<Vec<DshPkgReleaseMeta>, String> {
+    let client = github_client()?;
+    let releases: serde_json::Value = github_api_get(
+        &client,
+        &format!("{DSH_PKG_GITHUB_API}/releases?per_page=100"),
+    )
+    .await
+    .map_err(|e| format!("Release list request failed: {e}"))?
+    .json()
+    .await
+    .map_err(|e| format!("Failed to parse release list response: {e}"))?;
+
+    Ok(releases
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let tag = entry.get("tag_name")?.as_str()?.to_string();
+            let prerelease = entry
+                .get("prerelease")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            Some(DshPkgReleaseMeta { tag, prerelease })
+        })
+        .collect())
+}
+
 /// 拉取 pkg 仓库的 release tag 列表（tag, commit），用于反查历史记录对应的版本。
 ///
 /// 仅在更新判定需要反查“无 tag 的老记录”时调用，失败时由调用方回退到
@@ -609,6 +718,48 @@ mod tests {
         assert_eq!(parse_version_from_tag("dsh-0.2.0"), None);
         assert_eq!(parse_version_from_tag("0.1.0-rc.7-abc"), None);
         assert_eq!(parse_version_from_tag(""), None);
+    }
+
+    #[test]
+    fn preview_tag_detection_by_version_marker() {
+        // 预览标记：preview/beta/alpha/canary/next → 预览版
+        assert!(is_preview_tag("dsh-0.2.0-preview.1-32490000001"));
+        assert!(is_preview_tag("dsh-0.2.0-beta.1-32490000002"));
+        assert!(is_preview_tag("dsh-0.2.0-alpha.2-32490000003"));
+        assert!(is_preview_tag("dsh-0.2.0-canary.1-32490000004"));
+        assert!(is_preview_tag("dsh-0.2.0-next.3-32490000005"));
+        // rc 不算预览版：pkg 仓库的 rc 发布会正常推送用户更新
+        assert!(!is_preview_tag("dsh-0.1.1-rc.2-32485170079"));
+        assert!(!is_preview_tag("dsh-0.1.0-rc.8-32342588166"));
+        // 正式版 / 无法解析的 tag 均不算预览版
+        assert!(!is_preview_tag("dsh-0.2.0-32490000006"));
+        assert!(!is_preview_tag("dsh-0.2.0"));
+        assert!(!is_preview_tag(""));
+    }
+
+    #[test]
+    fn atom_fallback_skips_preview_and_picks_next_non_preview() {
+        // 最新条目是预览版 → 必须跳过，取下一条非预览版（rc）
+        let feed = concat!(
+            "<feed>",
+            "<entry><link rel=\"alternate\" href=\"/x/deepseek-harness-pkg/releases/tag/dsh-0.2.0-preview.1-32490000001\"/></entry>",
+            "<entry><link rel=\"alternate\" href=\"/x/deepseek-harness-pkg/releases/tag/dsh-0.1.1-rc.2-32485170079\"/></entry>",
+            "</feed>"
+        );
+        assert_eq!(
+            first_non_preview_tag_from_atom(feed).as_deref(),
+            Some("dsh-0.1.1-rc.2-32485170079")
+        );
+        // 全部是预览版 → None（调用方按「无可用 release」处理，不推更新）
+        let all_preview = concat!(
+            "<feed>",
+            "<entry><link rel=\"alternate\" href=\"/x/deepseek-harness-pkg/releases/tag/dsh-0.2.0-preview.1-32490000001\"/></entry>",
+            "<entry><link rel=\"alternate\" href=\"/x/deepseek-harness-pkg/releases/tag/dsh-0.2.0-beta.1-32490000002\"/></entry>",
+            "</feed>"
+        );
+        assert_eq!(first_non_preview_tag_from_atom(all_preview), None);
+        // 空 feed → None
+        assert_eq!(first_non_preview_tag_from_atom(""), None);
     }
 
     #[test]

--- a/src-tauri/src/service/download/mod.rs
+++ b/src-tauri/src/service/download/mod.rs
@@ -10,8 +10,9 @@ pub use core::{
     download_file, download_file_from_sources, ensure_extract, fetch_node_sha256, verify_sha256,
 };
 pub use github::{
-    fetch_dsh_pkg_asset, fetch_dsh_pkg_tags, fetch_latest_dsh_pkg_info, parse_version_from_tag,
-    record_matches_latest_release, resolve_update, LatestDshPkg, UpdateCheck,
+    fetch_dsh_pkg_asset, fetch_dsh_pkg_releases, fetch_dsh_pkg_tags, fetch_latest_dsh_pkg_info,
+    is_preview_tag, parse_version_from_tag, record_matches_latest_release, resolve_update,
+    DshPkgReleaseMeta, LatestDshPkg, UpdateCheck,
 };
 // 供核心面板切换版本时使用（跨模块内部接口，不进公共 API）
 pub(crate) use core::{remove_dir_with_retry, rename_with_retry};

--- a/src/components/config-core.tsx
+++ b/src/components/config-core.tsx
@@ -21,8 +21,9 @@ import { PanelState } from './panel-state'
  *
  * - 列表来自 `useDshCores`（`get_cores` 查询 + `setting_updated` 事件刷新）：
  *   `local` = 用户通过 CLI 全局安装的本地核心（存在时优先使用，需求 3）；
- *   `app-<tag>` = deepseek-harness-pkg 各发布版本（GitHub tags 拉取失败时
- *   降级为磁盘扫描，仅显示已下载版本）。
+ *   `app-<tag>` = deepseek-harness-pkg 各发布版本（GitHub releases 拉取失败时
+ *   降级为 git tags / 磁盘扫描，仅显示已下载版本）。预览版（Pre-release label
+ *   或 tag 命名）照常列出、可下载安装，但带「预览版」标签、不参与更新提示。
  * - 切换核心：持久化后**自动重启**服务（需求 5），重启走 harness store 的
  *   restart 流程（停止 → 重新启动 → 健康检查）。
  * - 下载版本：拉指定 tag 的发布资产到历史槽位（不激活），随后可切换；
@@ -45,10 +46,11 @@ export function ConfigCore() {
   const localCore = cores.find(c => c.source === 'local')
 
   // 本地核心是否有新版可更新：仅当存在更新的预打包发布时才显示「更新本地核心」。
-  // 版本行按 tags 最新在前，取第一个 app 版本作为"当前最新可用版本"（本地版本
-  // 已是最新时不再展示更新入口，避免"已最新仍提示更新"）。
+  // 版本行按 releases 最新在前，取第一个**非预览版** app 版本作为"当前最新可用
+  // 版本"（预览版不参与更新判定；本地版本已是最新时不再展示更新入口，避免
+  // "已最新仍提示更新"）。
   const localVersion = localCore?.version ?? ''
-  const latestVersion = cores.find(c => c.source === 'app')?.version ?? ''
+  const latestVersion = cores.find(c => c.source === 'app' && !c.preview)?.version ?? ''
   const hasLocalUpdate = !!(localCore?.present && localVersion && latestVersion && compareVersions(localVersion, latestVersion) < 0)
 
   /** 包裹行内操作：全局单例守卫 + 该行 busy 标记 */
@@ -201,6 +203,12 @@ export function ConfigCore() {
                   <If cond={core.source === 'app'}>
                     <Chip size="sm" variant="soft" color="default" className="shrink-0 font-medium">
                       {t('core.app')}
+                    </Chip>
+                  </If>
+                  {/* 预览版标记：Pre-release label 或 tag 命名判定的预览版，可下载安装但不参与更新提示 */}
+                  <If cond={core.preview}>
+                    <Chip size="sm" variant="soft" color="warning" className="shrink-0 font-medium">
+                      {t('core.preview')}
                     </Chip>
                   </If>
                   {/* 已下载：Chip 右侧的文件夹图标，点击打开所在目录 */}

--- a/src/hooks/use-dsh-cores.ts
+++ b/src/hooks/use-dsh-cores.ts
@@ -23,6 +23,8 @@ export interface HarnessCore {
   present: boolean
   /** 当前是否使用中 */
   active: boolean
+  /** 是否预览版（GitHub Pre-release label 或 tag 命名判定）：预览版不参与更新提示，仅列表展示 */
+  preview: boolean
   error?: string | null
 }
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -172,6 +172,7 @@
   "core.remove_confirm_title": "Uninstall version",
   "core.remove_confirm_desc": "Uninstall {{version}}? The engine copy will be removed from this device (other copies are unaffected).",
   "core.app": "Bundled",
+  "core.preview": "Preview",
   "core.update_local": "Update Local Core",
   "core.updated_toast": "Local core updated: {{version}}",
   "core.update_failed": "Failed to update the local core",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -172,6 +172,7 @@
   "core.remove_confirm_title": "卸载版本",
   "core.remove_confirm_desc": "确定卸载 {{version}} 吗？将移除本机的该引擎副本（其余副本不受影响）。",
   "core.app": "预打包",
+  "core.preview": "预览版",
   "core.update_local": "更新本地核心",
   "core.updated_toast": "本地核心已更新：{{version}}",
   "core.update_failed": "本地核心更新失败",


### PR DESCRIPTION
## 背景

发布预览版（GitHub Release 标记 Pre-release）时，桌面端不应把预览版推给用户自动更新；但核心列表仍需可见、可手动下载安装，并带「预览版」标签。

## 改动

**1. 预览版不再触发更新提示（service/download/github.rs）**
- 更新判定唯一入口 etch_latest_dsh_pkg_info 不再返回预览版：
  - /releases/latest 按 GitHub label 天然排除 Pre-release（正常路径本就安全）；
  - releases.atom 兜底由「取第一条 entry」改为逐条扫描、跳过预览版 tag（feed 无 label 字段，按 tag 命名判定），同时修掉兜底路径「下载 latest 正式资产、却拿预览版摘要校验」必失败的隐藏不一致；
  - 最终防线：任意路径拿到 tag 后，若 is_preview_tag（版本 pre-release 段含 preview/beta/alpha/canary/next；**rc 不算**，rc 发布会照常推送）→ 按「无更新」处理，不提示、不自动安装。

**2. 核心列表可见可装 + 「预览版」标签**
- 列表数据源由 git tags（无 label 信息）改为 GitHub releases API（etch_dsh_pkg_releases，含 Pre-release label）；离线/限流回退 git tags + tag 命名兜底；
- HarnessCore 新增 preview 字段，前端每行渲染黄色「预览版」Chip（core.preview，中英 i18n 已同步）；
- 下载安装走既有 download_core（/releases/tags/{tag}），预览版照常可下载、可切换；
- 「更新本地核心」可用性判断跳过预览版行。

## 验证

- cargo check 通过
- cargo test：336 项既有测试 + 3 项新增/更新测试（预览版判定、atom 兜底跳过预览版、版本去重含预览标记）全部通过
- pnpm typecheck 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview releases are now identified and labeled throughout core listings.
  * Preview versions remain available for manual installation.
  * Release discovery supports release metadata with tag and disk-scan fallbacks.
  * Added English and Simplified Chinese preview labels.

* **Bug Fixes**
  * Automatic update checks now select the newest stable release and exclude preview versions.
  * Improved fallback behavior when the latest release is a preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->