### PR TITLE
fix(download): install recommended dsh release

### DIFF
--- a/src-tauri/src/bridge/lifecycle.rs
+++ b/src-tauri/src/bridge/lifecycle.rs
@@ -116,7 +116,14 @@ pub async fn install_dependencies(app_handle: AppHandle) -> Result<bool, String>
         return Ok(false);
     }
 
-    let dsh_latest = download::fetch_latest_dsh_pkg_info().await;
+    // 安装目标遵循应用资源中的推荐版本，而不是 GitHub 的 latest。
+    // latest 可能是 alpha/beta 等超出推荐范围的预览版；并且 `/releases/latest`
+    // 不保证与推荐版本的摘要属于同一 release。按推荐 SemVer 反查固定 tag，后续
+    // 资产 URL 与 digest 都从该 tag 获取。
+    let dsh_latest = match config::recommended_dsh_version(&app_handle) {
+        Some(version) => download::fetch_dsh_pkg_version(&version).await,
+        None => download::fetch_latest_dsh_pkg_info().await,
+    };
 
     // 已安装文件在盘时，用 resolve_update 甄别「记录滞后」与「真更新」：
     // 记录滞后（HealUpToDate）只修正 store 记录、绝不整包重下。否则会把一个

--- a/src-tauri/src/bridge/lifecycle.rs
+++ b/src-tauri/src/bridge/lifecycle.rs
@@ -23,6 +23,20 @@ fn active_dsh_version(app_handle: &AppHandle) -> Option<String> {
     core::active_version(app_handle).or_else(|| config::get_dsh_version(app_handle))
 }
 
+/// 已安装版本高于推荐版本时保留现有核心，避免依赖自愈流程触发降级。
+fn preserve_newer_installed_dsh(
+    installed_version: Option<&str>,
+    recommended_version: Option<&str>,
+) -> bool {
+    match (
+        installed_version.and_then(|version| semver::Version::parse(version).ok()),
+        recommended_version.and_then(|version| semver::Version::parse(version).ok()),
+    ) {
+        (Some(installed), Some(recommended)) => installed > recommended,
+        _ => false,
+    }
+}
+
 fn install_lock() -> &'static tokio::sync::Mutex<()> {
     INSTALL_LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
@@ -120,9 +134,23 @@ pub async fn install_dependencies(app_handle: AppHandle) -> Result<bool, String>
     // latest 可能是 alpha/beta 等超出推荐范围的预览版；并且 `/releases/latest`
     // 不保证与推荐版本的摘要属于同一 release。按推荐 SemVer 反查固定 tag，后续
     // 资产 URL 与 digest 都从该 tag 获取。
