### PR TITLE
fix(plugin): avoid zod release-age false positives

### DIFF
--- a/src-tauri/src/service/plugin/install/mod.rs
+++ b/src-tauri/src/service/plugin/install/mod.rs
@@ -54,6 +54,7 @@ pub(crate) use super::process::{
 };
 pub(crate) use super::recovery::is_actionable_plugin_ref;
 pub(crate) use super::uninstall_recovery;
+pub(crate) use crate::service::profile::ensure_profile_pnpm_policy;
 
 mod allowlist;
 mod artifact;
@@ -163,6 +164,9 @@ async fn install_with_cancel(
     // 首次安装可能早于服务启动；提前写入非交互清理配置，避免 pnpm 在无 TTY
     // 环境以 ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY 中止（issue #130）。
     super::ensure_profile_npmrc(app_handle)?;
+    // 旧档案可能由早期版本创建，没有同步 Harness 的最小发布时间例外；补齐
+    // 精确的已审查 zod 版本，避免 registry 元数据瞬时失败阻断插件安装（issue #222）。
+    super::ensure_profile_pnpm_policy(app_handle)?;
 
     // 安装前停止运行中的服务，避免资源冲突
     if workflow::has_owned_process() {

--- a/src-tauri/src/service/plugin/install/single.rs
+++ b/src-tauri/src/service/plugin/install/single.rs
@@ -171,6 +171,9 @@ async fn run_single_plugin_command(
     let prefer_bundled_pnpm = ensure_pnpm(app_handle, &window, owner).await?;
     // `.npmrc` 可能在服务启动后被删除；升级/卸载同样可能触发 pnpm 非交互清理。
     super::ensure_profile_npmrc(app_handle)?;
+    // 与批量安装保持一致：旧档案也必须具备精确的 release-age 例外，
+    // 否则升级/卸载触发 pnpm lockfile 校验时同样会被 issue #222 的问题阻断。
+    super::ensure_profile_pnpm_policy(app_handle)?;
 
     // 插件操作会改写 profile，先停止运行中的服务（与安装一致）
     if workflow::has_owned_process() {
@@ -287,7 +290,11 @@ mod tests {
 
         // 命中：登记且已安装 → 返回实际安装包名（dsh-ok 未声明 package，回落 id）
         assert_eq!(
-            deprecated_installed_names(&[preset("dsh-ok", "dshmarket", false)], &deprecated, installed),
+            deprecated_installed_names(
+                &[preset("dsh-ok", "dshmarket", false)],
+                &deprecated,
+                installed
+            ),
             vec!["dsh-ok".to_string()]
         );
 
@@ -310,8 +317,11 @@ mod tests {
         // 内部插件即使登记弃用也不命中（内部插件由启动自愈强制安装）
         let internal = preset("dsh-internal", "dsh-tauri@0.2.0", true);
         assert!(
-            deprecated_installed_names(&[internal], &deprecated, |name| matches!(name, "dsh-internal"))
-                .is_empty()
+            deprecated_installed_names(&[internal], &deprecated, |name| matches!(
+                name,
+                "dsh-internal"
+            ))
+            .is_empty()
         );
     }
 }

--- a/src-tauri/src/service/plugin/mod.rs
+++ b/src-tauri/src/service/plugin/mod.rs
@@ -39,6 +39,7 @@ pub mod update;
 pub mod verify;
 pub mod watch;
 
+pub(crate) use crate::service::profile::ensure_profile_pnpm_policy;
 pub use cancel::cancel;
 pub(crate) use install::harness_prefer_bundled_pnpm;
 pub(crate) use install::uninstall_deprecated_plugins;

--- a/src-tauri/src/service/profile/mod.rs
+++ b/src-tauri/src/service/profile/mod.rs
@@ -12,6 +12,7 @@
 use crate::config;
 use crate::service::fs_guard;
 use serde::Serialize;
+use serde_yaml::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tauri::AppHandle;
@@ -29,7 +30,7 @@ const PROFILE_PATCH_TEMPLATE: &str = "# Your patch layer for this dsh profile, a
 
 /// dsh `initProfile` 生成的 pnpm 设置（与官方一致）
 const PROFILE_PNPM_WORKSPACE: &str =
-    "packages:\n  - .\n\nnodeLinker: hoisted\nautoInstallPeers: false\n";
+    "packages:\n  - .\n\nnodeLinker: hoisted\nautoInstallPeers: false\n\n# The desktop runtime intentionally reviews this fresh transitive release.\nminimumReleaseAgeExclude:\n  - zod@4.4.3\n";
 
 /// 档案行（序列化 camelCase 给前端）
 #[derive(Debug, Clone, Serialize)]
@@ -50,6 +51,57 @@ pub fn profile_dir_of(app_handle: &AppHandle, id: &str) -> PathBuf {
     config::get_dsh_data_path(app_handle)
         .join("profiles")
         .join(id)
+}
+
+/// pnpm 11 的最小发布时间策略会在 registry 元数据短暂不可用时把已审查的
+/// lockfile 条目误判为违规。zod 是当前 Harness runtime closure 中的已审查条目，
+/// 仅豁免 lockfile 使用的精确版本，避免关闭整个 supply-chain policy。
+const PROFILE_MINIMUM_RELEASE_AGE_EXCLUDES: [&str; 1] = ["zod@4.4.3"];
+
+/// 确保现有档案也获得与新建档案相同的 pnpm 供应链策略例外。
+/// 使用 YAML 合并而不是文本追加，避免重复映射键破坏 pnpm-workspace.yaml。
+pub(crate) fn ensure_profile_pnpm_policy(app_handle: &AppHandle) -> Result<(), String> {
+    let path = profile_dir_of(app_handle, &active_profile(app_handle)).join("pnpm-workspace.yaml");
+    let existing = match fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            PROFILE_PNPM_WORKSPACE.to_string()
+        }
+        Err(error) => return Err(format!("PROFILE_WORKSPACE_READ: {error}")),
+    };
+    let mut document: Value = serde_yaml::from_str(&existing)
+        .map_err(|e| format!("PROFILE_WORKSPACE_INVALID_YAML: {e}"))?;
+    let mapping = document.as_mapping_mut().ok_or_else(|| {
+        "PROFILE_WORKSPACE_NOT_MAP: pnpm-workspace.yaml must be a mapping".to_string()
+    })?;
+    let key = Value::String("minimumReleaseAgeExclude".to_string());
+    let excludes = mapping
+        .entry(key)
+        .or_insert_with(|| Value::Sequence(Vec::new()));
+    let sequence = excludes.as_sequence_mut().ok_or_else(|| {
+        "PROFILE_WORKSPACE_POLICY_INVALID: minimumReleaseAgeExclude must be a sequence".to_string()
+    })?;
+    let mut changed = false;
+    for package in PROFILE_MINIMUM_RELEASE_AGE_EXCLUDES {
+        let value = Value::String(package.to_string());
+        if !sequence.iter().any(|item| item == &value) {
+            sequence.push(value);
+            changed = true;
+        }
+    }
+    if changed {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("PROFILE_WORKSPACE_MKDIR: {e}"))?;
+        }
+        let rendered = serde_yaml::to_string(&document)
+            .map_err(|e| format!("PROFILE_WORKSPACE_RENDER: {e}"))?;
+        fs::write(&path, rendered).map_err(|e| format!("PROFILE_WORKSPACE_WRITE: {e}"))?;
+        log::info!(
+            "Ensured profile pnpm release-age policy: {}",
+            path.display()
+        );
+    }
+    Ok(())
 }
 
 /// 当前使用的档案 id。


### PR DESCRIPTION
## Summary\n- exempt the reviewed zod@4.4.3 runtime entry from pnpm minimumReleaseAge checks\n- apply the policy to both new and existing profiles before plugin operations\n- merge YAML structurally to preserve existing workspace configuration\n\n## Issue\nFixes #222\n\n## Validation\n- cargo fmt --check\n- cargo check\n- focused profile initialization and plugin diagnostic tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when launching or switching core versions by preventing conflicting operations.
  * Automatically cleans up stale background processes before launches and version switches.
  * Reports cleanup failures clearly when a core switch cannot stop an existing process.

* **Plugin Management**
  * Ensures plugin profiles include the required package security policy, including for existing profiles.
  * Applies the policy consistently during plugin installation, updates, and removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->