### PR TITLE
chore: release v0.11.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.11.0-beta.1",
+  "version": "0.11.0-beta.2",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.11.0-beta.1"
+version = "0.11.0-beta.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.11.0-beta.1"
+version = "0.11.0-beta.2"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.11.0-beta.1",
+  "version": "0.11.0-beta.2",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.11.0-beta.2` (`0.11.0-beta.1` → `0.11.0-beta.2`).

### Bug Fixes

- **worktree**: 模式选择器始终在访问模式右侧，工作树会话继承完整对话并在切换后归档源会话 (#293) (722925e)
- **panel-extension**: 技能页「刷新」按钮触发宿主 provider 重挂载并重新扫描 (#266, #292) (4ef18e3)
- **build**: 修复 macOS / Linux 构建因悬垂符号链接失败 (#290) (8dfc2e2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.11.0-beta.2** across all release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->