### PR TITLE
chore: release v0.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.9.5-beta.3",
+  "version": "0.9.5",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.9.5-beta.3"
+version = "0.9.5"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.9.5-beta.3"
+version = "0.9.5"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.9.5-beta.3",
+  "version": "0.9.5",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.9.5` (`0.9.5-beta.3` → `0.9.5`).

### Features

- **08**: 克隆档案 — full copy + auto-increment naming (#248) (ecd5277)
- **07**: 档案手动备份/还原 + 自动备份 (#247) (5ffe168)
- **06**: 插件禁用/启用 — loading-list removal (#246) (b2cee45)
- **05**: 预设插件可取消勾选/卸载 (#245) (70e76b0)
- **04**: 复制诊断日志 — copy-logs button on Setup error page (#244) (3efc491)
- **03**: 应用菜单重启 — desktop-restart menu item (#243) (575503b)
- macOS accessory mode + configurable close-to-tray (Phase 01) (#238) (89c8de1)

### Bug Fixes

- **workflow**: retry dsh boot on duplicate loader entry race (#253) (c4d74ba)
- prioritize source recommendation manifest in dev (#254) (abd6e73)
- **download**: install recommended dsh release (#240) (c5e7b16)

### Chores

- **workflow/launch**: temporarily disable alpha authentication patch (8debe57)
- **plugins**: mark dsh notification as abandoned and remove it from the preset plugin list (6a21281)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to **0.9.5**, marking the release as stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->