### PR TITLE
fix(core): prevent process races during version switching

### DIFF
--- a/src-tauri/src/service/core/version.rs
+++ b/src-tauri/src/service/core/version.rs
@@ -309,7 +309,7 @@ pub async fn set_active(app_handle: &AppHandle, id: &str) -> Result<HarnessCore,
 async fn switch_app_version(app_handle: &AppHandle, tag: &str) -> Result<(), String> {
     // 从切换开始到目录互换完成持续持有与 launch 共用的转换锁，避免两个切换
     // 重叠，也避免 launch 在状态检查后插入并从旧的 dependencies/dsh 加载 DLL。
-    let _transition_guard = workflow::acquire_core_transition().await;
+    let _transition_guard = workflow::acquire_core_transition().await?;
     let deps = dependencies_dir(app_handle);
     let active_dir = config::get_dsh_install_path(app_handle);
     fs_guard::validate_id(tag)?;

--- a/src-tauri/src/service/core/version.rs
+++ b/src-tauri/src/service/core/version.rs
@@ -307,7 +307,9 @@ pub async fn set_active(app_handle: &AppHandle, id: &str) -> Result<HarnessCore,
 /// 磁盘布局：激活版本固定为 `dependencies/dsh`（既有代码全部依赖该路径），
 /// 已下载的历史版本存放在 `dependencies/<tag>`（tag 以 `dsh-` 开头）。切换 = 目录
 /// 互换：先把当前激活目录改名为自己的 tag 槽位（清理残留同名槽位），再把目标槽位
-/// 改名为激活目录；任一步失败回滚。切换前先停服务，避免目录被进程句柄锁定（Windows DLL 锁）。
+/// 改名为激活目录；任一步失败回滚。切换前先停服务并清扫残留进程，避免目录被进程
+/// 句柄锁定（Windows DLL 锁）；切换期间持有核心切换守卫（`workflow::core_switch_guard`），
+/// 阻止并发 `launch` 在互换窗口内重新拉起进程锁死目录（CORE_SWITCH_FAILED, os error 32）。
 async fn switch_app_version(app_handle: &AppHandle, tag: &str) -> Result<(), String> {
     let deps = dependencies_dir(app_handle);
     let active_dir = config::get_dsh_install_path(app_handle);
@@ -324,11 +326,29 @@ async fn switch_app_version(app_handle: &AppHandle, tag: &str) -> Result<(), Str
         return Ok(());
     }
 
+    // 进入切换临界区：期间 `workflow::launch` 会等待/拒绝拉起新进程（新进程
+    // 从 `dependencies/dsh` 加载原生 DLL 锁住目录，互换重命名必然 os error 32）。
+    // 秒级窗口，`_switch_guard` 在函数返回（含失败路径）时自动复位。
+    let _switch_guard = workflow::core_switch_guard();
+
     // 切换前停止运行中的服务，避免目录被进程句柄锁定
     if workflow::has_owned_process() {
         if let Err(e) = workflow::stop(app_handle.clone()).await {
             log::warn!("failed to stop harness before core switch: {e}");
         }
+    }
+    // 只停本应用持有的进程还不够：崩溃/强杀残留的孤儿 Harness 实例（不在
+    // .harness.pid 标记中）同样从 dependencies/dsh 启动、占用目录文件句柄，
+    // 会导致切换重命名失败（os error 32）。与安装流程一致，按命令行路径精确
+    // 清扫所有本应用 dsh 安装目录启动的进程。枚举/结束涉及 powershell 枚举与
+    // taskkill（同步阻塞），移出 Tokio 线程。
+    {
+        let handle = app_handle.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            workflow::terminate_stale_harness_processes(&handle);
+        })
+        .await
+        .map_err(|e| format!("CORE_SWITCH_STOP_FAILED: {e}"))?;
     }
 
     // 1. 当前激活目录让出激活位：改名为自己的 tag 槽位（残留槽位先清理）

--- a/src-tauri/src/service/core/version.rs
+++ b/src-tauri/src/service/core/version.rs
@@ -205,9 +205,7 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
             present: true,
             active: source == CoreSource::App,
             // 无远程元数据（离线/限流）：预览标记按 tag 命名兜底
