### PR TITLE
fix(workflow): retry dsh boot on duplicate loader entry race

### DIFF
--- a/src-tauri/src/config/runtime.rs
+++ b/src-tauri/src/config/runtime.rs
@@ -410,20 +410,20 @@ fn user_home_dir() -> Option<PathBuf> {
 /// Harness 用户数据目录（$DSH_HOME）。
 ///
 /// 与官方 dsh（`${DSH_HOME:-$HOME/.dsh}`）保持一致：
-/// - 环境变量 `DSH_HOME` 非空时优先使用（用户显式指定优先于构建差异）；
-/// - 否则 release 构建默认 `~/.dsh`（Windows `%USERPROFILE%\.dsh`，Unix
-///   `$HOME/.dsh`，与官方 node 安装共用同一份数据）；
-/// - debug 构建默认 `~/.dsh.dev`：开发版与生产版同时运行时，会话、档案、
-///   插件与主题等数据互不干扰，也不会互相污染对方的会话。
+/// - release 构建使用非空环境变量 `DSH_HOME`，否则默认 `~/.dsh`；
+/// - debug 构建始终使用 `~/.dsh.dev`，忽略从旧 desktop checkout、终端或 release
+///   shim 继承的 `DSH_HOME`，避免两个构建误用同一 profile 并发改写；
+/// - debug 子进程由 launch 显式收到同一个 `~/.dsh.dev`，开发版与生产版的会话、档案、
+///   插件与主题因此互不干扰。
 pub fn get_dsh_data_path<R: Runtime>(_app_handle: &AppHandle<R>) -> PathBuf {
-    if let Some(home) = std::env::var_os("DSH_HOME") {
-        if !home.is_empty() {
-            return PathBuf::from(home);
-        }
-    }
     let dir_name = if cfg!(debug_assertions) {
         DSH_HOME_DEV_DIR_NAME
     } else {
+        if let Some(home) = std::env::var_os("DSH_HOME") {
+            if !home.is_empty() {
+                return PathBuf::from(home);
+            }
+        }
         DSH_HOME_DIR_NAME
     };
     user_home_dir()

--- a/src-tauri/src/service/plugin/internal/manifest.rs
+++ b/src-tauri/src/service/plugin/internal/manifest.rs
@@ -14,6 +14,78 @@ pub(super) fn internal_plugin_entry_is_ready(entry: &Path) -> bool {
     serde_json::from_slice::<serde_json::Value>(&raw).is_ok_and(|manifest| manifest.is_object())
 }
 
+/// 清理 profile bundle 列表中的重复引用，保留首次出现的顺序。
+///
+/// 旧工作目录切换期间，重复执行安装/迁移可能把同一个 bundle 追加多次；
+/// Cordis 会把每个引用都展开，最终报 duplicate loader entry。只修改 bundle
+/// 列表，不删除任何依赖或用户插件。
+pub(super) fn dedupe_profile_bundles(manifest: &mut serde_json::Value) -> bool {
+    let Some(bundles) = manifest
+        .get_mut("dsh")
+        .and_then(|dsh| dsh.get_mut("profile"))
+        .and_then(|profile| profile.get_mut("bundles"))
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return false;
+    };
+
+    let before = bundles.len();
+    let mut seen = HashSet::new();
+    bundles.retain(|bundle| {
+        bundle
+            .as_str()
+            .is_none_or(|name| seen.insert(name.to_string()))
+    });
+    bundles.len() != before
+}
+
+/// 从 profile 自身的 patch 层移除已经由 bundle 提供的重复 loader entry。
+///
+/// 旧版本从另一个桌面目录启动时，可能把插件的 `cordis.patch.yml` 内容复制到
+/// profile patch；当前 bundle 又会再次提供同一 id。只移除顶层 `insert` 中与
+/// bundle id 相同的条目，保留 win-terminal-inspector 等用户插件。
+pub(super) fn remove_duplicate_bundle_entries_from_patch(
+    patch: &mut serde_yaml::Value,
+    bundle_ids: &HashSet<&str>,
+) -> bool {
+    let mut modified = false;
+    remove_duplicate_inserted_entries(patch, bundle_ids, &mut modified);
+    modified
+}
+
+/// 递归清理 patch 中的 insert，兼容旧版本写入的 group 嵌套结构。
+fn remove_duplicate_inserted_entries(
+    value: &mut serde_yaml::Value,
+    bundle_ids: &HashSet<&str>,
+    modified: &mut bool,
+) {
+    match value {
+        serde_yaml::Value::Sequence(items) => {
+            for item in items {
+                remove_duplicate_inserted_entries(item, bundle_ids, modified);
+            }
+        }
+        serde_yaml::Value::Mapping(mapping) => {
+            if let Some(insert) = mapping
+                .get_mut(serde_yaml::Value::String("insert".to_string()))
+                .and_then(serde_yaml::Value::as_sequence_mut)
+            {
+                let before = insert.len();
+                insert.retain(|item| {
+                    item.get("id")
+                        .and_then(serde_yaml::Value::as_str)
+                        .is_none_or(|id| !bundle_ids.contains(id))
+                });
+                *modified |= insert.len() != before;
+            }
+            for child in mapping.values_mut() {
+                remove_duplicate_inserted_entries(child, bundle_ids, modified);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// 从 profile 清单精准移除待重装 internal 包的依赖与 bundle 引用。
 pub(super) fn remove_internal_plugins_from_manifest(
     manifest: &mut serde_json::Value,
@@ -178,6 +250,20 @@ mod tests {
         assert!(!internal_plugin_entry_is_ready(&root));
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn duplicate_profile_bundles_are_removed_without_reordering() {
+        let mut manifest = serde_json::json!({
+            "dsh": { "profile": { "bundles": ["dsh-tauri", "dshmarket", "dsh-tauri", "dshmarket"] } }
+        });
+
+        assert!(dedupe_profile_bundles(&mut manifest));
+        assert_eq!(
+            manifest["dsh"]["profile"]["bundles"],
+            serde_json::json!(["dsh-tauri", "dshmarket"])
+        );
+        assert!(!dedupe_profile_bundles(&mut manifest));
     }
 
     #[test]

--- a/src-tauri/src/service/plugin/internal/mod.rs
+++ b/src-tauri/src/service/plugin/internal/mod.rs
@@ -22,9 +22,11 @@ use super::install::install_internal;
 use super::installed::{installed_name, profile_dir, ProfilePackageJson};
 use super::preset::{bundled_dep_spec, bundled_plugin_dir, load_presets, PreinstallPluginInfo};
 use super::process::{new_process_owner, ProcessOwner};
+use crate::config;
 
 use manifest::{
-    dep_matches_spec, internal_plugin_entry_is_ready, remove_internal_plugins_from_manifest,
+    dedupe_profile_bundles, dep_matches_spec, internal_plugin_entry_is_ready,
+    remove_duplicate_bundle_entries_from_patch, remove_internal_plugins_from_manifest,
     remove_stale_plugin_entry, write_profile_manifest,
 };
 
@@ -158,6 +160,83 @@ fn ensure_lock() -> &'static tokio::sync::Mutex<EnsureCoordinator> {
     ENSURE_LOCK.get_or_init(|| tokio::sync::Mutex::new(EnsureCoordinator::default()))
 }
 
+/// 在启动 Harness 前修复旧桌面目录遗留的 profile loader 状态。
+///
+/// 这一步必须发生在启动 dsh 子进程之前：dsh 会同时合并 bundle patch、profile
+/// patch、home patch；如果旧 checkout 曾把内置插件 patch 写入其中，单纯重装
+/// `node_modules` 无法消除重复 loader entry。只清理桌面端明确拥有的内置 id，
+/// 绝不触碰用户插件。
+pub(crate) fn repair_loader_state(app_handle: &AppHandle) -> Result<(), String> {
+    let internal: Vec<_> = load_presets(app_handle)
+        .into_iter()
+        .filter(|preset| preset.internal)
+        .collect();
+    let bundle_ids: HashSet<&str> = internal.iter().map(|preset| preset.id.as_str()).collect();
+    let profile = profile_dir(app_handle);
+    let profile_manifest = profile.join("package.json");
+    let mut changed_manifest = false;
+    if let Ok(raw) = std::fs::read_to_string(&profile_manifest) {
+        let mut manifest = serde_json::from_str::<serde_json::Value>(&raw)
+            .map_err(|e| format!("INTERNAL_PLUGIN_MANIFEST_PARSE_FAILED: {e}"))?;
+        changed_manifest = dedupe_profile_bundles(&mut manifest);
+        if changed_manifest {
+            write_profile_manifest(&profile_manifest, &manifest)?;
+        }
+    }
+
+    for patch_path in [
+        profile.join("cordis.patch.yml"),
+        config::get_dsh_data_path(app_handle).join("cordis.patch.yml"),
+    ] {
+        let Ok(raw) = std::fs::read_to_string(&patch_path) else {
+            continue;
+        };
+        let mut patch = serde_yaml::from_str::<serde_yaml::Value>(&raw).map_err(|e| {
+            format!(
+                "INTERNAL_PLUGIN_PATCH_PARSE_FAILED: {}: {e}",
+                patch_path.display()
+            )
+        })?;
+        if remove_duplicate_bundle_entries_from_patch(&mut patch, &bundle_ids) {
+            let rendered = serde_yaml::to_string(&patch)
+                .map_err(|e| format!("INTERNAL_PLUGIN_PATCH_RENDER_FAILED: {e}"))?;
+            std::fs::write(&patch_path, rendered).map_err(|e| {
+                format!(
+                    "INTERNAL_PLUGIN_PATCH_WRITE_FAILED: {}: {e}",
+                    patch_path.display()
+                )
+            })?;
+            log::warn!(
+                "INTERNAL_PLUGIN_PROFILE_MIGRATED: removed stale internal loader entries from {}",
+                patch_path.display()
+            );
+        }
+    }
+
+    // dsh 会把运行时组合结果写回 cordis.yml；旧版本留下的组合结果会在下一次
+    // 启动时与新 patch 再合并，必须恢复官方约定的空根配置。
+    let root = profile.join("cordis.yml");
+    const EMPTY_ROOT: &str = "# dsh profile root — an empty entry list. The tree is composed as patches:\n# each bundle in package.json's dsh.profile.bundles, then cordis.patch.yml, then any\n# --patch overlays. Edit cordis.patch.yml, not this file.\n[]\n";
+    if std::fs::read_to_string(&root).ok().as_deref() != Some(EMPTY_ROOT) {
+        if profile.is_dir() {
+            std::fs::write(&root, EMPTY_ROOT).map_err(|e| {
+                format!("INTERNAL_PLUGIN_ROOT_WRITE_FAILED: {}: {e}", root.display())
+            })?;
+            log::warn!(
+                "INTERNAL_PLUGIN_PROFILE_MIGRATED: reset stale profile root {}",
+                root.display()
+            );
+        }
+    }
+    if changed_manifest {
+        log::warn!(
+            "INTERNAL_PLUGIN_PROFILE_MIGRATED: deduplicated profile bundles in {}",
+            profile_manifest.display()
+        );
+    }
+    Ok(())
+}
+
 pub(crate) async fn ensure(app_handle: &AppHandle) -> Result<(), String> {
     let presets = load_presets(app_handle);
     let internal: Vec<_> = presets.into_iter().filter(|p| p.internal).collect();
@@ -165,6 +244,7 @@ pub(crate) async fn ensure(app_handle: &AppHandle) -> Result<(), String> {
         return Ok(());
     }
 
+    repair_loader_state(app_handle)?;
     receive_current_or_next_flight(|| subscribe_or_start(app_handle, &internal)).await
 }
 
@@ -414,6 +494,37 @@ async fn ensure_inner(
         }
         None => HashMap::new(),
     };
+
+    // 旧工作目录留下的 profile 可能含重复 bundle；先做幂等迁移，避免在
+    // 检查依赖正常时直接进入 Cordis 并触发 duplicate loader entry。
+    let mut migrated = false;
+    if let Some(value) = manifest.as_mut() {
+        migrated = dedupe_profile_bundles(value);
+    }
+
+    let bundle_ids: HashSet<&str> = internal.iter().map(|preset| preset.id.as_str()).collect();
+    let patch_path = profile.join("cordis.patch.yml");
+    let mut patch = std::fs::read_to_string(&patch_path)
+        .ok()
+        .and_then(|raw| serde_yaml::from_str::<serde_yaml::Value>(&raw).ok());
+    if let Some(value) = patch.as_mut() {
+        if remove_duplicate_bundle_entries_from_patch(value, &bundle_ids) {
+            let rendered = serde_yaml::to_string(value)
+                .map_err(|e| format!("INTERNAL_PLUGIN_PATCH_RENDER_FAILED: {e}"))?;
+            std::fs::write(&patch_path, rendered)
+                .map_err(|e| format!("INTERNAL_PLUGIN_PATCH_WRITE_FAILED: {e}"))?;
+            migrated = true;
+            log::warn!(
+                "INTERNAL_PLUGIN_PROFILE_MIGRATED: removed duplicate bundle entries from {}",
+                patch_path.display()
+            );
+        }
+    }
+    if migrated {
+        if let Some(value) = manifest.as_ref() {
+            write_profile_manifest(&manifest_path, value)?;
+        }
+    }
 
     let mut need: Vec<(String, String, PathBuf)> = Vec::new();
     for preset in internal {

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -204,6 +204,45 @@ pub async fn restart(app_handle: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// 把 active profile 的 `cordis.yml` 重置为官方空根。
+///
+/// dsh 的 Loader 在插件 dispose 时会把组合后的整棵 entry 树回写进
+/// `cordis.yml`（dsh-app-boot：plugin self-disposing persists the current
+/// tree）。上一轮被杀/崩溃的 dsh 若留下组合行，新 boot 会读到已含 bundle 行的
+/// 文件，再叠加同一批 patch → `duplicate loader entry`。spawn 前与「早期退出
+/// 重试」各调用一次，把竞态窗口关闭到最小；文件已是空根时静默跳过。
+fn reset_active_profile_root(app_handle: &tauri::AppHandle) {
+    let profile_root = crate::service::profile::profile_dir_of(
+        app_handle,
+        &crate::service::profile::active_profile(app_handle),
+    );
+    if !profile_root.is_dir() {
+        return;
+    }
+    let root_config = profile_root.join("cordis.yml");
+    const PROFILE_ROOT_EMPTY: &str = "# dsh profile root — an empty entry list. The tree is composed as patches:\n# each bundle in package.json's dsh.profile.bundles, then cordis.patch.yml, then any\n# --patch overlays. Edit cordis.patch.yml, not this file.\n[]\n";
+    if std::fs::read_to_string(&root_config).ok().as_deref() != Some(PROFILE_ROOT_EMPTY) {
+        if let Err(e) = std::fs::write(&root_config, PROFILE_ROOT_EMPTY) {
+            log::warn!("PROFILE_ROOT_RESET_FAILED: {}: {e}", root_config.display());
+        } else {
+            log::info!(
+                "Reset stale profile root before spawn: {}",
+                root_config.display()
+            );
+        }
+    }
+}
+
+/// 判断 dsh 早期退出是否命中「duplicate loader entry」竞态签名。
+///
+/// 竞态特征：exit code 1 且 stderr 含 `duplicate loader entry`（dsh-app-boot
+/// 的 Include 把重复 bundle 行叠加进根树时抛出的 TypeError 文本，实测
+/// `duplicate loader entry id: dsh-tauri-worktree`）。
+#[cfg(windows)]
+fn is_duplicate_loader_exit(exit_code: u32, stderr: &str) -> bool {
+    exit_code == 1 && stderr.contains("duplicate loader entry")
+}
+
 /// 启动 Harness 服务进程
 pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     let mut setting = config::get_store_dat_setting(&app_handle);
@@ -459,6 +498,16 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
 
     log::info!("Starting Harness process");
 
+    // dsh 的 Loader 在插件 dispose 时会把组合后的整棵 entry 树回写进
+    // `cordis.yml`（dsh-app-boot：plugin self-disposing persists the current
+    // tree）。上一轮被杀/崩溃的 dsh 若在「新进程 prepareProfile 重置之后、
+    // Include 读取之前」完成回写，新 boot 会读到已含 bundle 组合行的文件，
+    // 再叠加同一批 patch → duplicate loader entry（本会话实测特征
+    // `duplicate loader entry id: dsh-tauri-worktree`）。spawn 前最后一刻重置
+    // profile 根关闭常见窗口；回写恰好落在探测窗口内的残余竞态由下方
+    // Windows 分支的「早期退出重试」兜底。
+    reset_active_profile_root(&app_handle);
+
     // Windows 打包版是 GUI 进程（没有控制台）。直接以 CREATE_NO_WINDOW 启动
     // node 会让 dsh 派生的子进程各自新建可见控制台窗口（频繁闪烁 cmd 黑窗），
     // 因此 Windows 上改用“隐藏控制台”方式启动，见 win_spawn 模块。
@@ -466,6 +515,12 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     let spawn_result = {
         #[cfg(windows)]
         {
+            use std::io::{BufReader, Read};
+            use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, WAIT_TIMEOUT};
+            use windows_sys::Win32::System::Threading::{
+                GetExitCodeProcess, WaitForSingleObject, INFINITE,
+            };
+
             let mut args: Vec<OsString> = vec![
                 dsh_binary_path.as_os_str().to_os_string(),
                 OsString::from("--profile"),
@@ -478,23 +533,83 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
             if no_open {
                 args.push(OsString::from("--no-open"));
             }
-            super::win_spawn::spawn_with_hidden_console_owned(
-                &node_binary_path,
-                &args,
-                Some(&config::get_dsh_install_path(&app_handle)),
-                &envs,
-            )
-            .map(|(stdout, stderr, pid, handle)| {
+
+            // 只负责 spawn 并返回管道/PID/句柄：探测与重试期间不登记、不挂
+            // 监视线程——只有最终采用的那个进程才登记，否则旧监视线程会通过
+            // `on_owned_process_exit` 把刚启动的新进程误当作已退出而回落状态。
+            let spawn_harness =
+                || -> std::io::Result<(std::fs::File, std::fs::File, u32, HANDLE)> {
+                    super::win_spawn::spawn_with_hidden_console_owned(
+                        &node_binary_path,
+                        &args,
+                        Some(&config::get_dsh_install_path(&app_handle)),
+                        &envs,
+                    )
+                };
+
+            // 早期退出重试：崩溃的上一轮 dsh 回写 `cordis.yml` 落在「新进程
+            // prepareProfile 重置之后、Include 读取之前」时，新 boot 会把已含
+            // bundle 组合行的 root 再叠加同一批 patch → `duplicate loader
+            // entry`（实测 exit code 1）。spawn 前重置只覆盖常见窗口，这里在
+            // spawn 后探测 ≤2.5s：命中签名则丢弃实例、重置 profile 根并重试
+            //（最多 3 次，第二次 boot 基于干净状态必然成功）；仍在运行则视为
+            // 健康立即放行登记。探测期间最长阻塞 2.5s，之后才返回给调用方。
+            let mut attempt = 0u32;
+            let mut outcome = spawn_harness();
+            loop {
+                attempt += 1;
+                let (stdout, stderr, pid, handle) = match outcome {
+                    Ok(spawned) => spawned,
+                    Err(error) => {
+                        // spawn 自身失败（非竞态）：保持 Err 交给下方 map 传播
+                        outcome = Err(error);
+                        break;
+                    }
+                };
+                let wait = unsafe { WaitForSingleObject(handle, 2500) };
+                if wait == WAIT_TIMEOUT {
+                    // 健康：进程仍在运行，交给下方登记 + 监视线程。
+                    outcome = Ok((stdout, stderr, pid, handle));
+                    break;
+                }
+                // 已提前退出：读 stderr 判断是否命中竞态签名。
+                let mut exit_code: u32 = 0;
+                let got_exit_code = unsafe { GetExitCodeProcess(handle, &mut exit_code) } != 0;
+                let mut stderr_text = String::new();
+                let mut stderr_reader = BufReader::new(stderr);
+                let _ = Read::read_to_string(&mut stderr_reader, &mut stderr_text);
+                let hit_duplicate =
+                    got_exit_code && is_duplicate_loader_exit(exit_code, &stderr_text);
+                if hit_duplicate && attempt < 3 {
+                    // 丢弃首个失败实例：从未登记，句柄由本分支关闭（此时没有
+                    // 监视线程，不存在重复 close）。
+                    drop(stdout);
+                    unsafe { CloseHandle(handle) };
+                    log::warn!(
+                        "DUPLICATE_LOADER_ENTRY: dsh exited early with duplicate loader entry \
+                         (pid={pid}, code={exit_code}); resetting profile root and relaunching \
+                         (attempt {attempt}/3)"
+                    );
+                    reset_active_profile_root(&app_handle);
+                    outcome = spawn_harness();
+                    continue;
+                }
+                // 非签名提前退出或重试耗尽：走正常路径——已捕获的 stderr 补写
+                // 日志避免失败原因丢失，句柄保持有效交给监视线程等待并关闭。
+                for line in stderr_text.lines() {
+                    log::warn!(target: "dsh", "{}", line);
+                }
+                outcome = Ok((stdout, stderr_reader.into_inner(), pid, handle));
+                break;
+            }
+
+            outcome.map(|(stdout, stderr, pid, handle)| {
                 // PID 与句柄作为整体一次登记，与退出清理（take 一并取出）配对
                 let handle_value = handle as usize;
                 set_owned_process_with_handle(pid, handle_value);
                 let exit_app_handle = app_handle.clone();
                 std::thread::spawn(move || unsafe {
-                    use windows_sys::Win32::Foundation::CloseHandle;
-                    use windows_sys::Win32::System::Threading::{
-                        GetExitCodeProcess, WaitForSingleObject, INFINITE,
-                    };
-                    let process_handle = handle_value as windows_sys::Win32::Foundation::HANDLE;
+                    let process_handle = handle_value as HANDLE;
                     WaitForSingleObject(process_handle, INFINITE);
                     // 进程确已退出：清空持有 PID 并把 Status 从 Running 回落为
                     // Stopped（原有实现只清 PID、状态永远停留在 Running）。
@@ -503,13 +618,13 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                     // terminate_owned_process 重复 close——进程已 exit，
                     // 通常是本线程取走）。
                     let owned = on_owned_process_exit(&exit_app_handle, pid, |owned| {
-                        let handle = owned.handle as windows_sys::Win32::Foundation::HANDLE;
+                        let handle = owned.handle as HANDLE;
                         let mut exit_code: u32 = 0;
                         (GetExitCodeProcess(handle, &mut exit_code) != 0)
                             .then_some(i64::from(exit_code))
                     });
                     if let Some(owned) = owned {
-                        let h = owned.handle as windows_sys::Win32::Foundation::HANDLE;
+                        let h = owned.handle as HANDLE;
                         CloseHandle(h);
                     }
                 });
@@ -657,6 +772,25 @@ mod tests {
         assert!(!version_supports_no_open("0.1"));
         assert!(!version_supports_no_open("v0.1.0"));
         assert!(!version_supports_no_open("not-a-version"));
+    }
+
+    /// 「duplicate loader entry」竞态签名的判定：只认 exit code 1 + stderr 含
+    /// 该文本（实测失败日志：
+    /// `Error: dsh: plugin tree failed to load: failed to apply loader entry
+    /// include (cordis:include): duplicate loader entry id: dsh-tauri-worktree`）。
+    #[cfg(windows)]
+    #[test]
+    fn duplicate_loader_exit_signature_matches_observed_error() {
+        let stderr = "Error: dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include): duplicate loader entry id: dsh-tauri-worktree\nTypeError: duplicate loader entry id: dsh-tauri-worktree\n    at EntryGroup.update (...)";
+        assert!(is_duplicate_loader_exit(1, stderr));
+        // 其他退出码、无关错误或没有该文本的启动失败不命中
+        assert!(!is_duplicate_loader_exit(0, stderr));
+        assert!(!is_duplicate_loader_exit(2, stderr));
+        assert!(!is_duplicate_loader_exit(
+            1,
+            "Error: EADDRINUSE: address already in use"
+        ));
+        assert!(!is_duplicate_loader_exit(1, ""));
     }
 
     /// 端口自愈（issue #91）：自动避让递增遗留的非默认端口，在回落目标空闲时


### PR DESCRIPTION
## Problem

Debug desktop boot fails intermittently right after starting dsh:

```
Error: dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include): duplicate loader entry id: dsh-tauri-worktree
```

The failure appears right after internal plugins are (re)installed, and also after switching profiles — but only from the desktop shell, never when booting dsh by hand with the same profile.

## Root cause

A transient race inside dsh's Include loader: when a plugin self-disposes, dsh-app-boot persists the *composed* entry tree back into the profile's `cordis.yml`. Every boot starts by resetting that file to an empty root, but the reset and the subsequent Include read are separated by an async gap. If a previous killed/crashed dsh process completes its write inside that gap, the fresh boot reads a root that already contains the combined bundle entries, then applies the same bundle patches on top → `duplicate loader entry` (exit code 1).

A leftover from an earlier checkout directory can also leave duplicated bundle references in the profile manifest/patches that survive reinstallation of `node_modules`.

## Changes

- **`src-tauri/src/service/workflow/launch.rs`** — reset the active profile root (`cordis.yml`) right before spawn and again after a detected early duplicate-loader exit; on Windows, probe the spawned dsh for up to 2.5 s and relaunch (max 3 attempts) when the early exit matches the race signature (exit code 1 + stderr containing `duplicate loader entry`). Only the final process is registered/observed, so no stale exit watcher can misreport the replacement process.
- **`src-tauri/src/service/plugin/internal/mod.rs`** — new `repair_loader_state()` runs before boot: dedupes profile bundle references, strips stale internal loader entries from profile/home patches, and resets stale profile roots to the official empty root.
- **`src-tauri/src/service/plugin/internal/manifest.rs`** — new `dedupe_profile_bundles()` and `remove_duplicate_bundle_entries_from_patch()` helpers (user plugins such as `win-terminal-inspector` are never touched).
- **`src-tauri/src/config/runtime.rs`** — debug builds always use `~/.dsh.dev` and ignore an inherited `DSH_HOME`, so a stale checkout or the release shim cannot point the dev build at the release profile.

## Verification

- `cargo test workflow::launch --lib` (9), `cargo test service::plugin::internal --lib` (11), `cargo test config::runtime --lib` (12) — all pass, including a new signature test reproducing the observed error text.
- `cargo fmt --check` clean.
- Real-machine run of `pnpm tauri dev`: dsh boots on `--profile test --port 3081 --no-open`, health check `healthy - 54/54 client modules ready`, stable for 30 s+; the ~2.5 s probe before "started successfully" confirms the new retry path is active.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate internal plugin entries that could prevent the application from launching.
  - Improved startup recovery when stale profile data causes loader errors.
  - On Windows, failed launches now automatically clean up and retry up to three times.
  - Improved separation of development and release profile settings for more reliable local testing.
  - Added safeguards to preserve valid plugin configuration while removing stale or duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->