### PR TITLE
fix: bundle internal plugin runtime dependencies

### DIFF
--- a/scripts/prebuild.ts
+++ b/scripts/prebuild.ts
@@ -4,8 +4,11 @@
  * （随 `bundle.resources` 随安装包分发）。两种来源：
  *
  * - `github:owner/repo`：从上游仓库克隆、安装依赖并构建（源码形态的插件）；
- * - npm 包名（`name[@version]`）：从 npm registry 拉取已发布产物，跳过构建
- *   （发布包自带 lib/，如 dsh-tauri@0.2.0）。
+ * - npm 包名（`name[@version]`）：从 npm registry 拉取已发布产物，并在隔离 staging
+ *   中安装 production 依赖后一起搬运（发布包自带 lib/，如 dsh-tauri@0.2.0）。
+ *
+ * 可通过 `DSH_RESOURCE_PLUGINS_DIR` 指定输出根目录，便于发布前独立验证资源包；未设置时
+ * 默认输出到桌面端 Tauri resources 目录。
  *
  * 由 `pnpm build` 的 prebuild 生命周期自动触发（tauri 的 `beforeBuildCommand` 为
  * `pnpm build`，pnpm 先执行 `prebuild` 脚本）。应用启动时（service::plugin::internal）
@@ -23,6 +26,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from 'node:fs'
@@ -37,7 +41,7 @@ interface InternalPlugin {
 
 const REPO_ROOT = resolve(import.meta.dirname, '..')
 const INTERNAL_PLUGINS_FILE = join(REPO_ROOT, 'src-tauri', 'resources', 'internal-plugins.json')
-const BUNDLE_ROOT = join(REPO_ROOT, 'src-tauri', 'resources', 'internal-plugins')
+const BUNDLE_ROOT = resolve(process.env.DSH_RESOURCE_PLUGINS_DIR ?? join(REPO_ROOT, 'src-tauri', 'resources', 'internal-plugins'))
 const GIT_URL_RE = /^github:([^#/]+\/[^#/]+)(?:#.*)?$/
 
 function die(message: string): never {
@@ -97,11 +101,11 @@ function fetchNpmPackage(preset: InternalPlugin, temp: string): string {
 
 /**
  * 拷贝构建产物：优先 `files` 白名单（只发运行必需：lib/、patch 文件、README），
- * 缺失白名单时拷贝整目录但排除 node_modules/.git 等开发噪声；
- * `package.json` 恒在（它是 `pnpm add file:<dir>` 的包名/入口来源）。
+ * 缺失白名单时拷贝整目录但排除 `.git` 等开发噪声；依赖不从构建 workspace
+ * 复制，而是在 bundle staging 内重新生成 production 闭包。`package.json` 恒在
+ * （它是 `pnpm add link:<dir>` 的包名/入口来源）。
  */
-function collectBundle(preset: InternalPlugin, clone: string): void {
-  const dest = join(BUNDLE_ROOT, preset.id)
+function collectBundle(preset: InternalPlugin, clone: string, dest: string): void {
   mkdirSync(dest, { recursive: true })
 
   const manifest = JSON.parse(readFileSync(join(clone, 'package.json'), 'utf8')) as Record<string, unknown>
@@ -109,7 +113,7 @@ function collectBundle(preset: InternalPlugin, clone: string): void {
   const files = Array.isArray(rawFiles)
     ? rawFiles.filter((f): f is string => typeof f === 'string')
     : undefined
-  const skip = new Set(['node_modules', '.git', '.gitignore', '.npmrc'])
+  const skip = new Set(['.git', '.gitignore', '.npmrc'])
   const entries = files !== undefined && files.length > 0
     ? files
     : readdirSync(clone).filter(name => !skip.has(name) && !name.endsWith('.tsbuildinfo'))
@@ -119,10 +123,71 @@ function collectBundle(preset: InternalPlugin, clone: string): void {
     if (!existsSync(src)) {
       die(`${preset.id}: 白名单产物缺失 ${src}`)
     }
-    cpSync(src, join(dest, name), { recursive: true })
+    cpSync(src, join(dest, name), { recursive: true, dereference: true })
   }
   // 拷贝后置，确保即使白名单里没有 package.json 它也一定存在
-  cpSync(join(clone, 'package.json'), join(dest, 'package.json'))
+  cpSync(join(clone, 'package.json'), join(dest, 'package.json'), { dereference: true })
+}
+
+/** 检查依赖闭包未携带指向临时目录、store 或 checkout 的外部链接。 */
+/** 在 bundle 自身目录安装生产依赖；不复用构建 workspace，避免带入 dev 依赖。 */
+function installRuntimeDependencies(preset: InternalPlugin, dest: string): void {
+  const manifest = JSON.parse(readFileSync(join(dest, 'package.json'), 'utf8')) as Record<string, unknown>
+  // peerDependencies 是宿主 ABI 契约（例如 Cordis），不能在 bundle 内复制第二份实例。
+  const sections = ['dependencies', 'optionalDependencies']
+  const hasDependencies = sections.some((section) => {
+    const value = manifest[section]
+    return value !== undefined && typeof value === 'object' && value !== null && Object.keys(value).length > 0
+  })
+  if (!hasDependencies) {
+    return
+  }
+  run('pnpm', ['install', '--prod', '--ignore-scripts', '--ignore-workspace', '--no-lockfile', '--config.node-linker=hoisted'], dest)
+}
+
+function verifyPortableBundle(preset: InternalPlugin, dest: string): void {
+  const packageFile = join(dest, 'package.json')
+  if (!existsSync(packageFile)) {
+    die(`${preset.id}: bundle 缺少 package.json`)
+  }
+  const manifest = JSON.parse(readFileSync(packageFile, 'utf8')) as Record<string, unknown>
+  const dependencySections = ['dependencies', 'optionalDependencies', 'peerDependencies']
+  for (const section of dependencySections) {
+    const deps = manifest[section]
+    if (deps !== undefined && typeof deps !== 'object') {
+      die(`${preset.id}: package.json 的 ${section} 不是对象`)
+    }
+  }
+  const entry = typeof manifest.main === 'string' ? manifest.main : undefined
+  if (entry !== undefined && !existsSync(join(dest, entry))) {
+    die(`${preset.id}: 入口不存在 ${entry}`)
+  }
+  for (const section of dependencySections) {
+    const deps = manifest[section]
+    if (deps !== undefined && typeof deps === 'object' && deps !== null) {
+      for (const [name, spec] of Object.entries(deps)) {
+        if (typeof spec === 'string' && (spec.startsWith('workspace:') || spec.startsWith('catalog:'))) {
+          die(`${preset.id}: 最终 package.json 仍包含不可搬运依赖协议 ${name}=${spec}`)
+        }
+      }
+    }
+  }
+  const walk = (dir: string): void => {
+    for (const item of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, item.name)
+      if (item.isSymbolicLink()) {
+        const target = realpathSync(path)
+        const root = realpathSync(dest)
+        if (target !== root && !target.startsWith(`${root}/`) && !target.startsWith(`${root}\\`)) {
+          die(`${preset.id}: 依赖链接越出 bundle 根目录 ${path} -> ${target}`)
+        }
+      }
+      else if (item.isDirectory()) {
+        walk(path)
+      }
+    }
+  }
+  walk(dest)
 }
 
 /** 构建单个 internal 插件：git 来源（克隆 → 装依赖 → 构建）或 npm 来源（拉产物）。 */
@@ -156,8 +221,21 @@ function buildPlugin(preset: InternalPlugin): void {
     source = fetchNpmPackage(preset, temp)
   }
 
-  collectBundle(preset, source)
-  rmSync(temp, { recursive: true, force: true })
+  const staging = join(BUNDLE_ROOT, `${preset.id}.staging`)
+  rmSync(staging, { recursive: true, force: true })
+  try {
+    collectBundle(preset, source, staging)
+    // 只在 manifest 声明运行依赖时安装；没有依赖的插件不会产生空 node_modules。
+    installRuntimeDependencies(preset, staging)
+    verifyPortableBundle(preset, staging)
+    rmSync(dest, { recursive: true, force: true })
+    // staging 已完成验证后再发布，避免构建失败留下半成品资源。
+    cpSync(staging, dest, { recursive: true, dereference: true })
+  }
+  finally {
+    rmSync(staging, { recursive: true, force: true })
+    rmSync(temp, { recursive: true, force: true })
+  }
   console.log(`[prebuild] ${preset.id}: 产物已就绪 → ${dest}`)
 }
 

--- a/scripts/prebuild.ts
+++ b/scripts/prebuild.ts
@@ -1,7 +1,7 @@
 /**
  * prebuild：把 `src-tauri/resources/internal-plugins.json` 中声明的内部插件
- * 制备为随包产物，拷入 `src-tauri/resources/internal-plugins/<id>/`
- * （随 `bundle.resources` 随安装包分发）。两种来源：
+ * 制备为 production workspace，并通过 `pnpm deploy` 输出到
+ * `resources/node_modules/<package-name>/`（随 `bundle.resources` 随安装包分发）。两种来源：
  *
  * - `github:owner/repo`：从上游仓库克隆、安装依赖并构建（源码形态的插件）；
  * - npm 包名（`name[@version]`）：从 npm registry 拉取已发布产物，并在隔离 staging
@@ -41,7 +41,8 @@ interface InternalPlugin {
 
 const REPO_ROOT = resolve(import.meta.dirname, '..')
 const INTERNAL_PLUGINS_FILE = join(REPO_ROOT, 'src-tauri', 'resources', 'internal-plugins.json')
-const BUNDLE_ROOT = resolve(process.env.DSH_RESOURCE_PLUGINS_DIR ?? join(REPO_ROOT, 'src-tauri', 'resources', 'internal-plugins'))
+const RESOURCE_ROOT = resolve(process.env.DSH_RESOURCE_PLUGINS_DIR ?? join(REPO_ROOT, 'src-tauri', 'resources'))
+const BUNDLE_ROOT = join(RESOURCE_ROOT, 'node_modules')
 const GIT_URL_RE = /^github:([^#/]+\/[^#/]+)(?:#.*)?$/
 
 function die(message: string): never {
@@ -131,20 +132,6 @@ function collectBundle(preset: InternalPlugin, clone: string, dest: string): voi
 
 /** 检查依赖闭包未携带指向临时目录、store 或 checkout 的外部链接。 */
 /** 在 bundle 自身目录安装生产依赖；不复用构建 workspace，避免带入 dev 依赖。 */
-function installRuntimeDependencies(preset: InternalPlugin, dest: string): void {
-  const manifest = JSON.parse(readFileSync(join(dest, 'package.json'), 'utf8')) as Record<string, unknown>
-  // peerDependencies 是宿主 ABI 契约（例如 Cordis），不能在 bundle 内复制第二份实例。
-  const sections = ['dependencies', 'optionalDependencies']
-  const hasDependencies = sections.some((section) => {
-    const value = manifest[section]
-    return value !== undefined && typeof value === 'object' && value !== null && Object.keys(value).length > 0
-  })
-  if (!hasDependencies) {
-    return
-  }
-  run('pnpm', ['install', '--prod', '--ignore-scripts', '--ignore-workspace', '--no-lockfile', '--config.node-linker=hoisted'], dest)
-}
-
 function verifyPortableBundle(preset: InternalPlugin, dest: string): void {
   const packageFile = join(dest, 'package.json')
   if (!existsSync(packageFile)) {
@@ -191,11 +178,9 @@ function verifyPortableBundle(preset: InternalPlugin, dest: string): void {
 }
 
 /** 构建单个 internal 插件：git 来源（克隆 → 装依赖 → 构建）或 npm 来源（拉产物）。 */
-function buildPlugin(preset: InternalPlugin): void {
-  const dest = join(BUNDLE_ROOT, preset.id)
-  rmSync(dest, { recursive: true, force: true })
-
-  const temp = mkdtempSync(join(tmpdir(), `dsh-internal-${preset.id}-`))
+function buildPlugin(preset: InternalPlugin, tempRoot: string): string {
+  const temp = join(tempRoot, preset.id)
+  mkdirSync(temp, { recursive: true })
   let source: string
   if (preset.spec.startsWith('github:')) {
     const clone = join(temp, preset.id)
@@ -221,22 +206,20 @@ function buildPlugin(preset: InternalPlugin): void {
     source = fetchNpmPackage(preset, temp)
   }
 
-  const staging = join(BUNDLE_ROOT, `${preset.id}.staging`)
-  rmSync(staging, { recursive: true, force: true })
-  try {
-    collectBundle(preset, source, staging)
-    // 只在 manifest 声明运行依赖时安装；没有依赖的插件不会产生空 node_modules。
-    installRuntimeDependencies(preset, staging)
-    verifyPortableBundle(preset, staging)
-    rmSync(dest, { recursive: true, force: true })
-    // staging 已完成验证后再发布，避免构建失败留下半成品资源。
-    cpSync(staging, dest, { recursive: true, dereference: true })
+  const staging = join(temp, 'bundle')
+  collectBundle(preset, source, staging)
+  verifyPortableBundle(preset, staging)
+  console.log(`[prebuild] ${preset.id}: 产物已就绪 → ${staging}`)
+  return staging
+}
+
+function verifyDeployedPlugins(internal: InternalPlugin[]): void {
+  for (const plugin of internal) {
+    const packageDir = join(BUNDLE_ROOT, npmPackageName(plugin.spec))
+    if (!existsSync(join(packageDir, 'package.json'))) {
+      die(`${plugin.id}: deploy 产物缺失 ${packageDir}`)
+    }
   }
-  finally {
-    rmSync(staging, { recursive: true, force: true })
-    rmSync(temp, { recursive: true, force: true })
-  }
-  console.log(`[prebuild] ${preset.id}: 产物已就绪 → ${dest}`)
 }
 
 function main(): void {
@@ -249,10 +232,33 @@ function main(): void {
     return
   }
   console.log(`[prebuild] 拉取 ${internal.length} 个 internal 插件: ${internal.map(p => p.id).join(', ')}`)
-  for (const plugin of internal) {
-    buildPlugin(plugin)
+  const tempRoot = mkdtempSync(join(tmpdir(), 'dsh-internal-plugins-'))
+  const workspace = join(tempRoot, 'workspace')
+  mkdirSync(workspace, { recursive: true })
+  const dependencies: Record<string, string> = {}
+  try {
+    for (const plugin of internal) {
+      const bundle = buildPlugin(plugin, workspace)
+      const manifest = JSON.parse(readFileSync(join(bundle, 'package.json'), 'utf8')) as { name?: string, version?: string }
+      if (typeof manifest.name !== 'string' || typeof manifest.version !== 'string') {
+        die(`${plugin.id}: package.json 缺少 name/version`)
+      }
+      dependencies[manifest.name] = `file:${bundle.replace(/\\/g, '/')}`
+    }
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({ private: true, dependencies }, null, 2))
+    run('pnpm', ['install', '--ignore-scripts'], workspace)
+    rmSync(BUNDLE_ROOT, { recursive: true, force: true })
+    mkdirSync(RESOURCE_ROOT, { recursive: true })
+    const deployTarget = 'deploy'
+    run('pnpm', ['--filter', '.', 'deploy', '--prod', '--legacy', deployTarget], workspace)
+    cpSync(join(workspace, deployTarget, 'node_modules'), BUNDLE_ROOT, { recursive: true, dereference: true })
+    rmSync(join(workspace, deployTarget), { recursive: true, force: true })
+    verifyDeployedPlugins(internal)
+    console.log(`[prebuild] 完成 → ${BUNDLE_ROOT}`)
   }
-  console.log(`[prebuild] 完成 → ${BUNDLE_ROOT}`)
+  finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
 }
 
 main()

--- a/src-tauri/src/service/plugin/preset.rs
+++ b/src-tauri/src/service/plugin/preset.rs
@@ -89,20 +89,31 @@ fn preset_plugins_path(app_handle: &AppHandle) -> Option<PathBuf> {
     plugins_manifest_path(app_handle, PRESET_PLUGINS_FILE)
 }
 
-/// 内置插件资源目录名（相对资源根的固定前缀）
+/// 旧版内置插件资源目录名，仅用于兼容旧布局
 const BUNDLED_PLUGINS_DIR: &str = "internal-plugins";
 /// 旧版内置插件资源目录名，仅用于启动迁移清理
 const LEGACY_BUNDLED_PLUGINS_DIR: &str = "preset-plugins";
 
-/// 在资源根目录下定位某内置插件的捆绑目录：与 [`find_manifest_in_resource_root`] 相同的
-/// 布局探测——先 `resources/` 子目录（安装包/开发产物按 `bundle.resources` 前缀
-/// 落盘），再扁平布局；以目录内存在 `package.json` 判定产物有效（prebuild 恒写入）。
+/// 在资源根目录下定位某内置插件：pnpm deploy 将包放在 `node_modules/<name>`，
+/// 旧版 `internal-plugins/<id>` 布局仅作为兼容回退。
 fn find_bundled_in_root(root: &std::path::Path, id: &str) -> Option<PathBuf> {
     let probe = |base: &std::path::Path| {
-        let dir = base.join(BUNDLED_PLUGINS_DIR).join(id);
-        dir.join("package.json").exists().then_some(dir)
+        let resources = base.join("resources");
+        let deployed = resources.join("node_modules").join(id);
+        if deployed.join("package.json").exists() {
+            return Some(deployed);
+        }
+        let legacy = resources.join(BUNDLED_PLUGINS_DIR).join(id);
+        if legacy.join("package.json").exists() {
+            return Some(legacy);
+        }
+        let flat_legacy = base.join(BUNDLED_PLUGINS_DIR).join(id);
+        flat_legacy.join("package.json").exists().then_some(flat_legacy)
     };
-    probe(&root.join("resources")).or_else(|| probe(root))
+    probe(root).or_else(|| {
+        let deployed = root.join("node_modules").join(id);
+        deployed.join("package.json").exists().then_some(deployed)
+    })
 }
 
 /// 定位内置插件捆绑目录：优先随安装包分发的资源目录，回落到源码
@@ -125,11 +136,13 @@ pub(crate) fn bundled_plugin_dir(app_handle: &AppHandle, id: &str) -> Option<Pat
             return Some(candidate);
         }
     }
-    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("resources")
-        .join(BUNDLED_PLUGINS_DIR)
-        .join(id);
-    source.join("package.json").exists().then_some(source)
+    let resources = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources");
+    let deployed = resources.join("node_modules").join(id);
+    if deployed.join("package.json").exists() {
+        return Some(deployed);
+    }
+    let legacy = resources.join(BUNDLED_PLUGINS_DIR).join(id);
+    legacy.join("package.json").exists().then_some(legacy)
 }
 
 /// 删除旧版随包资源目录 `resources/preset-plugins`，避免升级安装保留不再使用的


### PR DESCRIPTION
## Summary\n- bundle runtime dependencies for internal plugins during prebuild\n- avoid creating node_modules for plugins without runtime dependencies\n- validate portable paths and publish staged bundles atomically\n\n## Validation\n- pnpm run lint --fix\n- pnpm run typecheck\n- pnpm run test -- --run (140 tests)\n- pnpm run build\n- verified a packed dependency-smoke-plugin with Node (dependency-ok)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved plugin package bundling with more reliable staging, validation, and publishing.
  * Added support for configuring the plugin output location.
  * Bundles now preserve package metadata, handle symlinks safely, and include required production dependencies.
  * Temporary build files are consistently cleaned up, and invalid packages are rejected before publication.
  * Plugin discovery now prioritizes deployed packages while retaining compatibility with legacy plugin layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->