-            preview: active_tag
-                .as_deref()
-                .is_some_and(download::is_preview_tag),
+            preview: active_tag.as_deref().is_some_and(download::is_preview_tag),
             error: None,
         });
     }
@@ -215,10 +213,8 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
     // 磁盘扫描：tags 拉取失败/限流，或存在已下载但不在 tags 列表的版本（被移除的
     // 测试打包）时，把已下载的 `dsh-*` 槽位补进列表；同样按版本去重。
     // 激活版本已由版本行（或底部激活行）呈现，先放入 seen 避免扫描再补一条重复行。
-    let mut seen_versions: HashSet<String> = version_tags
-        .iter()
-        .map(|(v, _, _)| v.clone())
-        .collect();
+    let mut seen_versions: HashSet<String> =
+        version_tags.iter().map(|(v, _, _)| v.clone()).collect();
     if let Some(v) = &active_version {
         seen_versions.insert(v.clone());
     }
@@ -308,9 +304,12 @@ pub async fn set_active(app_handle: &AppHandle, id: &str) -> Result<HarnessCore,
 /// 已下载的历史版本存放在 `dependencies/<tag>`（tag 以 `dsh-` 开头）。切换 = 目录
 /// 互换：先把当前激活目录改名为自己的 tag 槽位（清理残留同名槽位），再把目标槽位
 /// 改名为激活目录；任一步失败回滚。切换前先停服务并清扫残留进程，避免目录被进程
-/// 句柄锁定（Windows DLL 锁）；切换期间持有核心切换守卫（`workflow::core_switch_guard`），
-/// 阻止并发 `launch` 在互换窗口内重新拉起进程锁死目录（CORE_SWITCH_FAILED, os error 32）。
+/// 句柄锁定（Windows DLL 锁）；切换期间持有与 `launch` 共用的转换锁，阻止并发
+/// `launch` 或另一个切换在互换窗口内插入并锁死目录（CORE_SWITCH_FAILED, os error 32）。
 async fn switch_app_version(app_handle: &AppHandle, tag: &str) -> Result<(), String> {
+    // 从切换开始到目录互换完成持续持有与 launch 共用的转换锁，避免两个切换
+    // 重叠，也避免 launch 在状态检查后插入并从旧的 dependencies/dsh 加载 DLL。
+    let _transition_guard = workflow::acquire_core_transition().await;
     let deps = dependencies_dir(app_handle);
     let active_dir = config::get_dsh_install_path(app_handle);
     fs_guard::validate_id(tag)?;
@@ -326,15 +325,13 @@ async fn switch_app_version(app_handle: &AppHandle, tag: &str) -> Result<(), Str
         return Ok(());
     }
 
-    // 进入切换临界区：期间 `workflow::launch` 会等待/拒绝拉起新进程（新进程
-    // 从 `dependencies/dsh` 加载原生 DLL 锁住目录，互换重命名必然 os error 32）。
-    // 秒级窗口，`_switch_guard` 在函数返回（含失败路径）时自动复位。
-    let _switch_guard = workflow::core_switch_guard();
-
     // 切换前停止运行中的服务，避免目录被进程句柄锁定
     if workflow::has_owned_process() {
         if let Err(e) = workflow::stop(app_handle.clone()).await {
-            log::warn!("failed to stop harness before core switch: {e}");
+            log::warn!(
+                "failed to stop harness before core switch at {}: {e}",
+                active_dir.display()
+            );
         }
     }
     // 只停本应用持有的进程还不够：崩溃/强杀残留的孤儿 Harness 实例（不在

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -17,7 +17,10 @@ use super::process::set_owned_process;
 use super::process::set_owned_process_with_handle;
 #[cfg(unix)]
 use super::process::warn_if_inotify_watch_limit_low;
