### PR TITLE
fix(workflow): retry duplicate loader startup on Unix

### DIFF
--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -30,6 +30,19 @@ use super::sweep::{dsh_bin_open_error, relaunch_marker_path, relaunch_via_shell_
 use super::utils::{is_port_in_use, rotate_service_log, spawn_output_readers};
 use super::win_inspector;
 
+#[cfg(windows)]
+type SpawnResult = std::io::Result<(
+    Option<std::fs::File>,
+    Option<std::fs::File>,
+    u32,
+)>;
+#[cfg(unix)]
+type SpawnResult = Result<(
+    Option<std::process::ChildStdout>,
+    Option<std::process::ChildStderr>,
+    u32,
+), String>;
+
 /// 端口释放等待上限：刚结束/清扫过上个会话的残留 dsh 进程后，TCP 端口释放
 /// 存在短暂滞后（taskkill 返回 ≠ 端口已可复用）。等待窗口内端口回落为空闲则
 /// 复用配置端口；到期仍未释放才按“真占用”逐级递增。
@@ -521,7 +534,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     // node 会让 dsh 派生的子进程各自新建可见控制台窗口（频繁闪烁 cmd 黑窗），
     // 因此 Windows 上改用“隐藏控制台”方式启动，见 win_spawn 模块。
     let active_profile = crate::service::profile::active_profile(&app_handle);
-    let spawn_result: Result<(Option<std::process::ChildStdout>, Option<std::process::ChildStderr>, u32), String> = {
+    let spawn_result: SpawnResult = {
         #[cfg(windows)]
         {
             use std::io::{BufReader, Read};

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -719,7 +719,10 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                                     for line in stderr_text.lines() {
                                         log::warn!(target: "dsh", "{}", line);
                                     }
-                                    return Err(format!("Harness exited early: {exit}"));
+                                    return Err(std::io::Error::new(
+                                        std::io::ErrorKind::Other,
+                                        format!("Harness exited early: {exit}"),
+                                    ));
                                 }
                                 Ok(None) if std::time::Instant::now() >= deadline => break,
                                 Ok(None) => {

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -719,10 +719,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                                     for line in stderr_text.lines() {
                                         log::warn!(target: "dsh", "{}", line);
                                     }
-                                    return Err(std::io::Error::new(
-                                        std::io::ErrorKind::Other,
-                                        format!("Harness exited early: {exit}"),
-                                    ));
+                                    return Err(format!("Harness exited early: {exit}"));
                                 }
                                 Ok(None) if std::time::Instant::now() >= deadline => break,
                                 Ok(None) => {

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
 #[cfg(not(windows))]
+use std::io::Read;
+#[cfg(not(windows))]
 use std::process::{Command, Stdio};
 use std::sync::atomic::Ordering;
 
@@ -501,9 +503,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     // alpha 的浏览器会话 Cookie 在沙箱跨源 iframe 上下文无法完成交换，因此桌面端
     // 显式追加 `--skip-auth`：只有核心（经上面的 alpha_auth 补丁，或上游官方合并）
     // 确实支持该标志才传，避免旧核心把未知选项当成错误退出。
-    let skip_auth = crate::service::patch::alpha_auth::web_startup_supports_skip_auth(
-        &app_handle,
-    );
+    let skip_auth = crate::service::patch::alpha_auth::web_startup_supports_skip_auth(&app_handle);
 
     log::info!("Starting Harness process");
 
@@ -669,21 +669,83 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                 .stderr(Stdio::piped())
                 // 独立进程组让停止操作只影响 Harness 及其后代。
                 .process_group(0);
-            cmd.spawn().map(|mut child| {
-                let pid = child.id();
-                let stdout = child.stdout.take();
-                let stderr = child.stderr.take();
-                set_owned_process(pid);
-                let exit_app_handle = app_handle.clone();
-                std::thread::spawn(move || {
-                    let code = child.wait().ok().and_then(|status| status.code());
-                    // 进程确已退出：清空持有 PID 并把 Status 从 Running 回落为 Stopped
-                    // （Unix 无进程句柄可关闭，忽略返回的进程记录）。
-                    // 仅当该 PID 仍是当前登记才取出——旧监视线程不会误清新进程。
-                    let _ = on_owned_process_exit(&exit_app_handle, pid, |_| code.map(i64::from));
-                });
-                (stdout, stderr, pid)
-            })
+            let mut attempt = 0u32;
+            let mut child = 'attempts: loop {
+                attempt += 1;
+                match cmd.spawn() {
+                    Ok(mut child) => {
+                        let deadline =
+                            std::time::Instant::now() + std::time::Duration::from_millis(2500);
+                        loop {
+                            match child.try_wait() {
+                                Ok(Some(exit)) => {
+                                    let mut stderr_text = String::new();
+                                    if let Some(mut stderr) = child.stderr.take() {
+                                        let _ = stderr.read_to_string(&mut stderr_text);
+                                    }
+                                    if exit.code() == Some(1)
+                                        && stderr_text.contains("duplicate loader entry")
+                                        && attempt < 3
+                                    {
+                                        log::warn!(
+                                            "DUPLICATE_LOADER_ENTRY: dsh exited early with duplicate loader entry \
+                                             (pid={}, code=1); resetting profile root and relaunching \
+                                             (attempt {attempt}/3)",
+                                            child.id()
+                                        );
+                                        reset_active_profile_root(&app_handle);
+                                        cmd = Command::new(&node_binary_path);
+                                        cmd.arg(&dsh_binary_path)
+                                            .arg("--profile")
+                                            .arg(active_profile.as_str())
+                                            .arg("--host")
+                                            .arg("127.0.0.1")
+                                            .arg("--port")
+                                            .arg(setting.port.to_string());
+                                        if no_open {
+                                            cmd.arg("--no-open");
+                                        }
+                                        if skip_auth {
+                                            cmd.arg("--skip-auth");
+                                        }
+                                        cmd.envs(&envs)
+                                            .current_dir(config::get_dsh_install_path(&app_handle))
+                                            .stdin(Stdio::null())
+                                            .stdout(Stdio::piped())
+                                            .stderr(Stdio::piped())
+                                            .process_group(0);
+                                        continue 'attempts;
+                                    }
+                                    for line in stderr_text.lines() {
+                                        log::warn!(target: "dsh", "{}", line);
+                                    }
+                                    return Err(std::io::Error::new(
+                                        std::io::ErrorKind::Other,
+                                        format!("Harness exited early: {exit}"),
+                                    ));
+                                }
+                                Ok(None) if std::time::Instant::now() >= deadline => break,
+                                Ok(None) => {
+                                    std::thread::sleep(std::time::Duration::from_millis(50))
+                                }
+                                Err(error) => return Err(error),
+                            }
+                        }
+                        break child;
+                    }
+                    Err(error) => return Err(error),
+                }
+            };
+            let pid = child.id();
+            let stdout = child.stdout.take();
+            let stderr = child.stderr.take();
+            set_owned_process(pid);
+            let exit_app_handle = app_handle.clone();
+            std::thread::spawn(move || {
+                let code = child.wait().ok().and_then(|status| status.code());
+                let _ = on_owned_process_exit(&exit_app_handle, pid, |_| code);
+            });
+            Ok((stdout, stderr, pid))
         }
     };
 

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -719,21 +719,18 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                                     for line in stderr_text.lines() {
                                         log::warn!(target: "dsh", "{}", line);
                                     }
-                                    return Err(std::io::Error::new(
-                                        std::io::ErrorKind::Other,
-                                        format!("Harness exited early: {exit}"),
-                                    ));
+                                    return Err(format!("Harness exited early: {exit}"));
                                 }
                                 Ok(None) if std::time::Instant::now() >= deadline => break,
                                 Ok(None) => {
                                     std::thread::sleep(std::time::Duration::from_millis(50))
                                 }
