### PR TITLE
chore: release v0.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.1"
+version = "0.10.2"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.2` (`0.10.1` → `0.10.2`).

### Bug Fixes

- **12**: 推荐插件页面支持卸载与 diff 增量操作 (#270) (a976c3f)
- **core**: detect dsh installed globally via fnm on Windows (#302) (050caf0)
- **install**: 进度百分比越过 100% 导致首装界面卡在 117% (#301) (b955982)
- **download**: 最新 release 是预览版时回退到非预览版，避免初始化卡死 (#299, #300) (ab94672)
- **11**: 修复 Windows 任务栏显示系统默认图标 (#269) (57d2ce3)