-use super::process::{has_owned_process, on_owned_process_exit, stop, LaunchGuard, LAUNCH_GUARD};
+use super::process::{
+    has_owned_process, on_owned_process_exit, stop, terminate_stale_harness_processes, LaunchGuard,
+    LAUNCH_GUARD,
+};
 use super::status;
 use super::sweep::persist_harness_pid;
 #[cfg(windows)]
@@ -184,6 +187,27 @@ pub async fn restart(app_handle: tauri::AppHandle) -> Result<(), String> {
 
 /// 启动 Harness 服务进程
 pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
+    // 核心切换（`dependencies/dsh` 版本目录互换）期间禁止拉起新进程：新进程会
+    // 以 `dependencies/dsh` 为 cwd 并加载原生模块 DLL（如 sharp 的 libvips）
+    // 进内存，目录被锁后互换重命名必然失败（CORE_SWITCH_FAILED, os error 32）。
+    // 切换是秒级操作：短暂等待其完成再继续，超时才报错（调用方稍后重试即可，
+    // 见 service::workflow::process::core_switch_in_progress）。
+    if super::process::core_switch_in_progress() {
+        const CORE_SWITCH_WAIT: std::time::Duration = std::time::Duration::from_secs(15);
+        let deadline = tokio::time::Instant::now() + CORE_SWITCH_WAIT;
+        while super::process::core_switch_in_progress()
+            && tokio::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        if super::process::core_switch_in_progress() {
+            return Err(
+                "CORE_SWITCH_IN_PROGRESS: core version switch still in progress, retry shortly"
+                    .to_string(),
+            );
+        }
+    }
+
     let mut setting = config::get_store_dat_setting(&app_handle);
     let node_binary_path = config::get_node_binary_path(&app_handle);
     // 活动核心的 dsh 入口（本地核心优先，未检测到走预打包）
@@ -213,6 +237,23 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
         return Ok(());
     }
     let _launch_guard = LaunchGuard;
+
+    // 只有持有启动守卫的这条路径清扫残留：并发启动的其它调用已在守卫处返回，
+    // 不会误杀刚拉起的进程。崩溃/强杀残留的孤儿 Harness 实例（不在
+    // .harness.pid 标记中）持续占用配置端口与 dependencies/dsh 的文件句柄，
+    // 不清扫会导致端口一路漂移（3080→…→3085，issue #91）并让后续目录互换
+    // 失败（os error 32）。按命令行路径精确匹配本应用 dsh 服务，不会误杀
+    // 用户其它 node 程序（debug 构建为 no-op，见 terminate_stale_harness_processes）。
+    {
+        let handle = app_handle.clone();
+        if let Err(e) = tauri::async_runtime::spawn_blocking(move || {
+            terminate_stale_harness_processes(&handle);
+        })
+        .await
+        {
+            log::warn!("failed to sweep stale harness processes before launch: {e}");
+        }
+    }
 
     // 端口自愈：自动避让递增（配置端口被占 → 逐级顶高）遗留的非默认端口，
     // 在回落目标（用户手动端口 manual_port，否则默认端口）空闲时回落，避免

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -205,7 +205,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
 
     // 从这里开始持有与核心切换共用的互斥锁：最终状态检查、启动守卫、残留清扫
     // 及新进程登记必须处于同一临界区，避免切换在检查后插入。
