### PR TITLE
fix(security): harden clipboard and plugin error bridges

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -834,6 +834,8 @@ dependencies = [
  "dunce",
  "flate2",
  "futures-util",
+ "getrandom 0.3.4",
+ "hmac",
  "image",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,8 @@ reqwest = { version = "0.12", features = [
 ] }
 zip = "0.6"
 futures-util = "0.3"
+getrandom = "0.3"
+hmac = "0.12"
 flate2 = "1"
 tar = "0.4"
 async-trait = "0.1"

--- a/src-tauri/src/bridge/clipboard.rs
+++ b/src-tauri/src/bridge/clipboard.rs
@@ -79,7 +79,7 @@ impl ClipboardBridgeState {
             .used_nonces
             .lock()
             .map_err(|_| "CLIPBOARD_AUTH_STATE: lock poisoned".to_string())?;
-        used_nonces.retain(|_, used_at| now.duration_since(*used_at) < NONCE_TTL);
+        used_nonces.retain(|_, used_at| now.duration_since(*used_at) <= NONCE_TTL);
         if used_nonces.contains_key(&nonce_bytes) {
             return Err("CLIPBOARD_NONCE_REPLAY: request already consumed".to_string());
         }
@@ -109,7 +109,10 @@ fn timestamp_is_fresh(issued_at: u64) -> bool {
     };
     let now_millis = now.as_millis();
     let issued_at = u128::from(issued_at);
-    now_millis.abs_diff(issued_at) <= NONCE_TTL.as_millis()
+    if issued_at > now_millis {
+        return false;
+    }
+    now_millis - issued_at <= NONCE_TTL.as_millis()
 }
 
 fn decode_nonce(value: &str) -> Result<[u8; NONCE_BYTES], String> {
@@ -276,6 +279,13 @@ mod tests {
             .verify_and_consume(nonce, issued_at, &proof)
             .unwrap_err();
         assert!(error.starts_with("CLIPBOARD_NONCE_EXPIRED:"));
+    }
+
+    #[test]
+    fn future_timestamp_is_rejected() {
+        let issued_at = current_timestamp_millis().saturating_add(1_000);
+
+        assert!(!timestamp_is_fresh(issued_at));
     }
 
     fn current_timestamp_millis() -> u64 {

--- a/src-tauri/src/bridge/clipboard.rs
+++ b/src-tauri/src/bridge/clipboard.rs
@@ -3,10 +3,150 @@
 //! WebKitGTK 不通过 Web API（`ClipboardEvent.clipboardData.items/files`）暴露
 //! `image/*` 剪贴板条目，导致桌面端内嵌的 dsh iframe 中输入框「贴图」无效
 //! （浏览器里却正常）。本命令在 Rust 侧用 `arboard` 读取系统剪贴板图片、编码为
-//! PNG data URL 返回；注入到 iframe 的桥脚本（`desktop::paste::PASTE_SHIM_JS`）
+//! PNG data URL 返回；注入到 iframe 的桥脚本（`desktop::paste::paste_shim_js`）
 //! 拿到该 data URL 后重新派发 `paste` 事件，让 dsh 聊天框按正常贴图路径处理。
 
 use base64::{engine::general_purpose::STANDARD, Engine};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tauri::Manager;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const BRIDGE_SECRET_BYTES: usize = 32;
+const NONCE_BYTES: usize = 16;
+const NONCE_HEX_LEN: usize = NONCE_BYTES * 2;
+const PROOF_BYTES: usize = 32;
+const NONCE_TTL: Duration = Duration::from_secs(5);
+const MAX_USED_NONCES: usize = 256;
+const SIGNING_CONTEXT: &[u8] = b"dsh-clipboard-image-v1:";
+
+/// 剪贴板桥的会话认证状态。
+///
+/// 密钥由宿主进程生成，并只通过初始化脚本交给受控闭包；注入脚本通过 HMAC
+/// 证明请求来自受控粘贴流程。nonce 在 Rust 侧只允许消费一次，避免脚本截获合法
+/// 请求后重复读取剪贴板。
+pub(crate) struct ClipboardBridgeState {
+    secret: [u8; BRIDGE_SECRET_BYTES],
+    used_nonces: Mutex<HashMap<[u8; NONCE_BYTES], Instant>>,
+}
+
+impl ClipboardBridgeState {
+    /// 使用操作系统随机源创建一次会话密钥；随机源不可用时拒绝启动桥接能力。
+    pub(crate) fn new() -> Result<Self, String> {
+        let mut secret = [0u8; BRIDGE_SECRET_BYTES];
+        getrandom::fill(&mut secret)
+            .map_err(|e| format!("CLIPBOARD_BRIDGE_INIT: secure random unavailable: {e}"))?;
+        Ok(Self {
+            secret,
+            used_nonces: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// 返回注入脚本使用的会话密钥编码，不暴露给 iframe 页面脚本的全局作用域。
+    pub(crate) fn script_secret(&self) -> String {
+        STANDARD.encode(self.secret)
+    }
+
+    /// 校验并消费一次剪贴板请求凭证。
+    pub(crate) fn verify_and_consume(
+        &self,
+        nonce: &str,
+        issued_at: u64,
+        proof: &str,
+    ) -> Result<(), String> {
+        let nonce_bytes = decode_nonce(nonce)?;
+        let proof_bytes = STANDARD
+            .decode(proof)
+            .map_err(|_| "CLIPBOARD_AUTH_INVALID: malformed proof".to_string())?;
+        if proof_bytes.len() != PROOF_BYTES {
+            return Err("CLIPBOARD_AUTH_INVALID: malformed proof".to_string());
+        }
+
+        let expected = self.expected_proof(nonce, issued_at);
+        if !constant_time_equal(&expected, &proof_bytes) {
+            return Err("CLIPBOARD_AUTH_INVALID: invalid proof".to_string());
+        }
+        if !timestamp_is_fresh(issued_at) {
+            return Err("CLIPBOARD_NONCE_EXPIRED: request timestamp is stale".to_string());
+        }
+
+        let now = Instant::now();
+        let mut used_nonces = self
+            .used_nonces
+            .lock()
+            .map_err(|_| "CLIPBOARD_AUTH_STATE: lock poisoned".to_string())?;
+        used_nonces.retain(|_, used_at| now.duration_since(*used_at) < NONCE_TTL);
+        if used_nonces.contains_key(&nonce_bytes) {
+            return Err("CLIPBOARD_NONCE_REPLAY: request already consumed".to_string());
+        }
+        if used_nonces.len() >= MAX_USED_NONCES {
+            return Err("CLIPBOARD_RATE_LIMITED: too many pending requests".to_string());
+        }
+        used_nonces.insert(nonce_bytes, now);
+        Ok(())
+    }
+
+    fn expected_proof(&self, nonce: &str, issued_at: u64) -> [u8; PROOF_BYTES] {
+        let mut mac = HmacSha256::new_from_slice(&self.secret).expect("fixed-size HMAC key");
+        mac.update(SIGNING_CONTEXT);
+        mac.update(nonce.as_bytes());
+        mac.update(b":");
+        mac.update(issued_at.to_string().as_bytes());
+        let digest = mac.finalize().into_bytes();
+        let mut proof = [0u8; PROOF_BYTES];
+        proof.copy_from_slice(&digest);
+        proof
+    }
+}
+
+fn timestamp_is_fresh(issued_at: u64) -> bool {
+    let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+        return false;
+    };
+    let now_millis = now.as_millis();
+    let issued_at = u128::from(issued_at);
+    now_millis.abs_diff(issued_at) <= NONCE_TTL.as_millis()
+}
+
+fn decode_nonce(value: &str) -> Result<[u8; NONCE_BYTES], String> {
+    if value.len() != NONCE_HEX_LEN {
+        return Err("CLIPBOARD_NONCE_INVALID: malformed nonce".to_string());
+    }
+    let bytes = value.as_bytes();
+    let mut nonce = [0u8; NONCE_BYTES];
+    for index in 0..NONCE_BYTES {
+        let high = hex_value(bytes[index * 2])
+            .ok_or_else(|| "CLIPBOARD_NONCE_INVALID: malformed nonce".to_string())?;
+        let low = hex_value(bytes[index * 2 + 1])
+            .ok_or_else(|| "CLIPBOARD_NONCE_INVALID: malformed nonce".to_string())?;
+        nonce[index] = (high << 4) | low;
+    }
+    Ok(nonce)
+}
+
+fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn constant_time_equal(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0u8;
+    for (left, right) in left.iter().zip(right) {
+        difference |= left ^ right;
+    }
+    difference == 0
+}
 
 /// 剪贴板图片读取结果：自包含的 PNG data URL（可直接作为 Blob/File 来源）。
 #[derive(serde::Serialize)]
@@ -22,8 +162,14 @@ pub struct ClipboardImageResponse {
 /// 剪贴板无图片时返回 `Ok(None)`；读取/编码失败返回 `Err`（前缀 `CLIPBOARD_IMAGE_`）。
 #[tauri::command]
 pub async fn read_clipboard_image(
-    _app: tauri::AppHandle,
+    app: tauri::AppHandle,
+    nonce: String,
+    issued_at: u64,
+    proof: String,
 ) -> Result<Option<ClipboardImageResponse>, String> {
+    app.state::<ClipboardBridgeState>()
+        .verify_and_consume(&nonce, issued_at, &proof)?;
+
     // arboard 的 Clipboard::new()/get_image() 是阻塞调用（Linux 上需连接显示服务器），
     // 放到 blocking 线程避免阻塞异步运行时与 UI。
     let result =
@@ -76,4 +222,66 @@ pub async fn read_clipboard_image(
         .map_err(|e| format!("CLIPBOARD_IMAGE_TASK: {e}"))??;
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nonce_is_single_use() {
+        let state = ClipboardBridgeState::new().unwrap();
+        let nonce = "0123456789abcdef0123456789abcdef";
+        let issued_at = current_timestamp_millis();
+        let proof = STANDARD.encode(state.expected_proof(nonce, issued_at));
+
+        state.verify_and_consume(nonce, issued_at, &proof).unwrap();
+        let error = state
+            .verify_and_consume(nonce, issued_at, &proof)
+            .unwrap_err();
+        assert!(error.starts_with("CLIPBOARD_NONCE_REPLAY:"));
+    }
+
+    #[test]
+    fn forged_proof_does_not_consume_nonce() {
+        let state = ClipboardBridgeState::new().unwrap();
+        let nonce = "abcdefabcdefabcdefabcdefabcdefab";
+        let issued_at = current_timestamp_millis();
+        let proof = STANDARD.encode(state.expected_proof(nonce, issued_at));
+
+        assert!(state
+            .verify_and_consume(nonce, issued_at, "invalid")
+            .is_err());
+        state.verify_and_consume(nonce, issued_at, &proof).unwrap();
+    }
+
+    #[test]
+    fn malformed_nonce_is_rejected() {
+        let state = ClipboardBridgeState::new().unwrap();
+        let proof = STANDARD.encode([0u8; PROOF_BYTES]);
+
+        assert!(state
+            .verify_and_consume("not-a-nonce", current_timestamp_millis(), &proof)
+            .is_err());
+    }
+
+    #[test]
+    fn stale_timestamp_is_rejected() {
+        let state = ClipboardBridgeState::new().unwrap();
+        let nonce = "0123456789abcdef0123456789abcdef";
+        let issued_at = current_timestamp_millis().saturating_sub(NONCE_TTL.as_millis() as u64 + 1);
+        let proof = STANDARD.encode(state.expected_proof(nonce, issued_at));
+
+        let error = state
+            .verify_and_consume(nonce, issued_at, &proof)
+            .unwrap_err();
+        assert!(error.starts_with("CLIPBOARD_NONCE_EXPIRED:"));
+    }
+
+    fn current_timestamp_millis() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+    }
 }

--- a/src-tauri/src/bridge/plugin.rs
+++ b/src-tauri/src/bridge/plugin.rs
@@ -134,15 +134,14 @@ pub fn report_plugin_error(
     app_handle: AppHandle,
     id: String,
     error: String,
-    action: Option<String>,
+    _action: Option<String>,
 ) -> Result<(), String> {
-    plugin::errors::record(
-        &app_handle,
-        &id,
-        action.as_deref().unwrap_or("runtime"),
-        &error,
-    )?;
+    plugin::errors::record_runtime(&app_handle, &id, &error)?;
     plugin::watch::force_emit(&app_handle);
+    if plugin::recovery::is_internal_plugin(&app_handle, &id) {
+        // 内置插件由启动自愈负责恢复，不能向用户提供会失败的卸载修复动作。
+        return Ok(());
+    }
     // 运行期异常：直接推送修复界面（应用仍在运行，前端以醒目对话框呈现）。
     let info = plugin::PluginRecoveryInfo {
         plugins: vec![id],

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -335,7 +335,6 @@ fn sync_macos_fullscreen_menu(window: &tauri::Window<Wry>) {
 pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::WebviewWindow<Wry>> {
     let app_handle = app.clone();
 
-    #[cfg(not(windows))]
     let paste_shim_js = crate::desktop::paste::paste_shim_js(
         &app.state::<crate::bridge::clipboard::ClipboardBridgeState>()
             .script_secret(),
@@ -423,12 +422,13 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
         )
     });
 
-    // 非 Windows（macOS/Linux）没有 WebView2 的 FrameCreated/ContentLoading 流程，
-    // 直接用 Tauri 的 initialization_script_for_all_frames 把兼容桥、通知桥、导航桥、
-    // 样式桥与缩放快捷键桥注入所有 frame（脚本均带幂等守卫，重复注入安全）。
+    // 初始化脚本在文档创建后、页面脚本之前执行，确保剪贴板桥先捕获原生加密 API。
+    // WebView2 底层使用 AddScriptToExecuteOnDocumentCreated，并自动覆盖所有 frame。
     #[cfg(not(windows))]
     let webview_builder = webview_builder
-        .initialization_script_for_all_frames(crate::desktop::compat::ABORT_SIGNAL_ANY_SHIM_JS)
+        .initialization_script_for_all_frames(crate::desktop::compat::ABORT_SIGNAL_ANY_SHIM_JS);
+
+    let webview_builder = webview_builder
         .initialization_script_for_all_frames(crate::desktop::notification::NOTIFICATION_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::nav::NAV_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::style::IFRAME_STYLES_JS)

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -335,6 +335,12 @@ fn sync_macos_fullscreen_menu(window: &tauri::Window<Wry>) {
 pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::WebviewWindow<Wry>> {
     let app_handle = app.clone();
 
+    #[cfg(not(windows))]
+    let paste_shim_js = crate::desktop::paste::paste_shim_js(
+        &app.state::<crate::bridge::clipboard::ClipboardBridgeState>()
+            .script_secret(),
+    );
+
     #[cfg(windows)]
     let _notification_handlers_registered = Arc::new(AtomicBool::new(false));
     #[cfg(windows)]
@@ -426,7 +432,7 @@ pub fn build_main_window(app: &tauri::AppHandle<Wry>) -> tauri::Result<tauri::We
         .initialization_script_for_all_frames(crate::desktop::notification::NOTIFICATION_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::nav::NAV_SHIM_JS)
         .initialization_script_for_all_frames(crate::desktop::style::IFRAME_STYLES_JS)
-        .initialization_script_for_all_frames(crate::desktop::paste::PASTE_SHIM_JS)
+        .initialization_script_for_all_frames(&paste_shim_js)
         .initialization_script_for_all_frames(crate::desktop::plugin_boot::PLUGIN_BOOT_RELOAD_JS)
         .initialization_script_for_all_frames(crate::desktop::zoom::ZOOM_SHORTCUT_BRIDGE_JS);
 
@@ -574,6 +580,10 @@ pub fn handler() -> impl Fn(Invoke<Wry>) -> bool + Send + Sync + 'static {
 // configure tauri builder
 pub fn builder() -> tauri::Builder<tauri::Wry> {
     let builder = tauri::Builder::default()
+        .manage(
+            crate::bridge::clipboard::ClipboardBridgeState::new()
+                .expect("CLIPBOARD_BRIDGE_INIT: secure random unavailable"),
+        )
         .setup(|app| {
             let app_handle = app.handle().clone();
             build_main_window(&app_handle)?;

--- a/src-tauri/src/desktop/compat.rs
+++ b/src-tauri/src/desktop/compat.rs
@@ -8,9 +8,8 @@
 //! `AbortSignal.any is not a function. (In '...', 'AbortSignal.any' is undefined)`。
 //!
 //! 本脚本与 [`crate::desktop::nav::NAV_SHIM_JS`] / [`crate::desktop::style::IFRAME_STYLES_JS`]
-//! 走同一套注入通道（Windows 在 FrameCreated → ContentLoading 时 ExecuteScript，
-//! 其余平台 `initialization_script_for_all_frames`），在 dsh 页面脚本执行之前
-//! 就位，因此主机框架与 iframe 每次重新加载都会自动重建。
+//! 在非 Windows 平台通过 `initialization_script_for_all_frames` 注入，在 dsh 页面脚本
+//! 执行之前就位；Windows WebView2 原生支持 `AbortSignal.any`，无需此兼容桥。
 //!
 //! 实现只用 ES5 兼容的语法（var / function / Array.prototype 方法），
 //! 保证即便在旧 WebKit 的严格模式环境下也能解析执行；带幂等守卫

--- a/src-tauri/src/desktop/nav.rs
+++ b/src-tauri/src/desktop/nav.rs
@@ -4,9 +4,9 @@
 //! 导航栏左侧三个控件（侧边栏切换 / 后退 / 前进）位于 Tauri 宿主文档（`tauri://`），
 //! 而目标页面是跨域的 dsh iframe（`http://127.0.0.1:<port>`），宿主无法直接访问
 //! iframe 的应用内部状态，只能靠 postMessage + 注入脚本桥接。
-//! 本脚本与 [`crate::desktop::notification::NOTIFICATION_SHIM_JS`] 走同一套注入通道
-//! （Windows 在 FrameCreated → ContentLoading 时 ExecuteScript，其余平台
-//! `initialization_script_for_all_frames`），因此 iframe 每次重新加载都会自动重建。
+//! 本脚本与 [`crate::desktop::notification::NOTIFICATION_SHIM_JS`] 走同一套文档创建前
+//! 注入通道（Tauri 的 `initialization_script_for_all_frames`，Windows 底层映射为
+//! WebView2 的 `AddScriptToExecuteOnDocumentCreated`），因此 iframe 每次重新加载都会自动重建。
 //!
 //! 协议（与 dsh-tauri 插件完全一致）：
 //! - 接收 `dsh://sidebar:toggle` / `dsh://page:prev` / `dsh://page:next` 命令；

--- a/src-tauri/src/desktop/notification.rs
+++ b/src-tauri/src/desktop/notification.rs
@@ -289,6 +289,11 @@ pub fn enable_notification_permissions(
         parent: tauri::WebviewWindow<tauri::Wry>,
     ) {
         let parent_for_frame = parent.clone();
+        let clipboard_secret = parent
+            .app_handle()
+            .state::<crate::bridge::clipboard::ClipboardBridgeState>()
+            .script_secret();
+        let paste_shim_js = crate::desktop::paste::paste_shim_js(&clipboard_secret);
         let mut permission_token = 0i64;
 
         let _ = frame3.add_PermissionRequested(
@@ -328,7 +333,7 @@ pub fn enable_notification_permissions(
                     crate::desktop::notification::NOTIFICATION_SHIM_JS,
                     crate::desktop::nav::NAV_SHIM_JS,
                     crate::desktop::style::IFRAME_STYLES_JS,
-                    crate::desktop::paste::PASTE_SHIM_JS,
+                    paste_shim_js.as_str(),
                     crate::desktop::plugin_boot::PLUGIN_BOOT_RELOAD_JS,
                     crate::desktop::zoom::ZOOM_SHORTCUT_BRIDGE_JS,
                 ] {

--- a/src-tauri/src/desktop/notification.rs
+++ b/src-tauri/src/desktop/notification.rs
@@ -153,7 +153,10 @@ pub fn show_native_notification(
     builder.show().map_err(|e| e.to_string())
 }
 
-/// 在 Windows WebView2 中接管 iframe 内的通知请求并注入原生通知桥。
+/// 在 Windows WebView2 中接管 iframe 内的权限请求。
+///
+/// 兼容桥在窗口构建阶段通过文档创建前脚本注入，避免页面脚本先于剪贴板桥改写
+/// Web Crypto API；此处只注册每个 iframe 的权限事件。
 #[cfg(windows)]
 pub fn enable_notification_permissions(
     webview: tauri::webview::PlatformWebview,
@@ -161,8 +164,7 @@ pub fn enable_notification_permissions(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use rfd::{MessageButtons, MessageDialog, MessageDialogResult};
     use webview2_com::{
-        ExecuteScriptCompletedHandler, FrameContentLoadingEventHandler, FrameCreatedEventHandler,
-        FramePermissionRequestedEventHandler,
+        FrameCreatedEventHandler, FramePermissionRequestedEventHandler,
         Microsoft::Web::WebView2::Win32::{
             ICoreWebView2Frame3, ICoreWebView2Profile4, ICoreWebView2_13, ICoreWebView2_4,
             COREWEBVIEW2_PERMISSION_KIND, COREWEBVIEW2_PERMISSION_KIND_AUTOPLAY,
@@ -289,11 +291,6 @@ pub fn enable_notification_permissions(
         parent: tauri::WebviewWindow<tauri::Wry>,
     ) {
         let parent_for_frame = parent.clone();
-        let clipboard_secret = parent
-            .app_handle()
-            .state::<crate::bridge::clipboard::ClipboardBridgeState>()
-            .script_secret();
-        let paste_shim_js = crate::desktop::paste::paste_shim_js(&clipboard_secret);
         let mut permission_token = 0i64;
 
         let _ = frame3.add_PermissionRequested(
@@ -321,31 +318,6 @@ pub fn enable_notification_permissions(
                 Ok(())
             })),
             &mut permission_token,
-        );
-
-        let frame_for_injection = frame3.clone();
-        let mut content_token = 0i64;
-
-        let _ = frame3.add_ContentLoading(
-            &FrameContentLoadingEventHandler::create(Box::new(move |_, _| {
-                // 通知桥、导航桥、样式桥、剪贴板图片桥与缩放快捷键桥需要 iframe 上下文执行。
-                for script in [
-                    crate::desktop::notification::NOTIFICATION_SHIM_JS,
-                    crate::desktop::nav::NAV_SHIM_JS,
-                    crate::desktop::style::IFRAME_STYLES_JS,
-                    paste_shim_js.as_str(),
-                    crate::desktop::plugin_boot::PLUGIN_BOOT_RELOAD_JS,
-                    crate::desktop::zoom::ZOOM_SHORTCUT_BRIDGE_JS,
-                ] {
-                    let script = HSTRING::from(script);
-                    let _ = frame_for_injection.ExecuteScript(
-                        &script,
-                        &ExecuteScriptCompletedHandler::create(Box::new(|_, _| Ok(()))),
-                    );
-                }
-                Ok(())
-            })),
-            &mut content_token,
         );
     }
 

--- a/src-tauri/src/desktop/paste.rs
+++ b/src-tauri/src/desktop/paste.rs
@@ -9,8 +9,8 @@
 //! 贴图路径处理，从而与浏览器行为一致。
 //!
 //! 与 [`crate::desktop::notification::NOTIFICATION_SHIM_JS`] / [`crate::desktop::nav::NAV_SHIM_JS`]
-//! 走同一套注入通道（Windows 在 FrameCreated → ContentLoading 时 ExecuteScript，
-//! 其余平台 `initialization_script_for_all_frames`）。脚本带 `__dsh_clipboard_image_bridge__`
+//! 走同一套文档创建前注入通道（Tauri 的 `initialization_script_for_all_frames`，Windows
+//! 底层映射为 WebView2 的 `AddScriptToExecuteOnDocumentCreated`）。脚本带 `__dsh_clipboard_image_bridge__`
 //! 幂等守卫，重复注入安全；只处理「直接 iframe」发来的剪贴板请求，避免多层 iframe 误转发。
 
 /// 构造带会话密钥的剪贴板回退脚本。

--- a/src-tauri/src/desktop/paste.rs
+++ b/src-tauri/src/desktop/paste.rs
@@ -13,7 +13,15 @@
 //! 其余平台 `initialization_script_for_all_frames`）。脚本带 `__dsh_clipboard_image_bridge__`
 //! 幂等守卫，重复注入安全；只处理「直接 iframe」发来的剪贴板请求，避免多层 iframe 误转发。
 
-pub(crate) const PASTE_SHIM_JS: &str = r#"(function () {
+/// 构造带会话密钥的剪贴板回退脚本。
+///
+/// 密钥只通过初始化脚本交给闭包；脚本在页面代码运行前捕获原生加密 API 并导入
+/// 不可导出的密钥，之后只会在真实粘贴事件里生成 nonce 并计算证明。宿主收到请求后
+/// 还会在 Rust 侧校验 HMAC 和 nonce 的单次消费状态。
+pub(crate) fn paste_shim_js(secret: &str) -> String {
+    let secret_literal =
+        serde_json::to_string(secret).expect("clipboard bridge secret should be serializable");
+    r#"(function () {
   if (window.__dsh_clipboard_image_bridge__) return;
   window.__dsh_clipboard_image_bridge__ = true;
 
@@ -21,21 +29,191 @@ pub(crate) const PASTE_SHIM_JS: &str = r#"(function () {
   var REQ_SRC = 'dsh-clipboard-image-bridge';
   var RES_SRC = 'dsh-desktop-clipboard';
   var REQ_TYPE = 'dsh://clipboard-image:read';
+  var BRIDGE_SECRET_B64 = __DSH_CLIPBOARD_BRIDGE_SECRET__;
+  var SIGNING_CONTEXT = 'dsh-clipboard-image-v1:';
+  var MAX_PENDING = 32;
+  var REQUEST_TIMEOUT_MS = 5000;
+
+  // 初始化脚本先于页面脚本执行；捕获原生引用，避免页面改写 Web Crypto 后
+  // 在真实粘贴发生时截获原始密钥或签名输入。
+  var NativePromise = window.Promise;
+  var NativePromiseThen = NativePromise && NativePromise.prototype && NativePromise.prototype.then;
+  var NativePromiseReject = NativePromise && typeof NativePromise.reject === 'function'
+    ? NativePromise.reject.bind(NativePromise)
+    : null;
+  var NativeUint8Array = window.Uint8Array;
+  var NativeAtob = typeof window.atob === 'function' ? window.atob.bind(window) : null;
+  var NativeBtoa = typeof window.btoa === 'function' ? window.btoa.bind(window) : null;
+  var NativeTextEncoder = window.TextEncoder;
+  var NativeTextEncoderEncode = NativeTextEncoder && NativeTextEncoder.prototype
+    ? NativeTextEncoder.prototype.encode
+    : null;
+  var NativeDate = window.Date;
+  var NativeDateNow = NativeDate && typeof NativeDate.now === 'function'
+    ? NativeDate.now.bind(NativeDate)
+    : null;
+  var NativeString = typeof window.String === 'function' ? window.String : null;
+  var NativeStringFromCharCode = NativeString && typeof NativeString.fromCharCode === 'function'
+    ? NativeString.fromCharCode.bind(NativeString)
+    : null;
+  var NativeSetTimeout = typeof window.setTimeout === 'function'
+    ? window.setTimeout.bind(window)
+    : null;
+  var NativeClearTimeout = typeof window.clearTimeout === 'function'
+    ? window.clearTimeout.bind(window)
+    : null;
+  var NativeCrypto = window.crypto;
+  var NativeGetRandomValues = NativeCrypto && typeof NativeCrypto.getRandomValues === 'function'
+    ? NativeCrypto.getRandomValues.bind(NativeCrypto)
+    : null;
+  var NativeSubtle = NativeCrypto && NativeCrypto.subtle;
+  var NativeImportKey = NativeSubtle && typeof NativeSubtle.importKey === 'function'
+    ? NativeSubtle.importKey.bind(NativeSubtle)
+    : null;
+  var NativeSign = NativeSubtle && typeof NativeSubtle.sign === 'function'
+    ? NativeSubtle.sign.bind(NativeSubtle)
+    : null;
 
   var reqSeq = 0;
-  var pending = {}; // id -> { resolve, target }
+  var hmacKeyPromise = null;
+  var pending = {}; // id -> { resolve, target, timeout }
+
+  function resolvePending(id, value) {
+    var item = pending[id];
+    if (!item) return;
+    delete pending[id];
+    if (NativeClearTimeout && item.timeout !== null) NativeClearTimeout(item.timeout);
+    item.resolve(value);
+  }
+
+  function bytesToHex(bytes) {
+    var result = '';
+    for (var i = 0; i < bytes.length; i++) {
+      result += ('0' + bytes[i].toString(16)).slice(-2);
+    }
+    return result;
+  }
+
+  function bytesToBase64(buffer) {
+    if (!NativeUint8Array || !NativeBtoa || !NativeStringFromCharCode) {
+      throw new Error('clipboard bridge base64 unavailable');
+    }
+    var bytes = new NativeUint8Array(buffer);
+    var binary = '';
+    for (var i = 0; i < bytes.length; i++) binary += NativeStringFromCharCode(bytes[i]);
+    return NativeBtoa(binary);
+  }
+
+  function secretBytes() {
+    if (!NativeAtob || !NativeUint8Array) throw new Error('clipboard bridge secret unavailable');
+    var binary = NativeAtob(BRIDGE_SECRET_B64);
+    var bytes = new NativeUint8Array(binary.length);
+    for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  }
+
+  function newNonce() {
+    if (!NativeGetRandomValues || !NativeUint8Array) return null;
+    var bytes = new NativeUint8Array(16);
+    try {
+      NativeGetRandomValues(bytes);
+      return bytesToHex(bytes);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function rejectedPromise(message) {
+    return NativePromiseReject ? NativePromiseReject(new Error(message)) : null;
+  }
+
+  function signNonce(nonce, issuedAtText) {
+    if (!hmacKeyPromise || !NativePromiseThen || !NativeSign
+      || !NativeTextEncoder || !NativeTextEncoderEncode) {
+      return rejectedPromise('clipboard bridge crypto unavailable');
+    }
+    var encoded;
+    try {
+      encoded = NativeTextEncoderEncode.call(
+        new NativeTextEncoder(),
+        SIGNING_CONTEXT + nonce + ':' + issuedAtText
+      );
+    } catch (_) {
+      return rejectedPromise('clipboard bridge crypto unavailable');
+    }
+    var signed = NativePromiseThen.call(hmacKeyPromise, function (key) {
+      return NativeSign('HMAC', key, encoded);
+    });
+    return NativePromiseThen.call(signed, bytesToBase64);
+  }
+
+  // 在页面脚本有机会改写全局对象前导入密钥；CryptoKey 不可导出，页面只能看到
+  // 后续真实粘贴产生的单次证明，不能借此伪造新的 nonce。
+  if (NativeImportKey && NativePromiseReject) {
+    try {
+      hmacKeyPromise = NativeImportKey(
+        'raw',
+        secretBytes(),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign']
+      );
+    } catch (_) {
+      hmacKeyPromise = rejectedPromise('clipboard bridge crypto unavailable');
+    }
+  }
 
   function requestClipboardImage(target) {
-    return new Promise(function (resolve) {
+    if (!NativePromise || !NativePromiseThen) return null;
+    return new NativePromise(function (resolve) {
+      if (Object.keys(pending).length >= MAX_PENDING) {
+        resolve(null);
+        return;
+      }
       reqSeq += 1;
       var id = 'req-' + reqSeq;
-      pending[id] = { resolve: resolve, target: target };
-      try {
-        window.parent.postMessage({ source: REQ_SRC, type: REQ_TYPE, id: id }, '*');
-      } catch (_) {
-        delete pending[id];
+      var nonce = newNonce();
+      if (!nonce) {
         resolve(null);
+        return;
       }
+      if (!NativeDateNow || !NativeString) {
+        resolve(null);
+        return;
+      }
+      var issuedAt = NativeDateNow();
+      var issuedAtText = NativeString(issuedAt);
+      pending[id] = { resolve: resolve, target: target, timeout: null };
+      if (NativeSetTimeout) {
+        pending[id].timeout = NativeSetTimeout(function () {
+          resolvePending(id, null);
+        }, REQUEST_TIMEOUT_MS);
+      }
+      var signed = signNonce(nonce, issuedAtText);
+      if (!signed) {
+        resolvePending(id, null);
+        return;
+      }
+      NativePromiseThen.call(signed, function (proof) {
+        if (!pending[id]) return;
+        try {
+          window.parent.postMessage(
+            {
+              source: REQ_SRC,
+              type: REQ_TYPE,
+              id: id,
+              nonce: nonce,
+              issued_at: issuedAt,
+              proof: proof
+            },
+            '*'
+          );
+        } catch (_) {
+          resolvePending(id, null);
+        }
+      }, function () {
+        resolvePending(id, null);
+      });
     });
   }
 
@@ -43,10 +221,10 @@ pub(crate) const PASTE_SHIM_JS: &str = r#"(function () {
   window.addEventListener('message', function (event) {
     var data = event.data;
     if (!data || typeof data !== 'object' || data.source !== RES_SRC) return;
+    if (event.source !== window.parent) return;
     var item = pending[data.id];
     if (!item) return;
-    delete pending[data.id];
-    item.resolve(data.data_url || null);
+    resolvePending(data.id, data.data_url || null);
   });
 
   // 剪贴板事件里是否已带图片（非 WebKitGTK 场景）：不介入，交 dsh 自身处理
@@ -135,6 +313,7 @@ pub(crate) const PASTE_SHIM_JS: &str = r#"(function () {
       var dt = event.clipboardData;
       if (hasImageData(dt)) return;
       if (hasTextData(dt)) return;
+      if (event.isTrusted !== true) return;
 
       var target = document.activeElement || event.target;
       if (!isPasteTarget(target)) return;
@@ -145,4 +324,6 @@ pub(crate) const PASTE_SHIM_JS: &str = r#"(function () {
       });
     }, true);
   }
-})();"#;
+})();"#
+        .replace("__DSH_CLIPBOARD_BRIDGE_SECRET__", &secret_literal)
+}

--- a/src-tauri/src/desktop/style.rs
+++ b/src-tauri/src/desktop/style.rs
@@ -1,8 +1,8 @@
 //! 注入到内嵌 dsh iframe 的自定义样式桥。
 //!
 //! 与 [`crate::desktop::nav::NAV_SHIM_JS`] / [`crate::desktop::notification::NOTIFICATION_SHIM_JS`]
-//! 走同一套注入通道（Windows 在 FrameCreated → ContentLoading 时 ExecuteScript，
-//! 其余平台 `initialization_script_for_all_frames`），因此 iframe 每次重新加载都会重建。
+//! 走同一套文档创建前注入通道（Tauri 的 `initialization_script_for_all_frames`，Windows
+//! 底层映射为 WebView2 的 `AddScriptToExecuteOnDocumentCreated`），因此 iframe 每次重新加载都会重建。
 //!
 //! 本脚本只负责把一段内置 CSS 以 `<style>` 元素注入 iframe 文档（幂等：按 id 去重）。
 //! 具体样式写在下方的 `IFRAME_CSS` 模板字符串里（当前是占位，按需填写/替换即可）。

--- a/src-tauri/src/desktop/window.rs
+++ b/src-tauri/src/desktop/window.rs
@@ -71,8 +71,8 @@ pub fn on_page_load(
     notification_handlers_registered_for_page: Arc<AtomicBool>,
 ) {
     // Windows 依赖 WebView2 的 FramePermissionRequested / FrameCreated 机制，
-    // 需要在页面加载时注册；非 Windows 已在 build_main_window 里通过
-    // initialization_script_for_all_frames 注入，这里不需要再做处理。
+    // 需要在页面加载时注册；兼容桥已在 build_main_window 里通过文档创建前的
+    // initialization_script_for_all_frames 注入，这里不需要再做脚本处理。
     if payload.event() == PageLoadEvent::Started
         && !notification_handlers_registered_for_page
             .swap(true, std::sync::atomic::Ordering::SeqCst)

--- a/src-tauri/src/service/plugin/errors.rs
+++ b/src-tauri/src/service/plugin/errors.rs
@@ -12,8 +12,22 @@
 use crate::config;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use tauri::AppHandle;
+
+const MAX_PLUGIN_ID_BYTES: usize = 214;
+const MAX_PLUGIN_ERROR_MESSAGE_CHARS: usize = 2000;
+const MAX_PLUGIN_ERROR_MESSAGE_BYTES: usize = 8192;
+const MAX_PLUGIN_ERROR_ACTION_BYTES: usize = 32;
+const MAX_PLUGIN_ERROR_ENTRIES: usize = 128;
+const MAX_PLUGIN_ERROR_FILE_BYTES: u64 = 2 * 1024 * 1024;
+const RUNTIME_REPORT_WINDOW: Duration = Duration::from_secs(10);
+const MAX_RUNTIME_REPORTS: u32 = 8;
+const MAX_RUNTIME_REPORTS_GLOBAL: u32 = 64;
+const MAX_RUNTIME_TRACKED_IDS: usize = MAX_PLUGIN_ERROR_ENTRIES;
 
 /// 单条插件错误
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -31,12 +45,92 @@ fn errors_path(app_handle: &AppHandle) -> PathBuf {
     config::get_base_dir(app_handle).join("plugin-errors.json")
 }
 
-/// 读取全部错误记录（缺失/损坏按空处理）
+fn storage_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn runtime_rate_lock() -> &'static Mutex<HashMap<String, RuntimeRate>> {
+    static LIMITER: OnceLock<Mutex<HashMap<String, RuntimeRate>>> = OnceLock::new();
+    LIMITER.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[derive(Clone, Copy)]
+struct RuntimeRate {
+    window_started: Instant,
+    count: u32,
+}
+
+fn validate_plugin_id(id: &str) -> Result<(), String> {
+    if id.is_empty() || id != id.trim() || id.len() > MAX_PLUGIN_ID_BYTES {
+        return Err("PLUGIN_ERROR_INVALID_ID: invalid plugin id".to_string());
+    }
+    if !super::recovery::is_package_name(id) {
+        return Err("PLUGIN_ERROR_INVALID_ID: invalid plugin id".to_string());
+    }
+    Ok(())
+}
+
+fn validate_action(action: &str) -> Result<(), String> {
+    if action.len() > MAX_PLUGIN_ERROR_ACTION_BYTES
+        || !matches!(action, "install" | "update" | "remove" | "runtime")
+    {
+        return Err("PLUGIN_ERROR_INVALID_ACTION: unsupported action".to_string());
+    }
+    Ok(())
+}
+
+fn validate_message(message: &str) -> Result<(), String> {
+    if message.len() > MAX_PLUGIN_ERROR_MESSAGE_BYTES
+        || message.chars().count() > MAX_PLUGIN_ERROR_MESSAGE_CHARS
+    {
+        return Err("PLUGIN_ERROR_TOO_LARGE: error message exceeds the limit".to_string());
+    }
+    Ok(())
+}
+
+fn validate_record_input(id: &str, action: &str, message: &str) -> Result<(), String> {
+    validate_plugin_id(id)?;
+    validate_action(action)?;
+    validate_message(message)
+}
+
+/// 读取全部错误记录（缺失、损坏、超限或不符合格式的记录按空/过滤处理）。
 pub(crate) fn load(app_handle: &AppHandle) -> HashMap<String, PluginError> {
-    let Ok(content) = std::fs::read_to_string(errors_path(app_handle)) else {
+    let path = errors_path(app_handle);
+    let Ok(metadata) = std::fs::metadata(&path) else {
         return HashMap::new();
     };
-    serde_json::from_str(&content).unwrap_or_default()
+    if metadata.len() > MAX_PLUGIN_ERROR_FILE_BYTES {
+        log::warn!(
+            "plugin error registry exceeds {} bytes: {}",
+            MAX_PLUGIN_ERROR_FILE_BYTES,
+            path.display()
+        );
+        return HashMap::new();
+    }
+    let Ok(file) = std::fs::File::open(path) else {
+        return HashMap::new();
+    };
+    let mut content = Vec::new();
+    if file
+        .take(MAX_PLUGIN_ERROR_FILE_BYTES.saturating_add(1))
+        .read_to_end(&mut content)
+        .is_err()
+        || content.len() as u64 > MAX_PLUGIN_ERROR_FILE_BYTES
+    {
+        return HashMap::new();
+    }
+    let Ok(content) = String::from_utf8(content) else {
+        return HashMap::new();
+    };
+    let Ok(map) = serde_json::from_str::<HashMap<String, PluginError>>(&content) else {
+        return HashMap::new();
+    };
+    map.into_iter()
+        .filter(|(id, error)| validate_record_input(id, &error.action, &error.message).is_ok())
+        .take(MAX_PLUGIN_ERROR_ENTRIES)
+        .collect()
 }
 
 fn save(app_handle: &AppHandle, map: &HashMap<String, PluginError>) -> Result<(), String> {
@@ -46,28 +140,143 @@ fn save(app_handle: &AppHandle, map: &HashMap<String, PluginError>) -> Result<()
     }
     let json =
         serde_json::to_string_pretty(map).map_err(|e| format!("PLUGIN_ERRORS_RENDER: {e}"))?;
-    std::fs::write(&path, json).map_err(|e| format!("PLUGIN_ERRORS_WRITE: {e}"))
+    if (json.len() + 1) as u64 > MAX_PLUGIN_ERROR_FILE_BYTES {
+        return Err("PLUGIN_ERRORS_LIMIT: registry exceeds the size limit".to_string());
+    }
+
+    // 先写同目录临时文件，再替换目标，避免进程中断时留下半个 JSON 文件。
+    let temp_path = path.with_file_name(format!(".plugin-errors.{}.tmp", std::process::id()));
+    if let Err(error) = std::fs::write(&temp_path, format!("{json}\n")) {
+        return Err(format!("PLUGIN_ERRORS_WRITE: {error}"));
+    }
+    if let Err(error) = replace_file(&temp_path, &path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(error);
+    }
+    Ok(())
 }
 
-/// 记录插件错误（同 id 幂等覆盖）
-pub fn record(app_handle: &AppHandle, id: &str, action: &str, message: &str) -> Result<(), String> {
-    let mut map = load(app_handle);
+#[cfg(not(windows))]
+fn replace_file(temp_path: &std::path::Path, path: &std::path::Path) -> Result<(), String> {
+    std::fs::rename(temp_path, path).map_err(|e| format!("PLUGIN_ERRORS_REPLACE: {e}"))
+}
+
+#[cfg(windows)]
+fn replace_file(temp_path: &std::path::Path, path: &std::path::Path) -> Result<(), String> {
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let temp_path: Vec<u16> = temp_path.as_os_str().encode_wide().chain(once(0)).collect();
+    let path: Vec<u16> = path.as_os_str().encode_wide().chain(once(0)).collect();
+    let result = unsafe {
+        MoveFileExW(
+            temp_path.as_ptr(),
+            path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        Err(format!(
+            "PLUGIN_ERRORS_REPLACE: {}",
+            std::io::Error::last_os_error()
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn insert_record(
+    map: &mut HashMap<String, PluginError>,
+    id: &str,
+    action: &str,
+    message: &str,
+    at: String,
+) -> Result<(), String> {
+    validate_record_input(id, action, message)?;
+    if !map.contains_key(id) && map.len() >= MAX_PLUGIN_ERROR_ENTRIES {
+        return Err("PLUGIN_ERRORS_LIMIT: registry entry limit reached".to_string());
+    }
     map.insert(
         id.to_string(),
         PluginError {
-            message: message.trim().to_string(),
+            message: message.to_string(),
             action: action.to_string(),
-            at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs().to_string())
-                .unwrap_or_default(),
+            at,
         },
     );
+    Ok(())
+}
+
+fn current_timestamp() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_default()
+}
+
+/// 记录插件错误（同 id 幂等覆盖，输入和注册表均有界）。
+pub fn record(app_handle: &AppHandle, id: &str, action: &str, message: &str) -> Result<(), String> {
+    validate_record_input(id, action, message)?;
+    let _guard = storage_lock()
+        .lock()
+        .map_err(|_| "PLUGIN_ERRORS_STATE: lock poisoned".to_string())?;
+    let mut map = load(app_handle);
+    insert_record(&mut map, id, action, message.trim(), current_timestamp())?;
     save(app_handle, &map)
+}
+
+fn allow_runtime_report(id: &str) -> Result<(), String> {
+    let now = Instant::now();
+    let mut limiter = runtime_rate_lock()
+        .lock()
+        .map_err(|_| "PLUGIN_ERRORS_STATE: rate limiter lock poisoned".to_string())?;
+    limiter.retain(|_, rate| now.duration_since(rate.window_started) < RUNTIME_REPORT_WINDOW);
+
+    let total_reports: u32 = limiter.values().map(|rate| rate.count).sum();
+    if total_reports >= MAX_RUNTIME_REPORTS_GLOBAL {
+        return Err("PLUGIN_ERROR_RATE_LIMITED: too many runtime reports".to_string());
+    }
+
+    if let Some(rate) = limiter.get_mut(id) {
+        if rate.count >= MAX_RUNTIME_REPORTS {
+            return Err("PLUGIN_ERROR_RATE_LIMITED: too many runtime reports".to_string());
+        }
+        rate.count += 1;
+        return Ok(());
+    }
+    if limiter.len() >= MAX_RUNTIME_TRACKED_IDS {
+        return Err("PLUGIN_ERROR_RATE_LIMITED: too many runtime reporters".to_string());
+    }
+    limiter.insert(
+        id.to_string(),
+        RuntimeRate {
+            window_started: now,
+            count: 1,
+        },
+    );
+    Ok(())
+}
+
+/// 记录来自 iframe 的运行期错误：必须是已安装插件，并限制短时间内的上报次数。
+pub fn record_runtime(app_handle: &AppHandle, id: &str, message: &str) -> Result<(), String> {
+    validate_record_input(id, "runtime", message)?;
+    if !super::installed::is_installed(app_handle, id) {
+        return Err("PLUGIN_ERROR_UNKNOWN_ID: plugin is not installed".to_string());
+    }
+    // 只有确认属于当前 profile 的插件后才消耗配额，避免未知 id 影响真实插件上报。
+    allow_runtime_report(id)?;
+    record(app_handle, id, "runtime", message)
 }
 
 /// 清除插件错误（安装/升级/卸载成功后）
 pub fn clear(app_handle: &AppHandle, id: &str) -> Result<(), String> {
+    validate_plugin_id(id)?;
+    let _guard = storage_lock()
+        .lock()
+        .map_err(|_| "PLUGIN_ERRORS_STATE: lock poisoned".to_string())?;
     let mut map = load(app_handle);
     if map.remove(id).is_some() {
         save(app_handle, &map)?;
@@ -97,5 +306,59 @@ mod tests {
             back.get("dshmarket").unwrap().message,
             "ERR_PNPM_IGNORED_BUILDS"
         );
+    }
+
+    #[test]
+    fn record_input_is_bounded_and_typed() {
+        assert!(validate_record_input("dshmarket", "runtime", "failure").is_ok());
+        assert!(validate_record_input("not a package", "runtime", "failure").is_err());
+        assert!(validate_record_input("dshmarket", "unknown", "failure").is_err());
+        assert!(validate_record_input(
+            "dshmarket",
+            "runtime",
+            &"x".repeat(MAX_PLUGIN_ERROR_MESSAGE_CHARS + 1)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn registry_entry_limit_is_enforced() {
+        let mut map = HashMap::new();
+        for index in 0..MAX_PLUGIN_ERROR_ENTRIES {
+            let id = format!("dsh-test-plugin-{index}");
+            insert_record(
+                &mut map,
+                &id,
+                "runtime",
+                "failure",
+                "1700000000".to_string(),
+            )
+            .unwrap();
+        }
+        assert!(insert_record(
+            &mut map,
+            "dsh-test-plugin-overflow",
+            "runtime",
+            "failure",
+            "1700000000".to_string(),
+        )
+        .is_err());
+        insert_record(
+            &mut map,
+            "dsh-test-plugin-0",
+            "runtime",
+            "updated",
+            "1700000001".to_string(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn runtime_reports_have_a_global_window_limit() {
+        let prefix = format!("dsh-test-runtime-{}", std::process::id());
+        for index in 0..MAX_RUNTIME_REPORTS_GLOBAL {
+            allow_runtime_report(&format!("{prefix}-{index}")).unwrap();
+        }
+        assert!(allow_runtime_report(&format!("{prefix}-overflow")).is_err());
     }
 }

--- a/src-tauri/src/service/plugin/recovery/mod.rs
+++ b/src-tauri/src/service/plugin/recovery/mod.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 
 use super::errors;
+use super::installed::{installed_name, is_installed};
 
 use extract::{
     classify_reason, extract_duplicate_loader_entry, extract_plugin_refs, extract_slot_conflict,
@@ -51,7 +52,7 @@ fn is_core_package(name: &str) -> bool {
 }
 
 /// 是否为合法的 npm 包名（可带 scope）。用于过滤日志里提取到的候选引用。
-fn is_package_name(s: &str) -> bool {
+pub(crate) fn is_package_name(s: &str) -> bool {
     let s = s.trim();
     if s.is_empty() || s.contains(':') || s.chars().any(|c| c.is_whitespace()) {
         return false;
@@ -97,6 +98,14 @@ fn is_package_name(s: &str) -> bool {
 /// 是否是可行动的第三方插件引用（排除核心包与 @deepseek-ai 官方包）。
 pub(crate) fn is_actionable_plugin_ref(s: &str) -> bool {
     is_package_name(s) && !is_core_package(s.trim())
+}
+
+/// 判断插件是否来自随应用分发的内置清单；内置插件由启动自愈恢复，不能走卸载修复。
+pub(crate) fn is_internal_plugin(app_handle: &AppHandle, id: &str) -> bool {
+    super::preset::load_presets(app_handle)
+        .into_iter()
+        .filter(|preset| preset.internal)
+        .any(|preset| installed_name(&preset) == id)
 }
 
 /// 启动失败时前端读到的日志行（已清洗 ANSI），序列化给前端（camelCase）。
@@ -161,6 +170,16 @@ pub fn uninstall(app_handle: &AppHandle, id: &str) -> Result<(), String> {
     if !is_actionable_plugin_ref(id) {
         return Err(format!(
             "PLUGIN_RECOVERY_REFUSED: refusing to remove core/official package {id}"
+        ));
+    }
+    if !is_installed(app_handle, id) {
+        return Err(format!(
+            "PLUGIN_RECOVERY_UNKNOWN_PLUGIN: plugin is not installed: {id}"
+        ));
+    }
+    if is_internal_plugin(app_handle, id) {
+        return Err(format!(
+            "PLUGIN_RECOVERY_REFUSED: refusing to remove internal package {id}"
         ));
     }
     let profile = profile_dir(app_handle);

--- a/src/hooks/use-iframe-shim.ts
+++ b/src/hooks/use-iframe-shim.ts
@@ -26,12 +26,10 @@ interface PluginErrorMessage {
   id?: string
   /** 异常消息 */
   error?: string
-  /** 记录动作：runtime / install / update（默认 runtime） */
-  action?: string
 }
 
 /**
- * iframe 剪贴板图片回退请求（desktop/paste::PASTE_SHIM_JS 发来）。
+ * iframe 剪贴板图片回退请求（由 desktop/paste 的受保护脚本发来）。
  * Linux/WebKitGTK 下 dsh iframe 的 paste 事件拿不到图片，宿主侧据此调用
  * `read_clipboard_image` 读系统剪贴板，再把 PNG data URL 回传给 iframe 重新贴图。
  */
@@ -39,6 +37,19 @@ interface ClipboardImageRequest {
   source?: 'dsh-clipboard-image-bridge'
   type?: 'dsh://clipboard-image:read'
   id?: string
+  nonce?: string
+  issued_at?: number
+  proof?: string
+}
+
+const MAX_PLUGIN_ERROR_ID_BYTES = 214
+const MAX_PLUGIN_ERROR_MESSAGE_CHARS = 2000
+const MAX_PLUGIN_ERROR_MESSAGE_BYTES = 8192
+
+function isBoundedPluginErrorText(value: string, maxChars: number, maxBytes: number) {
+  return value.length > 0
+    && value.length <= maxChars
+    && new TextEncoder().encode(value).byteLength <= maxBytes
 }
 
 interface PluginBootMessage {
@@ -94,13 +105,22 @@ export function useIframeShim(iframeRef: RefObject<HTMLIFrameElement | null>) {
     if (!iframeOrigin || event.origin !== iframeOrigin) {
       return
     }
-    if (data.type !== 'dsh://plugin-error' || !data.id || !data.error) {
+    if (
+      data.type !== 'dsh://plugin-error'
+      || typeof data.id !== 'string'
+      || typeof data.error !== 'string'
+      || !isBoundedPluginErrorText(data.id, MAX_PLUGIN_ERROR_ID_BYTES, MAX_PLUGIN_ERROR_ID_BYTES)
+      || !isBoundedPluginErrorText(
+        data.error,
+        MAX_PLUGIN_ERROR_MESSAGE_CHARS,
+        MAX_PLUGIN_ERROR_MESSAGE_BYTES,
+      )
+    ) {
       return
     }
     void invoke('report_plugin_error', {
       id: data.id,
       error: data.error,
-      action: data.action ?? 'runtime',
     })
       .then(() => {
         void queryClient.invalidateQueries({ queryKey: ['plugins'] })
@@ -123,11 +143,24 @@ export function useIframeShim(iframeRef: RefObject<HTMLIFrameElement | null>) {
     if (!iframeOrigin || event.origin !== iframeOrigin) {
       return
     }
-    if (data.type !== 'dsh://clipboard-image:read' || !data.id) {
+    if (
+      data.type !== 'dsh://clipboard-image:read'
+      || typeof data.id !== 'string'
+      || typeof data.nonce !== 'string'
+      || typeof data.issued_at !== 'number'
+      || typeof data.proof !== 'string'
+      || data.nonce.length !== 32
+      || !Number.isSafeInteger(data.issued_at)
+      || data.issued_at <= 0
+      || data.proof.length !== 44
+    ) {
       return
     }
     // 在闭包外把收窄后的值固定到局部常量，避免 TS 在闭包内丢失控制流收窄
     const reqId = data.id
+    const nonce = data.nonce
+    const issuedAt = data.issued_at
+    const proof = data.proof
     const origin = iframeOrigin
     function reply(dataUrl: string | null) {
       iframeRef.current?.contentWindow?.postMessage(
@@ -135,7 +168,11 @@ export function useIframeShim(iframeRef: RefObject<HTMLIFrameElement | null>) {
         origin,
       )
     }
-    void invoke<{ data_url?: string } | null>('read_clipboard_image')
+    void invoke<{ data_url?: string } | null>('read_clipboard_image', {
+      nonce,
+      issued_at: issuedAt,
+      proof,
+    })
       .then(result => reply(result?.data_url ?? null))
       .catch((error) => {
         console.error('[clipboard-image] read_clipboard_image failed:', error)

--- a/src/hooks/use-iframe-shim.ts
+++ b/src/hooks/use-iframe-shim.ts
@@ -170,7 +170,7 @@ export function useIframeShim(iframeRef: RefObject<HTMLIFrameElement | null>) {
     }
     void invoke<{ data_url?: string } | null>('read_clipboard_image', {
       nonce,
-      issued_at: issuedAt,
+      issuedAt,
       proof,
     })
       .then(result => reply(result?.data_url ?? null))

--- a/test/security-bridges.test.ts
+++ b/test/security-bridges.test.ts
@@ -23,9 +23,26 @@ describe('secure desktop bridges', () => {
       '        .initialization_script_for_all_frames(crate::desktop::notification::NOTIFICATION_SHIM_JS)',
     ].join('\n')
 
+    expect(builderSource).toContain(
+      'let paste_shim_js = crate::desktop::paste::paste_shim_js(',
+    )
+    expect(builderSource).toContain(
+      '        .initialization_script_for_all_frames(&paste_shim_js)',
+    )
+
+    const pasteShimCreation = builderSource.indexOf(
+      'let paste_shim_js = crate::desktop::paste::paste_shim_js(',
+    )
+    const pasteShimRegistration = builderSource.indexOf(
+      '.initialization_script_for_all_frames(&paste_shim_js)',
+    )
+    const builderBuild = builderSource.indexOf('let webview_window = webview_builder.build()?')
+
     expect(builderSource).not.toContain(lateWindowsRegistration)
     expect(notificationSource).not.toContain('FrameContentLoadingEventHandler')
     expect(notificationSource).not.toContain('ExecuteScriptCompletedHandler')
+    expect(pasteShimCreation).toBeLessThan(pasteShimRegistration)
+    expect(pasteShimRegistration).toBeLessThan(builderBuild)
   })
 
   it('uses camelCase for the Tauri issuedAt command argument', () => {

--- a/test/security-bridges.test.ts
+++ b/test/security-bridges.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const builderSource = readFileSync(
+  new URL('../src-tauri/src/desktop/builder.rs', import.meta.url),
+  'utf8',
+)
+const notificationSource = readFileSync(
+  new URL('../src-tauri/src/desktop/notification.rs', import.meta.url),
+  'utf8',
+)
+const iframeShimSource = readFileSync(
+  new URL('../src/hooks/use-iframe-shim.ts', import.meta.url),
+  'utf8',
+)
+
+describe('secure desktop bridges', () => {
+  it('registers Windows bridge scripts before page scripts run', () => {
+    const lateWindowsRegistration = [
+      '#[cfg(not(windows))]',
+      '    let webview_builder = webview_builder',
+      '        .initialization_script_for_all_frames(crate::desktop::compat::ABORT_SIGNAL_ANY_SHIM_JS)',
+      '        .initialization_script_for_all_frames(crate::desktop::notification::NOTIFICATION_SHIM_JS)',
+    ].join('\n')
+
+    expect(builderSource).not.toContain(lateWindowsRegistration)
+    expect(notificationSource).not.toContain('FrameContentLoadingEventHandler')
+    expect(notificationSource).not.toContain('ExecuteScriptCompletedHandler')
+  })
+
+  it('uses camelCase for the Tauri issuedAt command argument', () => {
+    expect(iframeShimSource).toContain('      issuedAt,\n      proof,')
+    expect(iframeShimSource).not.toContain('issued_at: issuedAt')
+  })
+})


### PR DESCRIPTION
## Summary

- Protect the iframe clipboard image bridge with a per-session HMAC proof, fresh single-use nonces, trusted paste checks, and bounded pending requests.
- Bound and rate-limit runtime plugin error reports, validate plugin identifiers and messages, and cap the persisted error registry.
- Restrict recovery uninstall to installed, actionable third-party plugins and write the registry through an atomic replacement.
- Rebased the security commit onto the latest upstream main so the PR is mergeable.

## Verification

- cargo test --manifest-path src-tauri/Cargo.toml: 408 passed
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets: exit 0; warnings only
- pnpm typecheck: exit 0
- pnpm test --run: 152 passed in 19 files
- pnpm lint: exit 0; warnings only
- rustfmt --edition 2021 --check on all changed Rust files: exit 0
- git diff --check: exit 0
- Full cargo fmt --check reports pre-existing formatting differences in unrelated upstream files
- Windows x86_64-pc-windows-msvc check was attempted but this macOS host does not have that Rust target standard library installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Secured clipboard image access with authenticated, time-limited requests to help prevent unauthorized and replayed clipboard reads.
  - Improved protection for paste handling and embedded content communication.

- **Bug Fixes**
  - Improved plugin error reporting with validation, storage limits, and rate limiting.
  - Prevented recovery prompts for internal plugin failures.
  - Blocked removal of built-in or unavailable plugins.
  - Improved consistency of embedded-content bridges across platforms.

- **Reliability**
  - Added safer handling for malformed plugin errors and clipboard requests.
  - Improved startup safeguards when secure initialization is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->