### PR TITLE
fix(install): 进度百分比越过 100% 导致首装界面卡在 117%

### DIFF
--- a/src-tauri/src/service/download/progress.rs
+++ b/src-tauri/src/service/download/progress.rs
@@ -70,9 +70,7 @@ impl<'a, R: Runtime> ProgressTracker<'a, R> {
 
         *last_emit = Some(now);
 
-        let phase_weight = 100.0 / self.total_phases as f64;
-        let global_pct =
-            (self.current_phase as f64 * phase_weight) + (stage_pct * phase_weight / 100.0);
+        let global_pct = global_percentage(self.current_phase, self.total_phases, stage_pct);
 
         let _ = self.window.emit(
             "install-progress",
@@ -90,5 +88,78 @@ impl<'a, R: Runtime> ProgressTracker<'a, R> {
     /// 跳过指定数量的阶段
     pub fn skip_phases(&mut self, count: usize) {
         self.current_phase = (self.current_phase + count).min(self.total_phases);
+    }
+}
+
+/// 计算全局安装进度百分比 (0.0 - 100.0)，并永远以 100.0 封顶。
+///
+/// 阶段权重均匀分摊：`current_phase` 个已完成阶段各占 `100/total_phases`，
+/// 当前阶段的 `stage_pct`（0-100）再折算进最后一个权重区间。
+///
+/// 末尾调用方（如 `install.rs` 在全部任务结束后再补一次
+/// `update(100.0, "依赖已安装完毕", "All tasks completed")`）会携带已经等于
+/// `total_phases` 的 `current_phase`；若此刻再把 `stage_pct` 折算进权重，
+/// 会在已完成阶段之外多算一份权重（macOS 6 阶段时得到 `6×(100/6) + 100×(100/6)/100
+/// = 116.7 ≈ 117%`，正是 issue #283 首页「第一次安装卡住」误显示 117% 的根因）。
+/// 因此这里一律把结果钳制到 100.0，避免进度条数值越过 100%。
+fn global_percentage(current_phase: usize, total_phases: usize, stage_pct: f64) -> f64 {
+    if total_phases == 0 {
+        return 100.0;
+    }
+    let phase_weight = 100.0 / total_phases as f64;
+    let global = (current_phase as f64 * phase_weight) + (stage_pct * phase_weight / 100.0);
+    global.clamp(0.0, 100.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::global_percentage;
+
+    #[test]
+    fn clamps_to_100_when_all_phases_done_plus_final_update() {
+        // issue #283：macOS 首装 3 任务 × 2 阶段 = 6 阶段，全部结束后再补一次
+        // update(100.0)。修复前得到 116.7%，界面误显示 117%。
+        let pct = global_percentage(6, 6, 100.0);
+        assert_eq!(pct, 100.0);
+    }
+
+    #[test]
+    fn stays_below_100_mid_phase() {
+        // 当前处于第 0 阶段（download 开始），stage 进度 50% → 6 阶段下应约 8.33%
+        let pct = global_percentage(0, 6, 50.0);
+        assert!((pct - 8.3333).abs() < 1e-3);
+        assert!(pct < 100.0);
+    }
+
+    #[test]
+    fn reaches_100_exactly_at_last_phase_end() {
+        // 最后一个阶段（第 5 个，index 5）完成到 100% → 恰为 100%
+        let pct = global_percentage(5, 6, 100.0);
+        assert_eq!(pct, 100.0);
+    }
+
+    #[test]
+    fn total_phases_one_and_mid() {
+        // 单阶段（total=1）：阶段完成即 100，无越界
+        let done = global_percentage(1, 1, 100.0);
+        assert_eq!(done, 100.0);
+        let half = global_percentage(0, 1, 50.0);
+        assert_eq!(half, 50.0);
+    }
+
+    #[test]
+    fn never_exceeds_100_regardless_of_input() {
+        // 防御性：任何输入组合都不应越过 100
+        for current in 0..=10 {
+            for stage in [0.0, 25.0, 50.0, 75.0, 100.0, 200.0] {
+                let pct = global_percentage(current, 6, stage);
+                assert!(pct <= 100.0, "pct={pct} current={current} stage={stage}");
+            }
+        }
+    }
+
+    #[test]
+    fn degenerate_zero_total_is_safe() {
+        assert_eq!(global_percentage(0, 0, 100.0), 100.0);
     }
 }


### PR DESCRIPTION
## 问题

issue #283 首装界面卡住、进度显示 **117%**、标题停留在「正在解压 pnpm 包管理器」。

## 根因

安装任务全部结束后，`install.rs` 又补发一次 `tracker.update(100.0, "依赖已安装完毕", "All tasks completed")`。此时 `current_phase` 已等于 `total_phases`（macOS 3 任务 × 2 阶段 = 6），而 `progress.rs` 的公式会在已完成阶段之外**多算一份权重**：

```
phase_weight = 100 / 6 ≈ 16.67
global_pct   = 6 × 16.67 + 100 × 16.67 / 100
             = 100 + 16.67 ≈ 116.7 → 显示 117%
```

前端进度条宽度已按 `Math.min(percentage, 100)` 截断，但数值仍输出原始 `Math.round(percentage)` = 117%，于是用户看到进度越过 100% 且安装「看起来卡住」（实际已 `All tasks completed`）。

## 修复

- 把全局百分比计算抽成 `global_percentage`，并统一用 `.clamp(0.0, 100.0)` 钳制，**任何输入组合都不越过 100%**。
- 新增单测：全阶段完成后补发 update、阶段中进度、末阶段 100%、单阶段、以及任意输入不越界的防御性用例。

## 测试

`cargo test --lib service::download::progress` — 6 个用例全部通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress indicators now stop at 100% after completion.
  * Progress calculations remain stable when there are no active phases.
  * Mid-process and single-phase progress reporting is more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->