### PR TITLE
fix(build): 修复 release 内置插件依赖解析失败并清理废弃目录

### DIFF
--- a/scripts/build-plugins.ts
+++ b/scripts/build-plugins.ts
@@ -128,6 +128,11 @@ function main(): void {
   // 来的 node_modules 混入整个 workspace 的生产依赖（桌面壳的 React/UI 栈全部冗余）。
   // 改为现代「注入式」deploy（`--config.inject-workspace-packages=true`），只把 bundle 的
   // workspace 依赖及其真实生产闭包注入产物，得到紧凑可移植的 node_modules。
+  // 但注入式默认仍是 isolated 布局：第三方依赖收进 `.pnpm/<dep>@<ver>/` 虚拟仓库，
+  // 各插件靠虚拟仓库条目内的同级链接解析。materializeTree 把顶层插件符号链接解引用成
+  // 实体目录时会丢掉这些同级依赖链接，产物里插件 `dist/index.js` 的裸 import（pathe /
+  // unstorage 等）随之解析失败。改用 hoisted 布局（`--config.node-linker=hoisted`）让依赖
+  // 平铺到顶层 node_modules，产物即自包含可解析，也彻底绕开符号链接。
   // 目标必须是空目录（src-tauri/resources 内含下发清单，不能直接部署）且为相对路径，
   // 因此先部署到仓库内相对临时目录，再把自包含的 node_modules 落入 resources/node_modules。
   const deployTarget = '.build-plugins-tmp'
@@ -141,6 +146,7 @@ function main(): void {
       'deploy',
       '--prod',
       '--config.inject-workspace-packages=true',
+      '--config.node-linker=hoisted',
       deployTarget,
     ])
     const deployed = join(temp, 'node_modules')

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -39,10 +39,11 @@ fn windows_drag_browser_args() -> &'static str {
 
 /// setup app
 pub fn setup(app_handle: tauri::AppHandle) {
-    // 升级清理：内部插件资源已迁至 resources/internal-plugins；旧安装可能保留
-    // resources/preset-plugins 目录。仅删除旧目录，失败告警并继续启动。
+    // 升级清理：内置插件已迁至 resources/node_modules（pnpm deploy 产物）；旧安装
+    // 可能残留 resources/preset-plugins 与 resources/internal-plugins 目录。仅删除
+    // 旧目录，失败告警并继续启动（查找回退见 preset::find_bundled_in_root）。
     if let Err(e) = crate::service::plugin::remove_legacy_bundled_plugins(&app_handle) {
-        log::warn!("legacy preset plugins cleanup skipped: {e}");
+        log::warn!("legacy bundled plugins cleanup skipped: {e}");
     }
 
     // 启动前清扫上次崩溃残留的孤儿 Harness（端口/PID 双重确认，见

--- a/src-tauri/src/service/plugin/preset.rs
+++ b/src-tauri/src/service/plugin/preset.rs
@@ -270,9 +270,10 @@ fn preset_plugins_path(app_handle: &AppHandle) -> Option<PathBuf> {
     plugins_manifest_path(app_handle, PRESET_PLUGINS_FILE)
 }
 
-/// 旧版内置插件资源目录名，仅用于兼容旧布局
+/// 旧版内置插件资源目录名。作为查找回退保留（已装旧布局插件的自愈仍能命中），
+/// 同时由 [`remove_legacy_bundled_plugins`] 在启动时清理升级残留的整目录副本。
 const BUNDLED_PLUGINS_DIR: &str = "internal-plugins";
-/// 旧版内置插件资源目录名，仅用于启动迁移清理
+/// 旧版预装插件资源目录名，仅用于启动迁移清理
 const LEGACY_BUNDLED_PLUGINS_DIR: &str = "preset-plugins";
 
 /// 在资源根目录下定位某内置插件：pnpm deploy 将包放在 `node_modules/<name>`，
@@ -330,9 +331,10 @@ pub(crate) fn bundled_plugin_dir(app_handle: &AppHandle, id: &str) -> Option<Pat
     legacy.join("package.json").exists().then_some(legacy)
 }
 