-    let _transition_guard = super::process::acquire_core_transition().await;
+    let _transition_guard = super::process::acquire_core_transition().await?;
 
     // 避免重复启动（配合启动守卫，确保并发调用只拉起一个进程）
     if has_owned_process() {

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -187,27 +187,6 @@ pub async fn restart(app_handle: tauri::AppHandle) -> Result<(), String> {
 
 /// 启动 Harness 服务进程
 pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
-    // 核心切换（`dependencies/dsh` 版本目录互换）期间禁止拉起新进程：新进程会
-    // 以 `dependencies/dsh` 为 cwd 并加载原生模块 DLL（如 sharp 的 libvips）
-    // 进内存，目录被锁后互换重命名必然失败（CORE_SWITCH_FAILED, os error 32）。
-    // 切换是秒级操作：短暂等待其完成再继续，超时才报错（调用方稍后重试即可，
-    // 见 service::workflow::process::core_switch_in_progress）。
-    if super::process::core_switch_in_progress() {
-        const CORE_SWITCH_WAIT: std::time::Duration = std::time::Duration::from_secs(15);
-        let deadline = tokio::time::Instant::now() + CORE_SWITCH_WAIT;
-        while super::process::core_switch_in_progress()
-            && tokio::time::Instant::now() < deadline
-        {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
-        if super::process::core_switch_in_progress() {
-            return Err(
-                "CORE_SWITCH_IN_PROGRESS: core version switch still in progress, retry shortly"
-                    .to_string(),
-            );
-        }
-    }
-
     let mut setting = config::get_store_dat_setting(&app_handle);
     let node_binary_path = config::get_node_binary_path(&app_handle);
     // 活动核心的 dsh 入口（本地核心优先，未检测到走预打包）
@@ -223,6 +202,10 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
         log::error!("Harness not installed");
         return Err("HARNESS_NOT_FOUND: Harness not installed".to_string());
     }
+
+    // 从这里开始持有与核心切换共用的互斥锁：最终状态检查、启动守卫、残留清扫
+    // 及新进程登记必须处于同一临界区，避免切换在检查后插入。
+    let _transition_guard = super::process::acquire_core_transition().await;
 
     // 避免重复启动（配合启动守卫，确保并发调用只拉起一个进程）
     if has_owned_process() {
@@ -251,7 +234,10 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
         })
         .await
         {
-            log::warn!("failed to sweep stale harness processes before launch: {e}");
+            log::warn!(
+                "failed to sweep stale Harness processes before launch at {}: {e}",
+                dsh_binary_path.display()
+            );
         }
     }
 

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -27,6 +27,7 @@ pub use health::proxy_health_check;
 pub use install::install;
 pub use launch::{launch, restart, start};
 pub use process::{
-    core_switch_guard, has_owned_process, stop, stop_on_exit, terminate_stale_harness_processes,
+    acquire_core_transition, has_owned_process, stop, stop_on_exit,
+    terminate_stale_harness_processes,
 };
 pub use sweep::sweep_orphan_harness;

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -26,5 +26,7 @@ mod sweep;
 pub use health::proxy_health_check;
 pub use install::install;
 pub use launch::{launch, restart, start};
-pub use process::{has_owned_process, stop, stop_on_exit};
+pub use process::{
+    core_switch_guard, has_owned_process, stop, stop_on_exit, terminate_stale_harness_processes,
+};
 pub use sweep::sweep_orphan_harness;

--- a/src-tauri/src/service/workflow/process.rs
+++ b/src-tauri/src/service/workflow/process.rs
@@ -107,6 +107,35 @@ impl Drop for LaunchGuard {
     }
 }
 
+/// 核心切换守卫：切换（`dependencies/dsh` 版本目录互换）期间禁止 `launch`
+/// 拉起新的 Harness 进程。
+///
+/// 竞态根因：切换流程先 `stop` 停掉自有进程、再重命名互换目录，而 `stop` 会
+/// 把 `LAUNCH_GUARD` 复位；若此刻前端（启动重试/自动恢复）又发起 `launch`，
+/// 新进程会以 `dependencies/dsh` 为 cwd 并加载原生模块 DLL（如 sharp 的
+/// libvips-42.dll）进内存，目录被锁后互换重命名必然失败
+/// （CORE_SWITCH_FAILED, os error 32，重试 60 次/30 秒仍失败）。
+pub(crate) static CORE_SWITCH_GUARD: AtomicBool = AtomicBool::new(false);
+
+/// 进入核心切换临界区：置位守卫，返回的 RAII 守卫在切换结束时（drop）复位。
+pub fn core_switch_guard() -> CoreSwitchGuard {
+    CORE_SWITCH_GUARD.store(true, Ordering::SeqCst);
+    CoreSwitchGuard
+}
+
+/// 核心切换是否进行中（切换期间 `launch` 应等待/拒绝拉起新进程）。
+pub fn core_switch_in_progress() -> bool {
+    CORE_SWITCH_GUARD.load(Ordering::SeqCst)
+}
+
+pub struct CoreSwitchGuard;
+
+impl Drop for CoreSwitchGuard {
+    fn drop(&mut self) {
+        CORE_SWITCH_GUARD.store(false, Ordering::SeqCst);
+    }
+}
+
 /// 是否持有 Harness 进程。与其它访问器一致：锁被毒化（panic 残留）时取回
 /// 毒化守卫继续读取，而不是把「已登记进程」误报为「无」。
 pub fn has_owned_process() -> bool {
@@ -489,6 +518,18 @@ mod tests {
             without_code,
             serde_json::json!({ "pid": 43, "exitCode": null })
         );
+    }
+
+    /// 核心切换守卫：持有期间 `core_switch_in_progress` 为 true（launch 需等待/
+    /// 拒绝），drop 后立即复位，保证切换窗口不被泄漏到下一次启动。
+    #[test]
+    fn core_switch_guard_set_while_held_and_cleared_on_drop() {
+        assert!(!core_switch_in_progress());
+        {
+            let _guard = core_switch_guard();
+            assert!(core_switch_in_progress());
+        }
+        assert!(!core_switch_in_progress());
     }
 
     /// `ps -axo pid=,command=` 行解析：首列 PID，其余为命令行。