-                                Err(error) => return Err(error),
+                                Err(error) => return Err(error.to_string()),
                             }
                         }
                         break child;
                     }
-                    Err(error) => return Err(error),
+                    Err(error) => return Err(error.to_string()),
                 }
             };
             let pid = child.id();
@@ -743,7 +740,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
             let exit_app_handle = app_handle.clone();
             std::thread::spawn(move || {
                 let code = child.wait().ok().and_then(|status| status.code());
-                let _ = on_owned_process_exit(&exit_app_handle, pid, |_| code);
+                let _ = on_owned_process_exit(&exit_app_handle, pid, |_| code.map(i64::from));
             });
             Ok((stdout, stderr, pid))
         }

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -521,7 +521,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     // node 会让 dsh 派生的子进程各自新建可见控制台窗口（频繁闪烁 cmd 黑窗），
     // 因此 Windows 上改用“隐藏控制台”方式启动，见 win_spawn 模块。
     let active_profile = crate::service::profile::active_profile(&app_handle);
-    let spawn_result = {
+    let spawn_result: Result<(Option<std::process::ChildStdout>, Option<std::process::ChildStderr>, u32), String> = {
         #[cfg(windows)]
         {
             use std::io::{BufReader, Read};


### PR DESCRIPTION
## Summary
- extend duplicate loader entry early-exit recovery to Unix
- reset the active profile root and retry up to three times
- retain stderr diagnostics for non-retriable early exits

Fixes #285

## Validation
- pnpm typecheck
- cargo fmt --all
- cargo check was attempted but could not complete because the build failed with disk space error (os error 112).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when launching Harness processes on Unix systems.
  - Added automatic retries for temporary duplicate-loader startup failures.
  - Improved startup error reporting, including early process exits and diagnostic details.
  - Standardized process-launch behavior across Unix and Windows platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->