### PR TITLE
fix(runtime): align Node support with DSH alpha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ export function FooComponent(props: FooProps) {
    - Broadcast `WM_SETTINGCHANGE` after writing PATH; tell users to reopen terminals.
 5. **CLI shim (`service/cli`)**:
    - Scripts at Win `%LOCALAPPDATA%\deepseek-harness\bin`, Unix `~/.local/bin`.
-   - Prefer local Node (v22.15+ / v23.8+ / v24+), fallback to bundled Node; mind escaping (`%`→`%%`, `'`→`'\''`).
+   - Prefer local Node (v22.19+ / v24+; v23 unsupported), fallback to bundled Node; mind escaping (`%`→`%%`, `'`→`'\''`).
    - Shim text must be English-only (cmd/ps1 parse by code page, Chinese breaks).
    - pnpm shim: forward user-installed pnpm first, else bundled node `dependencies/pnpm/bin/pnpm.cjs`.
    - Install skips when bundled installed **or** user pnpm on PATH (`Pnpm::check_installed`).

--- a/docs/testing/01-install/03-本机Node与Pnpm复用.md
+++ b/docs/testing/01-install/03-本机Node与Pnpm复用.md
@@ -12,9 +12,9 @@
 
 ## [P2] 验证本机 Node 版本过期时回退内置 Node
 [测试类型] 兼容性
-[前置条件] 本机 PATH 中存在 node v22.14.0（低于 v22.15.0 下限）；捆绑 `runtime\node.exe` 已是 v22.22.0；网络可达
-[测试步骤] 1. 在本机安装 Node v22.14.0 并加入 PATH，确认 `node --version` 输出 v22.14.0。2. 确保 `%APPDATA%\io.github.hairyf.deepseek-harness-desktop\runtime\node.exe` 位于 v22.22.0。3. 启动安装，观察 Node 任务是否走捆绑运行时（is_runtime_compatible 判定）与安装结果
-[预期结果] 1. 本机 v22.14.0 不满足 v22.15.0 门槛，get_local_node_path 返回 None，不使用本机 node。2. 捆绑 `runtime\node.exe`（v22.22.0）被复用，Node 任务 check_installed 通过兼容判定、不重新下载。3. get_active_node_version 返回 22.22.0，安装成功并进入 Running
+[前置条件] 本机 PATH 中存在 node v22.18.0（低于 v22.19.0 下限）；捆绑 `runtime\node.exe` 已是 v22.22.0；网络可达
+[测试步骤] 1. 在本机安装 Node v22.18.0 并加入 PATH，确认 `node --version` 输出 v22.18.0。2. 确保 `%APPDATA%\io.github.hairyf.deepseek-harness-desktop\runtime\node.exe` 位于 v22.22.0。3. 启动安装，观察 Node 任务是否走捆绑运行时（is_runtime_compatible 判定）与安装结果
+[预期结果] 1. 本机 v22.18.0 不满足 v22.19.0 门槛，get_local_node_path 返回 None，不使用本机 node；Node 23 同样不受支持。2. 捆绑 `runtime\node.exe`（v22.22.0）被复用，Node 任务 check_installed 通过兼容判定、不重新下载。3. get_active_node_version 返回 22.22.0，安装成功并进入 Running
 
 ## [P2] 验证本机已有 pnpm 时优先用用户 pnpm
 [测试类型] 兼容性

--- a/docs/testing/07-cli/02-PATH注册与shim.md
+++ b/docs/testing/07-cli/02-PATH注册与shim.md
@@ -13,8 +13,8 @@
 ## [P2] 验证shim优先使用本机兼容Node并在不兼容时回退内置Node
 [测试类型] 功能
 [前置条件] release 构建；本机 PATH 前置 Node v22.22.0；内置 Node 已随应用安装至运行时目录；`cli_link_enabled` 为 true
-[测试步骤] 1. 在 PATH 前置本机 Node 目录后新开终端执行 `dsh --version`。2. 将本机 Node 切换为不兼容版本 v21.7.0（PATH 中仅有 v21.7.0）后新开终端执行 `dsh --version`。
-[预期结果] 1. shim 解析到本机 `node`（v22.22.0 满足 v22.15+ 条件），`dsh --version` 输出版本号、退出码为 0。2. 本机 Node v21.7.0 不满足兼容条件，shim 回退使用内置 `%APP_DIR%\runtime\node.exe`，`dsh --version` 仍输出版本号、退出码为 0。
+[测试步骤] 1. 在 PATH 前置本机 Node v22.22.0 目录后新开终端执行 `dsh --version`。2. 将 PATH 中的本机 Node 切换为 v22.18.0 后新开终端执行 `dsh --version`。3. 再切换为 v23.11.1 后重复执行。
+[预期结果] 1. shim 解析到本机 `node`（v22.22.0 满足 v22.19+ 条件），`dsh --version` 输出版本号、退出码为 0。2. 本机 Node v22.18.0 和 v23.11.1 均不满足兼容条件，两次都回退使用内置 `%APP_DIR%\runtime\node.exe`，`dsh --version` 仍输出版本号、退出码为 0。
 
 ## [P2] 验证用户已安装pnpm时pnpm shim优先转发用户pnpm
 [测试类型] 功能

--- a/docs/testing/all_cases.md
+++ b/docs/testing/all_cases.md
@@ -100,9 +100,9 @@
 
 ## [P2] 验证本机 Node 版本过期时回退内置 Node
 [测试类型] 兼容性
-[前置条件] 本机 PATH 中存在 node v22.14.0（低于 v22.15.0 下限）；捆绑 `runtime\node.exe` 已是 v22.22.0；网络可达
-[测试步骤] 1. 在本机安装 Node v22.14.0 并加入 PATH，确认 `node --version` 输出 v22.14.0。2. 确保 `%APPDATA%\io.github.hairyf.deepseek-harness-desktop\runtime\node.exe` 位于 v22.22.0。3. 启动安装，观察 Node 任务是否走捆绑运行时（is_runtime_compatible 判定）与安装结果
-[预期结果] 1. 本机 v22.14.0 不满足 v22.15.0 门槛，get_local_node_path 返回 None，不使用本机 node。2. 捆绑 `runtime\node.exe`（v22.22.0）被复用，Node 任务 check_installed 通过兼容判定、不重新下载。3. get_active_node_version 返回 22.22.0，安装成功并进入 Running
+[前置条件] 本机 PATH 中存在 node v22.18.0（低于 v22.19.0 下限）；捆绑 `runtime\node.exe` 已是 v22.22.0；网络可达
+[测试步骤] 1. 在本机安装 Node v22.18.0 并加入 PATH，确认 `node --version` 输出 v22.18.0。2. 确保 `%APPDATA%\io.github.hairyf.deepseek-harness-desktop\runtime\node.exe` 位于 v22.22.0。3. 启动安装，观察 Node 任务是否走捆绑运行时（is_runtime_compatible 判定）与安装结果
+[预期结果] 1. 本机 v22.18.0 不满足 v22.19.0 门槛，get_local_node_path 返回 None，不使用本机 node；Node 23 同样不受支持。2. 捆绑 `runtime\node.exe`（v22.22.0）被复用，Node 任务 check_installed 通过兼容判定、不重新下载。3. get_active_node_version 返回 22.22.0，安装成功并进入 Running
 
 ## [P2] 验证本机已有 pnpm 时优先用用户 pnpm
 [测试类型] 兼容性
@@ -1019,8 +1019,8 @@
 ## [P2] 验证shim优先使用本机兼容Node并在不兼容时回退内置Node
 [测试类型] 功能
 [前置条件] release 构建；本机 PATH 前置 Node v22.22.0；内置 Node 已随应用安装至运行时目录；`cli_link_enabled` 为 true
-[测试步骤] 1. 在 PATH 前置本机 Node 目录后新开终端执行 `dsh --version`。2. 将本机 Node 切换为不兼容版本 v21.7.0（PATH 中仅有 v21.7.0）后新开终端执行 `dsh --version`。
-[预期结果] 1. shim 解析到本机 `node`（v22.22.0 满足 v22.15+ 条件），`dsh --version` 输出版本号、退出码为 0。2. 本机 Node v21.7.0 不满足兼容条件，shim 回退使用内置 `%APP_DIR%\runtime\node.exe`，`dsh --version` 仍输出版本号、退出码为 0。
+[测试步骤] 1. 在 PATH 前置本机 Node v22.22.0 目录后新开终端执行 `dsh --version`。2. 将 PATH 中的本机 Node 切换为 v22.18.0 后新开终端执行 `dsh --version`。3. 再切换为 v23.11.1 后重复执行。
+[预期结果] 1. shim 解析到本机 `node`（v22.22.0 满足 v22.19+ 条件），`dsh --version` 输出版本号、退出码为 0。2. 本机 Node v22.18.0 和 v23.11.1 均不满足兼容条件，两次都回退使用内置 `%APP_DIR%\runtime\node.exe`，`dsh --version` 仍输出版本号、退出码为 0。
 
 ## [P2] 验证用户已安装pnpm时pnpm shim优先转发用户pnpm
 [测试类型] 功能
@@ -1280,5 +1280,3 @@
 [前置条件] 分别具备 Windows 与 macOS/Linux 环境；Windows 已安装插件与 Git Bash；$DSH_HOME 为 ~/.dsh
 [测试步骤] 1. 在 macOS/Linux 环境调用 win_inspector::apply（非 Windows 分支）。2. 在 Windows 环境连续两次调用 win_inspector::apply。3. 检查 cordis.patch.yml 与 minimal-win preset 目录
 [预期结果] 1. 非 Windows 平台 apply 返回 Ok 且无任何副作用，不创建 cordis.patch.yml 挂载行、不生成 ~/.dsh/.agent-presets/minimal-win/。2. 第二次调用不重复追加，cordis.patch.yml 中 dsh-win-terminal-inspector 挂载块仍仅出现一次、内容不变。3. ~/.dsh/.agent-presets/minimal-win/agent.cordis.yml 与 preset.yml 保持首次生成内容，未被覆盖或重写
-
-

--- a/src-tauri/src/config/constants.rs
+++ b/src-tauri/src/config/constants.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-/// 捆绑的 Node.js 运行时版本（满足 v22.15.0+ / v23.8.0+ 的要求）
+/// 捆绑的 Node.js 运行时版本（满足当前 DSH 的 v22.19.0+ 或 v24+ 要求）
 pub const NODE_VERSION: &str = "v22.22.0";
 
 /// Node.js 官方下载地址

--- a/src-tauri/src/config/i18n.rs
+++ b/src-tauri/src/config/i18n.rs
@@ -43,8 +43,8 @@ pub fn t(key: &str) -> String {
             "Node.js runtime not found, run setup first",
         ),
         "runtime.incompatible" => (
-            "Node.js 运行时版本过低，需要 v22.15.0+ 或 v23.8.0+",
-            "Node.js runtime is too old, need v22.15.0+ or v23.8.0+",
+            "Node.js 运行时不兼容，需要 Node 22.19+（仅 22.x）或 Node 24+",
+            "Node.js runtime is incompatible; need Node 22.19+ (22.x only) or Node 24+",
         ),
         "harness.title" => ("DeepSeek Harness 核心", "DeepSeek Harness core"),
         "harness.core_not_found" => (

--- a/src-tauri/src/config/runtime.rs
+++ b/src-tauri/src/config/runtime.rs
@@ -468,14 +468,13 @@ fn parse_node_version(output: &str) -> Option<(u64, u64, u64)> {
     Some((major, minor, patch))
 }
 
-/// 兼容性规则：v22.15.0+ 或 v23.8.0+（v24+ 也满足）
+/// 兼容性规则与当前 DSH `engines.node` 一致：v22.19.0+ 或 v24+；v23 不受支持。
 fn is_supported_node_version(version: &str) -> bool {
     let Some((major, minor, _patch)) = parse_node_version(version) else {
         return false;
     };
     match major {
-        22 => minor >= 15,
-        23 => minor >= 8,
+        22 => minor >= 19,
         major if major >= 24 => true,
         _ => false,
     }
@@ -596,6 +595,17 @@ mod tests {
     fn node_base_url_switches_on_region() {
         assert_eq!(node_base_url(Region::Overseas), NODE_BASE_URL);
         assert_eq!(node_base_url(Region::Domestic), NODE_MIRROR_BASE_URL);
+    }
+
+    /// 当前 DSH 明确支持 22.19+ 与 24+，不支持 22.18 及整个 Node 23 系列。
+    #[test]
+    fn node_runtime_boundary_matches_current_dsh_engine() {
+        assert!(!is_supported_node_version("v22.18.0"));
+        assert!(is_supported_node_version("v22.19.0"));
+        assert!(!is_supported_node_version("v22.19.0-rc.1"));
+        assert!(!is_supported_node_version("v23.99.0"));
+        assert!(is_supported_node_version("v24.0.0"));
+        assert!(!is_supported_node_version("v24.0.0-nightly.1"));
     }
 
     #[test]

--- a/src-tauri/src/service/cli/shim/build.rs
+++ b/src-tauri/src/service/cli/shim/build.rs
@@ -740,6 +740,78 @@ mod tests {
         }
     }
 
+    /// 三种 shim 的版本门槛必须与应用预检及当前 DSH engines 保持一致。
+    #[test]
+    fn generated_shims_match_current_dsh_node_engine() {
+        let cmd = build_cmd_shim(&sample_app_dir(), &sample_dsh_home());
+        let ps1 = build_ps1_shim(&sample_app_dir(), &sample_dsh_home());
+
+        assert!(cmd.contains(r#"findstr /r /x "v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*""#));
+        assert!(cmd.contains("EQU 22 if defined NODE_MINOR if %NODE_MINOR% GEQ 19"));
+        assert!(!cmd.contains("NODE_MAJOR% EQU 23"));
+        assert!(ps1.contains(r#"-match '^v(\d+)\.(\d+)\.(\d+)$'"#));
+        assert!(ps1.contains("$major -eq 22 -and $minor -ge 19"));
+        assert!(!ps1.contains("$major -eq 23"));
+        assert!(SH_NODE_RESOLVE.contains(r#"awk '/^v[0-9]+\.[0-9]+\.[0-9]+$/"#));
+        assert!(SH_NODE_RESOLVE.contains("$MAJOR\" -eq 22 ] && [ \"$MINOR\" -ge 19"));
+        assert!(!SH_NODE_RESOLVE.contains("$MAJOR\" -eq 23"));
+    }
+
+    /// cmd shim 不得把 Node 预发布版本误判为满足稳定版 engines 范围。
+    #[cfg(windows)]
+    #[test]
+    fn cmd_shim_rejects_prerelease_node_and_accepts_stable_boundaries() {
+        let dir = temp_dir("node-version-boundary");
+        let app_dir = dir.join("app");
+        let pnpm_bin = app_dir.join("dependencies/pnpm/bin/pnpm.cjs");
+        std::fs::create_dir_all(pnpm_bin.parent().unwrap()).unwrap();
+        std::fs::write(&pnpm_bin, "fixture").unwrap();
+        let shim = dir.join("pnpm.cmd");
+        std::fs::write(&shim, build_pnpm_cmd_shim(&app_dir)).unwrap();
+        let node_dir = dir.join("local-node");
+        std::fs::create_dir_all(&node_dir).unwrap();
+        let node = node_dir.join("node.cmd");
+        let system_root = std::env::var_os("SystemRoot").unwrap_or_else(|| "C:\\Windows".into());
+        let system32 = PathBuf::from(&system_root).join("System32");
+        let path = std::env::join_paths([&node_dir, &system32]).unwrap();
+
+        for (version, accepted) in [
+            ("v22.19.0", true),
+            ("v22.19.0-rc.1", false),
+            ("v23.11.1", false),
+            ("v24.0.0", true),
+            ("v24.0.0-nightly.1", false),
+        ] {
+            std::fs::write(
+                &node,
+                format!(
+                    "@echo off\r\nif \"%~1\"==\"--version\" (\r\n  echo {version}\r\n  exit /b 0\r\n)\r\necho LOCAL_NODE_LAUNCHED\r\nexit /b 0\r\n"
+                ),
+            )
+            .unwrap();
+            let output = std::process::Command::new(system32.join("cmd.exe"))
+                .args(["/d", "/c"])
+                .arg(&shim)
+                .arg("--version")
+                .env("PATH", &path)
+                .env("SystemRoot", &system_root)
+                .env_remove("DSH_NODE")
+                .env("DSH_PREFER_BUNDLED_PNPM", "1")
+                .output()
+                .unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert_eq!(
+                output.status.success(),
+                accepted,
+                "version {version}, stdout: {stdout:?}, stderr: {:?}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(stdout.contains("LOCAL_NODE_LAUNCHED"), accepted);
+        }
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     #[cfg(windows)]
     #[test]
     fn ps1_shim_escapes_quotes() {

--- a/src-tauri/src/service/cli/shim/templates.rs
+++ b/src-tauri/src/service/cli/shim/templates.rs
@@ -8,8 +8,8 @@
 // shim 共享片段：node 解析逻辑（dsh / pnpm shim 共用）
 //
 // 规则：优先 `DSH_NODE` 环境变量（桌面端注入其已解析并核验过的 node 路径，
-// 保证 shim 与应用预检一致），其次 PATH 中版本兼容的本地 node（v22.15+ /
-// v23.8+ / v24+，与 config::is_supported_node_version 一致），否则回退捆绑
+// 保证 shim 与应用预检一致），其次 PATH 中版本兼容的本地 node（v22.19+ /
+// v24+，与 config::is_supported_node_version 一致），否则回退捆绑
 // 运行时。`DSH_NODE` 只在桌面端自身派生的子进程里存在，终端用户环境不受影响。
 // ---------------------------------------------------------------------------
 
@@ -31,11 +31,13 @@ if exist "%NODE%" goto :launch
 :skip_dsh_node
 where node >nul 2>nul
 if errorlevel 1 goto :use_bundled
-for /f "tokens=1,2 delims=v." %%a in ('node --version 2^>nul ^| findstr /b "v"') do set "NODE_MAJOR=%%a" & set "NODE_MINOR=%%b"
+set "NODE_VERSION="
+for /f "delims=" %%v in ('node --version 2^>nul ^| findstr /r /x "v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"') do set "NODE_VERSION=%%v"
+if not defined NODE_VERSION goto :use_bundled
+for /f "tokens=1,2 delims=v." %%a in ("%NODE_VERSION%") do set "NODE_MAJOR=%%a" & set "NODE_MINOR=%%b"
 if not defined NODE_MAJOR goto :use_bundled
 if %NODE_MAJOR% GEQ 24 goto :node_ok
-if %NODE_MAJOR% EQU 22 if defined NODE_MINOR if %NODE_MINOR% GEQ 15 goto :node_ok
-if %NODE_MAJOR% EQU 23 if defined NODE_MINOR if %NODE_MINOR% GEQ 8 goto :node_ok
+if %NODE_MAJOR% EQU 22 if defined NODE_MINOR if %NODE_MINOR% GEQ 19 goto :node_ok
 goto :use_bundled
 
 :node_ok
@@ -69,10 +71,10 @@ if (-not $node) {
     if ($localNode) {
         try {
             $version = & node --version 2>$null
-            if ($version -match '^v(\d+)\.(\d+)') {
+            if ($version -match '^v(\d+)\.(\d+)\.(\d+)$') {
                 $major = [int]$matches[1]
                 $minor = [int]$matches[2]
-                if (($major -eq 22 -and $minor -ge 15) -or ($major -eq 23 -and $minor -ge 8) -or $major -ge 24) {
+                if (($major -eq 22 -and $minor -ge 19) -or $major -ge 24) {
                     $node = 'node'
                 }
             }
@@ -102,12 +104,13 @@ if [ -n "$DSH_NODE" ] && [ -x "$DSH_NODE" ]; then
 fi
 if [ -z "$NODE" ] && command -v node >/dev/null 2>&1; then
   NODE_V=$(node --version 2>/dev/null)
-  MAJOR=$(printf '%s' "$NODE_V" | awk -F. '{ gsub(/^v/, "", $1); print $1 }')
-  MINOR=$(printf '%s' "$NODE_V" | awk -F. '{ print $2 }')
-  if { [ -n "$MAJOR" ] && [ "$MAJOR" -ge 24 ]; } 2>/dev/null || \
-     { [ "$MAJOR" -eq 22 ] && [ "$MINOR" -ge 15 ]; } 2>/dev/null || \
-     { [ "$MAJOR" -eq 23 ] && [ "$MINOR" -ge 8 ]; } 2>/dev/null; then
-    NODE="node"
+  if printf '%s\n' "$NODE_V" | awk '/^v[0-9]+\.[0-9]+\.[0-9]+$/ { exit 0 } { exit 1 }'; then
+    MAJOR=$(printf '%s' "$NODE_V" | awk -F. '{ gsub(/^v/, "", $1); print $1 }')
+    MINOR=$(printf '%s' "$NODE_V" | awk -F. '{ print $2 }')
+    if { [ -n "$MAJOR" ] && [ "$MAJOR" -ge 24 ]; } 2>/dev/null || \
+       { [ "$MAJOR" -eq 22 ] && [ "$MINOR" -ge 19 ]; } 2>/dev/null; then
+      NODE="node"
+    fi
   fi
 fi
 if [ -z "$NODE" ]; then


### PR DESCRIPTION
## Summary

Align Desktop's local Node selection and generated command shims with official DeepSeek Harness `dsh-v0.1.2-alpha.1`, whose root engine is `^22.19.0 || >=24.0.0`.

Before this change, Desktop accepted Node 22.15-22.18 and Node 23.8+, even though the current Harness refuses them. The Rust preflight and terminal shims could also disagree for prerelease/nightly builds: Rust rejected them while CMD, PowerShell, and POSIX sh accepted them from only the major/minor fields.

## Changes

- accept stable Node 22.19+ within the 22.x line, or stable Node 24+
- reject Node 22.18 and older, all Node 23 releases, and prerelease/nightly version strings
- keep Rust preflight, CMD, PowerShell, and POSIX sh predicates in sync
- add exact engine-boundary assertions and a real Windows shim execution matrix
- update runtime messages and manual compatibility cases to exercise 22.18 and Node 23 fallback

The bundled Node 22.22 runtime remains supported and unchanged.

Upstream engine source: https://github.com/deepseek-ai/deepseek-harness/blob/cd5ef8148158c3a752a658978873241fdf8e2bbc/package.json#L8-L10

## Verification

- `cargo fmt -- --check`
- `cargo check`
- `cargo test` — 352 passed
- executable Windows CMD shim matrix:
  - accepts `v22.19.0`, `v24.0.0`
  - rejects `v22.19.0-rc.1`, `v23.11.1`, `v24.0.0-nightly.1`
- independent exact-diff review, including PowerShell and POSIX sh parity — no remaining findings
- `git diff --check`

This PR is intentionally limited to runtime compatibility; the separate alpha authentication concern remains tracked in #230.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated supported local Node.js versions to 22.19+ or 24+.
  * Node.js 23 is now explicitly unsupported.
  * Improved version validation for command-line shims, including prerelease handling.
  * Incompatible Node.js versions now correctly fall back to the bundled runtime.

* **Documentation**
  * Updated compatibility guidance and testing scenarios for the revised Node.js requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->