### PR TITLE
chore: release v0.11.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.0",
+  "version": "0.11.0-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.0"
+version = "0.11.0-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.0"
+version = "0.11.0-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.0",
+  "version": "0.11.0-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.11.0-beta.1` (`0.10.0` → `0.11.0-beta.1`).

### Features

- migrate to dsh alpha.3 line (catalog/types/patch + panel width drag) (#284) (14bb1ec)
- **plugins**: migrate built-in plugins to desktop repository (#274) (37891c0)
- **alpha_auth**: refactoring alpha authentication patch to control authentication skipping through startup parameters (9bfffd7)

### Bug Fixes

- prevent better-sidebar layout residue on settings (#278) (24dffbc)
- pin dsh download metadata before install (#277) (67c956a)
- bundle internal plugin runtime dependencies (#272) (bb13a07)
- **plugin**: retry dsh plugin add on transient junction read failure (#264, #267) (ff09bea)

### Refactors

- **plugins**: restructure to host/client/shared layers and adopt UnJS stack (#282) (1fa37c1)

### Chores

- update docs paths (0dd5d7e)
- update docs (7a8dada)

### Other Changes

- Merge branch 'hairy/support-alpha' (71e467a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.11.0-beta.1** across the desktop app and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->