--- a/src-tauri/src/service/workflow/process.rs
+++ b/src-tauri/src/service/workflow/process.rs
@@ -118,12 +118,25 @@ fn core_transition_lock() -> &'static Arc<tokio::sync::Mutex<()>> {
     LOCK.get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
 }
 
-/// 获取核心目录操作互斥锁。
+/// 获取核心目录操作互斥锁，最长等待 15 秒。
 ///
 /// 调用方必须从获取锁开始，持续持有到目录切换完成或 Harness 进程登记完成；
-/// RAII guard 会在所有成功/失败路径自动释放。
-pub async fn acquire_core_transition() -> tokio::sync::OwnedMutexGuard<()> {
-    Arc::clone(core_transition_lock()).lock_owned().await
+/// RAII guard 会在所有成功/失败路径自动释放。超时必须失败返回，避免切换或启动
+/// 卡死后永久阻塞后续所有核心操作。
+pub async fn acquire_core_transition(
+) -> Result<tokio::sync::OwnedMutexGuard<()>, String> {
+    const CORE_TRANSITION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+    tokio::time::timeout(
+        CORE_TRANSITION_TIMEOUT,
+        Arc::clone(core_transition_lock()).lock_owned(),
+    )
+    .await
+    .map_err(|error| {
+        format!(
+            "CORE_TRANSITION_TIMEOUT: timed out after {} seconds waiting for core transition lock: {error}",
+            CORE_TRANSITION_TIMEOUT.as_secs()
+        )
+    })
 }
 
 /// 是否持有 Harness 进程。与其它访问器一致：锁被毒化（panic 残留）时取回
@@ -513,7 +526,9 @@ mod tests {
     /// 核心转换锁可被多个异步操作按顺序获取，避免两个切换重叠。
     #[tokio::test]
     async fn core_transition_lock_serializes_operations() {
-        let first = acquire_core_transition().await;
+        let first = acquire_core_transition()
+            .await
+            .expect("first transition lock should be acquired");
         let second = tokio::time::timeout(
             std::time::Duration::from_millis(20),
             acquire_core_transition(),
@@ -526,13 +541,16 @@ mod tests {
             acquire_core_transition()
         )
         .await
+        .expect("transition lock should be available after release")
         .is_ok());
     }
 
     /// 两个切换请求不能重叠：第一个释放转换锁后，第二个才可进入。
     #[tokio::test]
     async fn overlapping_switches_are_serialized() {
-        let first = acquire_core_transition().await;
+        let first = acquire_core_transition()
+            .await
+            .expect("first transition lock should be acquired");
         let (entered_tx, mut entered_rx) = tokio::sync::mpsc::channel(1);
         let waiter = tokio::spawn(async move {
             let _second = acquire_core_transition().await;
@@ -557,7 +575,9 @@ mod tests {
     /// 启动请求不能在切换持锁期间进入：切换完成后启动才可进入并完成登记阶段。
     #[tokio::test]
     async fn launch_and_switch_overlap_is_serialized() {
-        let switch_guard = acquire_core_transition().await;
+        let switch_guard = acquire_core_transition()
+            .await
+            .expect("switch transition lock should be acquired");
         let (entered_tx, mut entered_rx) = tokio::sync::mpsc::channel(1);
         let launcher = tokio::spawn(async move {
             let _launch_guard = acquire_core_transition().await;

--- a/src-tauri/src/service/workflow/process.rs
+++ b/src-tauri/src/service/workflow/process.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 #[cfg(windows)]
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
 use super::status;
@@ -107,33 +107,23 @@ impl Drop for LaunchGuard {
     }
 }
 
-/// 核心切换守卫：切换（`dependencies/dsh` 版本目录互换）期间禁止 `launch`
-/// 拉起新的 Harness 进程。
+/// 核心目录操作互斥锁：统一串行化「切换目录」与「启动并登记进程」两个临界区。
 ///
-/// 竞态根因：切换流程先 `stop` 停掉自有进程、再重命名互换目录，而 `stop` 会
-/// 把 `LAUNCH_GUARD` 复位；若此刻前端（启动重试/自动恢复）又发起 `launch`，
-/// 新进程会以 `dependencies/dsh` 为 cwd 并加载原生模块 DLL（如 sharp 的
-/// libvips-42.dll）进内存，目录被锁后互换重命名必然失败
-/// （CORE_SWITCH_FAILED, os error 32，重试 60 次/30 秒仍失败）。
-pub(crate) static CORE_SWITCH_GUARD: AtomicBool = AtomicBool::new(false);
-
-/// 进入核心切换临界区：置位守卫，返回的 RAII 守卫在切换结束时（drop）复位。
-pub fn core_switch_guard() -> CoreSwitchGuard {
-    CORE_SWITCH_GUARD.store(true, Ordering::SeqCst);
-    CoreSwitchGuard
+/// 不能只用一个布尔守卫：两个并发切换可能互相覆盖/清除状态，且 launch 在检查
+/// 守卫与登记进程之间仍存在窗口。使用同一把 Tokio mutex 后，切换从停服到目录
+/// 互换完成、launch 从最终状态检查到进程登记均保持互斥，避免 Harness 进程在
+/// `dependencies/dsh` 目录交换期间加载 DLL 并产生 Windows os error 32。
+fn core_transition_lock() -> &'static Arc<tokio::sync::Mutex<()>> {
+    static LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    LOCK.get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
 }
 
-/// 核心切换是否进行中（切换期间 `launch` 应等待/拒绝拉起新进程）。
-pub fn core_switch_in_progress() -> bool {
-    CORE_SWITCH_GUARD.load(Ordering::SeqCst)
-}
-
-pub struct CoreSwitchGuard;
-
-impl Drop for CoreSwitchGuard {
-    fn drop(&mut self) {
-        CORE_SWITCH_GUARD.store(false, Ordering::SeqCst);
-    }
+/// 获取核心目录操作互斥锁。
+///
+/// 调用方必须从获取锁开始，持续持有到目录切换完成或 Harness 进程登记完成；
+/// RAII guard 会在所有成功/失败路径自动释放。
+pub async fn acquire_core_transition() -> tokio::sync::OwnedMutexGuard<()> {
+    Arc::clone(core_transition_lock()).lock_owned().await
 }
 
 /// 是否持有 Harness 进程。与其它访问器一致：锁被毒化（panic 残留）时取回
@@ -520,16 +510,74 @@ mod tests {
         );
     }
 
-    /// 核心切换守卫：持有期间 `core_switch_in_progress` 为 true（launch 需等待/
-    /// 拒绝），drop 后立即复位，保证切换窗口不被泄漏到下一次启动。
-    #[test]
-    fn core_switch_guard_set_while_held_and_cleared_on_drop() {
-        assert!(!core_switch_in_progress());
-        {
-            let _guard = core_switch_guard();
-            assert!(core_switch_in_progress());
-        }
-        assert!(!core_switch_in_progress());
+    /// 核心转换锁可被多个异步操作按顺序获取，避免两个切换重叠。
+    #[tokio::test]
+    async fn core_transition_lock_serializes_operations() {
+        let first = acquire_core_transition().await;
+        let second = tokio::time::timeout(
+            std::time::Duration::from_millis(20),
+            acquire_core_transition(),
+        )
+        .await;
+        assert!(second.is_err());
+        drop(first);
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            acquire_core_transition()
+        )
+        .await
+        .is_ok());
+    }
+
+    /// 两个切换请求不能重叠：第一个释放转换锁后，第二个才可进入。
+    #[tokio::test]
+    async fn overlapping_switches_are_serialized() {
+        let first = acquire_core_transition().await;
+        let (entered_tx, mut entered_rx) = tokio::sync::mpsc::channel(1);
+        let waiter = tokio::spawn(async move {
+            let _second = acquire_core_transition().await;
+            entered_tx
+                .send(())
+                .await
+                .expect("notify second switch entry");
+        });
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), entered_rx.recv())
+                .await
+                .is_err()
+        );
+        drop(first);
+        tokio::time::timeout(std::time::Duration::from_millis(100), waiter)
+            .await
+            .expect("second switch should enter after first releases")
+            .expect("second switch task should complete");
+    }
+
+    /// 启动请求不能在切换持锁期间进入：切换完成后启动才可进入并完成登记阶段。
+    #[tokio::test]
+    async fn launch_and_switch_overlap_is_serialized() {
+        let switch_guard = acquire_core_transition().await;
+        let (entered_tx, mut entered_rx) = tokio::sync::mpsc::channel(1);
+        let launcher = tokio::spawn(async move {
+            let _launch_guard = acquire_core_transition().await;
+            // 模拟启动完成进程登记后才释放转换锁。
+            entered_tx
+                .send(())
+                .await
+                .expect("notify launch registration");
+        });
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), entered_rx.recv())
+                .await
+                .is_err()
+        );
+        drop(switch_guard);
+        tokio::time::timeout(std::time::Duration::from_millis(100), launcher)
+            .await
+            .expect("launch should enter after switch releases")
+            .expect("launch task should complete");
     }
 
     /// `ps -axo pid=,command=` 行解析：首列 PID，其余为命令行。


### PR DESCRIPTION
## 问题

切换预打包核心时，流程会先停止当前 Harness，再把 dependencies/dsh 与历史版本槽位互换。停止后 LAUNCH_GUARD 被复位，启动重试/自动恢复可能在目录互换完成前重新拉起 Harness；新进程加载原生 DLL 后锁住 dependencies/dsh，最终连续 60 次重命名失败并报 CORE_SWITCH_FAILED / Windows os error 32。

同一类孤儿进程还会占用旧端口，导致刷新后端口从默认的 3080 漂移到 3085。

## 修复

- 增加核心切换临界区守卫：切换期间并发 launch 等待切换完成（最多 15 秒），避免重新拉起进程锁目录；超时返回明确错误。
- 切换前停止自有进程后，按精确命令行路径清扫所有残留 Harness 进程，释放 DLL 文件句柄。
- launch 在获取唯一启动守卫后清扫残留进程，避免页面刷新时孤儿进程继续占用端口；清扫后已有端口自愈逻辑会把漂移端口恢复到默认端口（例如 3080）。
- debug 构建沿用现有行为：路径清扫为 no-op，避免开发版误杀共用目录中的 release 服务。
- 新增核心切换守卫单元测试。

## 验证

- cargo check 通过
- cargo test 通过（全部测试）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved core version switching reliability by preventing overlapping switches and launches.
  * Launches now coordinate safely with active core transitions and report transition failures clearly.
  * Added a timeout when waiting for an ongoing transition, preventing launches or switches from waiting indefinitely.
  * Automatically cleans up stale background processes before switching or launching.
  * Improved warning messages with the active directory path to make process and transition issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->