### PR TITLE
chore: release v0.9.5-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.9.5-beta.1",
+  "version": "0.9.5-beta.2",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.9.5-beta.1"
+version = "0.9.5-beta.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.9.5-beta.1"
+version = "0.9.5-beta.2"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.9.5-beta.1",
+  "version": "0.9.5-beta.2",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.9.5-beta.2` (`0.9.5-beta.1` → `0.9.5-beta.2`).

### Features

- enforce recommended dsh version (#232) (e6b736b)
- **core**: new manual refresh function for core list added (2aec8bc)

### Bug Fixes

- **runtime**: align Node support with DSH alpha (#231) (f5e9d1e)
- **recovery**: retain official leaf refs during extraction (#215) (f4eb452)
- **client-hmr**: fix the sensitivity of upstream repair process detection to indentation (2e37822)

### Other Changes

- Handle alpha boot bundle URLs (e6d8575)
- Add alpha embedded authentication patch (c8077b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.9.5-beta.2.
  * Updated the application version across its distribution components for consistent release identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->