-    let dsh_latest = match config::recommended_dsh_version(&app_handle) {
-        Some(version) => download::fetch_dsh_pkg_version(&version).await,
-        None => download::fetch_latest_dsh_pkg_info().await,
+    let recommended_version = config::recommended_dsh_version(&app_handle);
+    let installed_version = dsh_files_ok
+        .then(|| active_dsh_version(&app_handle))
+        .flatten();
+    let preserve_installed =
+        preserve_newer_installed_dsh(installed_version.as_deref(), recommended_version.as_deref());
+    let dsh_latest = if preserve_installed {
+        log::info!(
+            "Keeping installed dsh version above recommendation: {}",
+            installed_version.as_deref().unwrap_or_default()
+        );
+        None
+    } else {
+        Some(match recommended_version {
+            Some(version) => download::fetch_dsh_pkg_version(&version).await,
+            None => download::fetch_latest_dsh_pkg_info().await,
+        })
     };
 
     // 已安装文件在盘时，用 resolve_update 甄别「记录滞后」与「真更新」：
@@ -130,23 +158,11 @@ pub async fn install_dependencies(app_handle: AppHandle) -> Result<bool, String>
     // 可用的 node_modules 整目录删除重解压，Windows 上原生模块 DLL 锁/重解压
     // 很容易留下破损安装，导致启动报找不到 @deepseek-ai/dsh-client-ui-settings
     // 或 HARNESS_NOT_FOUND。仅在真更新（UpdateAvailable）时才允许重新下载。
-    let dsh_need_install = match &dsh_latest {
-        Ok(latest)
-            if dsh_files_ok
-                && download::parse_version_from_tag(&latest.tag).is_some_and(|version| {
-                    config::is_dsh_version_above_recommended(&app_handle, &version)
-                }) =>
-        {
-            log::info!(
-                "Recommended version policy prevents automatic dsh installation: {}",
-                latest.tag
-            );
-            false
-        }
-        Ok(latest) if dsh_files_ok => {
+    let dsh_need_install = match dsh_latest.as_ref() {
+        None => false,
+        Some(Ok(latest)) if dsh_files_ok => {
             let record_commit = config::get_dsh_pkg_commit(&app_handle);
             let record_tag = config::get_dsh_pkg_tag(&app_handle);
-            let installed_version = active_dsh_version(&app_handle);
             // 老记录没有 tag，反查 pkg 仓库 tags 列表确认记录对应的发布版本；
             // 反查失败时由 resolve_update 回退到“以实际文件为准”的保守分支
             let legacy_tags = if record_tag.is_none() {
@@ -192,8 +208,8 @@ pub async fn install_dependencies(app_handle: AppHandle) -> Result<bool, String>
             }
         }
         // 核心文件缺失（首次安装或目录被清空）→ 需要安装
-        Ok(_) => true,
-        Err(e) => {
+        Some(Ok(_)) => true,
+        Some(Err(e)) => {
             // 网络不可用或 GitHub API 限流时保留本地安装，不阻塞启动
             log::warn!(
                 "Failed to check latest dsh release info, keeping local install: {}",
@@ -219,7 +235,10 @@ pub async fn install_dependencies(app_handle: AppHandle) -> Result<bool, String>
     workflow::status::emit_status(&app_handle);
     // 返回 dsh 是否真正落盘更新：仅重装 Node/pnpm 或全部任务被跳过（例如
     // 版本相同仅记录滞后）时为 false，前端据此决定是否重启页面/保留更新提示
-    let updated = match workflow::install(&app_handle, dsh_latest.ok()).await {
+    // 高于推荐版本的核心没有 release 元数据，因此仅补装 Node/pnpm 时不会被
+    // workflow 当作过期并下载较旧核心。
+    let install_target = dsh_latest.and_then(Result::ok);
+    let updated = match workflow::install(&app_handle, install_target).await {
         Ok(updated) => updated,
         Err(e) => {
             // 安装失败把状态复位，避免后续 install_dependencies 命中
@@ -254,8 +273,13 @@ pub async fn check_dsh_update(
 
     // 当前运行的是预览版时不提示稳定/RC 更新：预览版可能高于当前 release，
     // 但不能把用户主动选择的 alpha/beta 版本降级成较旧的 rc。
-    if config::get_store_dat_setting(&app_handle).active_core.as_deref() == Some("app")
-        && config::get_dsh_pkg_tag(&app_handle).as_deref().is_some_and(download::is_preview_tag)
+    if config::get_store_dat_setting(&app_handle)
+        .active_core
+        .as_deref()
+        == Some("app")
+        && config::get_dsh_pkg_tag(&app_handle)
+            .as_deref()
+            .is_some_and(download::is_preview_tag)
     {
         log::info!("Suppressing dsh update because a preview core is active");
         return Ok(None);
@@ -360,7 +384,7 @@ pub fn runtime_ready(app_handle: AppHandle) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::install_lock;
+    use super::{install_lock, preserve_newer_installed_dsh};
 
     #[test]
     fn install_lock_is_exclusive_while_held() {
@@ -373,5 +397,21 @@ mod tests {
         // 释放后可重新获取
         drop(guard);
         assert!(lock.try_lock().is_ok());
+    }
+
+    #[test]
+    fn newer_installed_dsh_is_preserved_from_recommended_downgrade() {
+        assert!(preserve_newer_installed_dsh(
+            Some("0.1.1-rc.3"),
+            Some("0.1.1-rc.2")
+        ));
+        assert!(!preserve_newer_installed_dsh(
+            Some("0.1.1-rc.2"),
+            Some("0.1.1-rc.2")
+        ));
+        assert!(!preserve_newer_installed_dsh(
+            Some("0.1.1-rc.1"),
+            Some("0.1.1-rc.2")
+        ));
     }
 }

--- a/src-tauri/src/service/download/github.rs
+++ b/src-tauri/src/service/download/github.rs
@@ -16,6 +16,7 @@ use crate::config;
 const DSH_PKG_GITHUB_API: &str = "https://api.github.com/repos/dsh-tauri-desk/deepseek-harness-pkg";
 /// pkg 仓库 HTML 来源；`releases.atom` 走 github.com 而非 api.github.com，不受未认证限流约束。
 const DSH_PKG_REPO: &str = "https://github.com/dsh-tauri-desk/deepseek-harness-pkg";
+const GITHUB_RELEASES_PAGE_SIZE: usize = 100;
 
 /// 最新 Harness 发行版信息（版本 tag + 对应 commit hash）
 #[derive(Debug, Clone, serde::Serialize)]
@@ -656,7 +657,7 @@ async fn fetch_dsh_pkg_releases_from_html(
     Ok(releases)
 }
 
-/// 拉取 pkg 仓库的 release 列表（最新在前），含 GitHub 的 Pre-release label。
+/// 拉取 pkg 仓库的完整 release 列表（最新在前），含 GitHub 的 Pre-release label。
 ///
 /// 核心面板的多版本列表以此作为远程数据源（替代 git tags）：git tags 不含
 /// Pre-release label，无法区分预览版；releases 列表还能天然排除 draft（未发布
@@ -664,42 +665,59 @@ async fn fetch_dsh_pkg_releases_from_html(
 /// 由调用方回退 git tags，预览标记按 tag 命名（[`is_preview_tag`]）兜底。
 pub async fn fetch_dsh_pkg_releases() -> Result<Vec<DshPkgReleaseMeta>, String> {
     let client = github_client()?;
-    match github_api_get(
-        &client,
-        &format!("{DSH_PKG_GITHUB_API}/releases?per_page=100"),
-    )
-    .await
-    {
-        Ok(response) => {
-            let releases: serde_json::Value = response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse release list response: {e}"))?;
-            Ok(releases
-                .as_array()
-                .into_iter()
-                .flatten()
-                .filter_map(|entry| {
-                    let tag = entry.get("tag_name")?.as_str()?.to_string();
-                    let prerelease = entry
-                        .get("prerelease")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    Some(DshPkgReleaseMeta { tag, prerelease })
-                })
-                .collect())
+    let mut all_releases = Vec::new();
+    let mut page = 1;
+    loop {
+        let response = match github_api_get(
+            &client,
+            &format!(
+                "{DSH_PKG_GITHUB_API}/releases?per_page={GITHUB_RELEASES_PAGE_SIZE}&page={page}"
+            ),
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(api_error) => {
+                if page > 1 {
+                    return Err(format!(
+                        "DSH_RELEASE_LIST_INCOMPLETE: page {page} request failed before pagination completed: {api_error}"
+                    ));
+                }
+                log::warn!(
+                    "GitHub API release list unavailable ({}), falling back to Releases page",
+                    api_error
+                );
+                return fetch_dsh_pkg_releases_from_html(&client)
+                    .await
+                    .map_err(|page_error| {
+                        format!("Release list request failed: {api_error}; {page_error}")
+                    });
+            }
+        };
+        let releases: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse release list response: {e}"))?;
+        let entries = releases
+            .as_array()
+            .ok_or_else(|| "DSH_RELEASE_LIST_INVALID: response was not an array".to_string())?;
+        let last_page = entries.len() < GITHUB_RELEASES_PAGE_SIZE;
+        let page_releases = entries
+            .iter()
+            .filter_map(|entry| {
+                let tag = entry.get("tag_name")?.as_str()?.to_string();
+                let prerelease = entry
+                    .get("prerelease")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                Some(DshPkgReleaseMeta { tag, prerelease })
+            })
+            .collect::<Vec<_>>();
+        all_releases.extend(page_releases);
+        if last_page {
+            return Ok(all_releases);
         }
-        Err(api_error) => {
-            log::warn!(
-                "GitHub API release list unavailable ({}), falling back to Releases page",
-                api_error
-            );
-            fetch_dsh_pkg_releases_from_html(&client)
-                .await
-                .map_err(|page_error| {
-                    format!("Release list request failed: {api_error}; {page_error}")
-                })
-        }
+        page += 1;
     }
 }
 

--- a/src-tauri/src/service/download/github.rs
+++ b/src-tauri/src/service/download/github.rs
@@ -305,7 +305,9 @@ pub async fn fetch_latest_dsh_pkg_info() -> Result<LatestDshPkg, String> {
         }
     };
 
-    // 4. 资产 URL 与摘要：仅 API 可达时资产/摘要可信；否则 URL 平台确定性回退、digest=None
+    // 4. 资产 URL 与摘要：URL 与摘要必须始终来自同一个 release。
+    // API 不可用时 tag 来自 Atom，因此下载地址也必须按该 tag 确定性构造，
+    // 不能继续使用 latest 地址，否则会把别的 release 内容拿来匹配当前摘要。
     let (asset_url, mut digest) = match api_release.as_ref() {
         Some(release) => {
             let asset = release
@@ -327,7 +329,7 @@ pub async fn fetch_latest_dsh_pkg_info() -> Result<LatestDshPkg, String> {
                 .map(|v| v.to_string());
             (asset_url, digest)
         }
-        None => (config::get_dsh_download_url()?, None),
+        None => (config::get_dsh_download_url_for_tag(&tag_name)?, None),
     };
 
     // 4b. API 限流/不可用导致取不到可信摘要时，改从 expanded_assets HTML
@@ -363,12 +365,24 @@ pub async fn fetch_latest_dsh_pkg_info() -> Result<LatestDshPkg, String> {
     })
 }
 
+/// 按指定 SemVer 查找并返回 Harness 发行版，供推荐版本策略使用。
+///
+/// 推荐版本可能是 pre-release，不能使用 GitHub 的 `/releases/latest`；该端点会
+/// 排除标记为 pre-release 的发行版。先从完整 release 列表按解析后的 SemVer 精确匹配
+/// tag，再复用固定 tag 的资产与摘要查询，确保下载内容与校验摘要属于同一发布。
+pub async fn fetch_dsh_pkg_version(version: &str) -> Result<LatestDshPkg, String> {
+    let release = fetch_dsh_pkg_releases()
+        .await?
+        .into_iter()
+        .find(|release| parse_version_from_tag(&release.tag).as_deref() == Some(version))
+        .ok_or_else(|| format!("DSH_RECOMMENDED_NOT_FOUND: no release found for {version}"))?;
+    fetch_dsh_pkg_asset(&release.tag).await
+}
+
 /// 拉取指定 tag 的发行版信息（资产 URL + 可信摘要），供核心面板按版本下载。
 ///
-/// 与 `fetch_latest_dsh_pkg_info` 同源策略：优先走 api.github.com
-/// （`/releases/tags/{tag}` 拿资产与摘要），失败时资产 URL 平台确定性推导
-/// （latest 地址的 tag 位替换）、摘要走 expanded_assets HTML；digest 仍取不到
-/// 则置 `None`，调用方据此安全中止下载（沿用 DSH_INTEGRITY_UNAVAILABLE 设计）。
+/// API 失败时资产 URL 按 tag 确定性构造，摘要从同一个 tag 的页面读取，避免
+/// latest 地址与固定 tag 的摘要发生错配。
 pub async fn fetch_dsh_pkg_asset(tag: &str) -> Result<LatestDshPkg, String> {
     let client = github_client()?;
     let expected_name = config::get_dsh_download_url()?
@@ -728,6 +742,20 @@ mod tests {
             asset_url: "https://example.invalid/dsh.zip".to_string(),
             digest: Some(format!("sha256:{}", "0".repeat(64))),
         }
+    }
+
+    #[test]
+    fn atom_fallback_download_url_is_pinned_to_resolved_tag() {
+        let tag = "dsh-src-0.1.2-alpha.1-33260039971";
+        let url = config::get_dsh_download_url_for_tag(tag).expect("dsh url");
+        assert!(url.contains(&format!("/releases/download/{tag}/")));
+        assert!(!url.contains("/releases/latest/download/"));
+        assert!(
+            url.ends_with("deepseek-harness-pkg-windows.zip")
+                || url.ends_with("deepseek-harness-pkg-linux.zip")
+                || url.ends_with("deepseek-harness-pkg-macos-arm64.zip")
+                || url.ends_with("deepseek-harness-pkg-macos-x64.zip")
+        );
     }
 
     #[test]

--- a/src-tauri/src/service/download/mod.rs
+++ b/src-tauri/src/service/download/mod.rs
@@ -10,9 +10,9 @@ pub use core::{
     download_file, download_file_from_sources, ensure_extract, fetch_node_sha256, verify_sha256,
 };
 pub use github::{
-    fetch_dsh_pkg_asset, fetch_dsh_pkg_releases, fetch_dsh_pkg_tags, fetch_latest_dsh_pkg_info,
-    is_preview_tag, parse_version_from_tag, record_matches_latest_release, resolve_update,
-    DshPkgReleaseMeta, LatestDshPkg, UpdateCheck,
+    fetch_dsh_pkg_asset, fetch_dsh_pkg_releases, fetch_dsh_pkg_tags, fetch_dsh_pkg_version,
+    fetch_latest_dsh_pkg_info, is_preview_tag, parse_version_from_tag,
+    record_matches_latest_release, resolve_update, DshPkgReleaseMeta, LatestDshPkg, UpdateCheck,
 };
 // 供核心面板切换版本时使用（跨模块内部接口，不进公共 API）
 pub(crate) use core::{remove_dir_with_retry, rename_with_retry};

--- a/src-tauri/src/service/workflow/install.rs
+++ b/src-tauri/src/service/workflow/install.rs
@@ -148,7 +148,11 @@ pub async fn install(
                 // issue #31），这里带退避重取，避免启动被瞬时失败卡死。
                 if dsh_latest.is_none() {
                     for attempt in 0..3 {
-                        match download::fetch_latest_dsh_pkg_info().await {
+                        let metadata = match config::recommended_dsh_version(app_handle) {
+                            Some(version) => download::fetch_dsh_pkg_version(&version).await,
+                            None => download::fetch_latest_dsh_pkg_info().await,
+                        };
+                        match metadata {
                             Ok(info) => {
                                 dsh_latest = Some(info);
                                 break;


### PR DESCRIPTION
## Summary\n- install the configured recommended DSH version instead of GitHub latest\n- pin fallback downloads to the resolved release tag\n- keep asset URL and SHA-256 digest from the same release\n\n## Validation\n- cargo test service::download::github::tests --lib\n- cargo check\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency downloads now consistently use the configured recommended version when available.
  * Fallback downloads are pinned to the matching release, improving package and integrity verification reliability.
  * Existing retry and digest validation behavior remains unchanged.

* **Tests**
  * Added coverage to verify that fallback download URLs reference the correct release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->