-/// 删除旧版随包资源目录 `resources/preset-plugins`，避免升级安装保留不再使用的
-/// 内部插件副本。仅处理 Tauri 运行时资源根下的目录，绝不删除源码 checkout；逐个
-/// 尝试所有布局后再汇总错误，避免一个被占用的旧目录阻碍其余目录清理。
+/// 删除旧版随包资源目录 `resources/preset-plugins` 与 `resources/internal-plugins`，
+/// 避免升级安装保留不再使用/已迁至 `resources/node_modules/<name>` 的内置插件副本。
+/// 仅处理 Tauri 运行时资源根下的目录，绝不删除源码 checkout；逐个尝试所有布局后
+/// 再汇总错误，避免一个被占用的旧目录阻碍其余目录清理。
 pub(crate) fn remove_legacy_bundled_plugins(app_handle: &AppHandle) -> Result<(), String> {
     let Ok(root) = app_handle.path().resource_dir() else {
         return Ok(());
@@ -340,7 +342,13 @@ pub(crate) fn remove_legacy_bundled_plugins(app_handle: &AppHandle) -> Result<()
     let candidates = vec![
         root.join(LEGACY_BUNDLED_PLUGINS_DIR),
         root.join("resources").join(LEGACY_BUNDLED_PLUGINS_DIR),
+        root.join(BUNDLED_PLUGINS_DIR),
+        root.join("resources").join(BUNDLED_PLUGINS_DIR),
     ];
+    // resource_dir() 在不同平台可能返回安装根或 resources 根；若 root 本身即
+    // resources，则上面的 `root/resources` 会误拼一个不存在的嵌套资源根，这里
+    // 只删真正存在且含旧布局的目录（remove_legacy_candidates 本身也会跳过
+    // 不存在的目录）。
     remove_legacy_candidates(candidates, |path| std::fs::remove_dir_all(path))
 }
 


### PR DESCRIPTION
## 背景

release 版本安装后内置插件全部加载失败，`.temp/desktop.log` 报 `ERR_MODULE_NOT_FOUND`：

```
Cannot find package 'pathe' imported from ...\resources\node_modules\dsh-tauri-panel-extension\dist\index.js
Cannot find package 'unstorage' imported from ...\resources\node_modules\dsh-tauri\dist\index.js
```

dsh 进程在启动阶段即退出（`HARNESS_NOT_OWNED`），应用无法使用。

## 修复一：内置插件部署改用 hoisted 布局（`scripts/build-plugins.ts`）

**根因**：`pnpm deploy`（注入式，默认 isolated 布局）把第三方依赖收进 `.pnpm/<dep>@<ver>/` 虚拟仓库，插件包靠"虚拟仓库条目内的同级链接"解析依赖。而 `materializeTree` 把顶层插件符号链接解引用成实体目录时**只复制了插件包本身，丢掉了同级的依赖链接**，于是部署产物里插件 `dist/index.js` 的裸 import（`pathe`/`unstorage`/`hookable`/`ofetch` 等）全部解析失败。

**方案**：deploy 增加 `--config.node-linker=hoisted`，让依赖平铺到顶层 `node_modules/`。产物自包含、零符号链接，绕开符号链接解引用丢失依赖的问题。

**验证**：重跑 `pnpm build:plugins` 后，release 产物中 8 个插件全部能真实 import 加载（含 `pathe`/`unstorage` 等全部依赖 resolve 成功）。

## 修复二：启动时自动清理废弃的 `internal-plugins` 目录（Rust）

新版构建不再生成 `resources/internal-plugins/` 目录（内置插件已迁至 `resources/node_modules/<name>`），它只作为旧版升级残留出现。将 `internal-plugins` 纳入 `remove_legacy_bundled_plugins` 的启动清理，与 `preset-plugins` 处理对称；同时**保留** `find_bundled_in_root` 的查找回退，确保旧布局已装插件的升级自愈不受影响。

**验证**：`cargo test --lib service::plugin` 全部 158 个测试通过；`cargo check` 无告警；改动文件 rustfmt 干净。

## 变更文件

- `scripts/build-plugins.ts` — deploy 改用 hoisted 布局
- `src-tauri/src/service/plugin/preset.rs` — 清理废弃 `internal-plugins` 目录
- `src-tauri/src/desktop/builder.rs` — 更新启动清理注释与日志文案


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin deployment so bundled plugins reliably resolve their dependencies after installation.
  * Prevented outdated dependency links from causing plugin runtime import failures.
* **Maintenance**
  * Added cleanup for legacy bundled-plugin directories during application updates.
  * Improved upgrade handling by removing obsolete plugin files from previous resource layouts.
  * Cleanup now continues across all eligible locations even if one removal encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->