### PR TITLE
docs(webhook): dsh-webhook(-github) 接口盘点单与桌面端落地评估 (fix #287)

### DIFF
--- a/docs/plugins/4.优化计划.alpha.plan.md
+++ b/docs/plugins/4.优化计划.alpha.plan.md
@@ -174,7 +174,10 @@ alpha:  dsh-client-modules（客户端模块系统：__ModuleLoader__ 惰性 CJS
 - [x] **归档入口优化**：`workspace-patch.ts` 的「归档工作区」菜单项在目标工作区**无会话**（或运行时匹配失败）时**直接隐藏**，不插入无动作条目（不再出现"点了没反应"）；点击使用插入时捕获的 workspace/sessionIds 闭包，避免菜单切换竞态。
 - [x] **桌面壳引导桥修复**：`src-tauri/src/desktop/plugin_boot.js.inc` 在 `initialization_script_for_all_frames` 极早期执行时 `document.documentElement` 可能为 null，`MutationObserver.observe(null)` 抛 "parameter 1 is not of type 'Node'" 并中断后续 timer 注册；加 try/catch 防御性跳过 observe、由 fallbackTimer 轮询兜底。
 - [ ] **SDK stdio 桥**：评估用 `dsh-sdk-jsonrpc-server` 提供「核心外挂进程」能力（预留，不阻塞主线）。
-- [ ] **Webhook 集成**：评估 `dsh-webhook(-github)`（预留，不阻塞主线）。
+- [x] **Webhook 接口盘点**：产出 `dsh-webhook(-github)` 公开 API 盘点单
+  （`docs/plugins/5.优化计划.webhook-集成.盘点.md`）；确认桌面端 host 平面（`agents/agentPresets/
+  permissionPresets/workspaceRegistry/webServer/credentials`）与 `WebhookRuntime` 会话创建完全兼容，
+  仅依赖 alpha 线核心（rc.2 无此包 → 能力探测 + 显式降级）。落地 PoC 与规则管理 UI 为后续独立项（预留，不阻塞主线）。
 - [ ] **工具库替换**：host 侧手写路径/时间/值工具换 `dsh-util-*`（低优先级）。
 
 ### Phase 4 — 双核心验证与灰度

--- a/docs/plugins/5.优化计划.webhook-集成.盘点.md
+++ b/docs/plugins/5.优化计划.webhook-集成.盘点.md
@@ -1,0 +1,233 @@
+# dsh-webhook(-github) 接口盘点与桌面端落地评估
+
+> 对应议题：#287「Phase 3: Webhook 集成 — dsh-webhook(-github) 外部事件 → 自动建会话（评估/预留）」。
+> 目标：产出 `@deepseek-ai/dsh-webhook` / `@deepseek-ai/dsh-webhook-github` 的**公开接口盘点单**（记录到 `docs/`），
+> 核查其「规则 → 会话创建」能力与桌面端现有会话/档案/核心层的协作点，并给出最小闭环 PoC 的落地路径。
+>
+> 依据：`4.优化计划.alpha.plan.md` §3.2「高价值新接口要点」`dsh-webhook / dsh-webhook-github` 项；
+> 接口实测基准为 npm 发布物 `0.1.2-alpha.2` 与 `0.1.2-alpha.3`（两者实现**逐字节一致**，仅 peerDependencies 版本上移到 alpha.3）。
+
+---
+
+## 一、结论速览
+
+- **可落地**：桌面端插件 host 平面已具备 `dsh-webhook(-github)` 所需的全部服务平面
+  （`ctx.agents` / `ctx.agentPresets` / `ctx.permissionPresets` / `ctx.sessionTitle` /
+  `ctx.workspaceRegistry` / `ctx.webServer`），`WebhookRuntime` 的会话创建与仓库既有
+  `dsh-tauri-worktree` 的 `handoff.ts` 走的是**同一套**核心接口，无需新增桌面壳补丁。
+- **能力探测门槛**：`@deepseek-ai/dsh-webhook` 只在 **alpha 线（0.1.2-alpha.\*）** 发布，
+  rc.2（`0.1.1-rc.2`，桌面端当前捆绑的 core）**没有该包**。落地前必须先确认运行核心版本，
+  缺包时插件应显式降级（报错/隐藏），绝不静默半工作。
+- **主交付**：本文档即接口盘点单；最小闭环 PoC 为可选（见 §八）。
+- **不阻塞主线**：维持 `4.优化计划.alpha.plan.md` Phase 3「预留，不阻塞」的定位。
+
+---
+
+## 二、包级概览与版本基线
+
+| 包 | 最近版本 | alpha 标签 | 角色 | npm 来源目录 |
+| --- | --- | --- | --- | --- |
+| `@deepseek-ai/dsh-webhook` | `0.1.2-alpha.2`（latest）| `0.1.2-alpha.4`（alpha）| 规则运行时 + 会话创建（`WebhookRuntime`）| `packages/webhook/webhook` |
+| `@deepseek-ai/dsh-webhook-github` | `0.1.2-alpha.2`（latest）| `0.1.2-alpha.4`（alpha）| 签名 GitHub HTTP 适配器 | `packages/webhook/webhook-github` |
+
+- 两级模式：**运行时**（`dsh-webhook`，provider 无关） + **适配器**（`dsh-webhook-github`，provider 特定）。
+- `dsh-webhook` 的 peerDependencies（alpha.3）：`cordis ^4.0.2`、`dsh-agent`、`dsh-agent-default-model`、
+  `dsh-agent-presets`、`dsh-invariants`、`dsh-llm`、`dsh-permission-presets`、`dsh-session`、
+  `dsh-session-title`、`dsh-workspace`，均 `^0.1.2-alpha.3`。依赖：`dsh-brand`、`dsh-util-values`。
+- `dsh-webhook-github` 的 peerDependencies（alpha.3）：`cordis`、`dsh-invariants`、`dsh-session`、
+  `dsh-webhook`、`dsh-credentials`、`dsh-host-webserver`，均 `^0.1.2-alpha.3`。
+  依赖：`@octokit/webhooks ^14.2.0`、`dsh-util-values`、`@deepseek-ai/schemastery`。
+
+> **版本对齐提示**：仓库 catalog 目前把客户端相关包钉在 `0.1.2-alpha.3`（见 `pnpm-workspace.yaml`
+> `catalog:dsh`）。`dsh-webhook(-github)` 的 npm **latest 与 alpha 标签不一致**（latest=alpha.2、
+> alpha=alpha.4），采用时须按 `pnpm-workspace.yaml` 显式钉版本（推荐对齐 alpha.3，与既有客户端包一致；
+> 若后续核心已到 alpha.4 再整体上移），不要依赖 `^` 浮动到不可预期的 alpha 标签。
+
+---
+
+## 三、`dsh-webhook` 公开 API 盘点
+
+### 3.1 服务注入与类型扩展
+
+- **注入服务（`WebhookRuntime.inject`）**：`agents`、`agentDefaultModel`、`agentPresets`、
+  `permissionPresets`、`sessionTitle`、`workspaceRegistry`。
+- **Cordis Context 扩展**：`ctx.webhookRuntime: WebhookRuntime`。
+- 对 `dsh-llm` 的 `MessageSourceMap` 声明合并：新增 `webhook` 消息来源
+  （`kind: 'webhook'` + `provider/source/deliveryId/ruleId` + `form: 'notice'` + `summary`）——
+  webhook 建出的会话首条 `user` 消息会带上该来源标注（血缘/provenance）。
+
+### 3.2 类型导出
+
+| 导出 | 说明 |
+| --- | --- |
+| `WebhookRuleId` / `WebhookSourceId` / `WebhookDeliveryId`（brand types + 工厂函数）| 三个不透明品牌身份；工厂只做编译期标注（运行时返回原串）|
+| `WebhookEventMap` | 空接口；由各适配器经声明合并注册 `kind → 事件类型`（GitHub 注册 `github`）|
+| `WebhookEventOf<K>` | 已知 provider kind 的事件类型；未知 kind 退化为 `JsonValue` |
+| `VerifiedWebhookDelivery<K>` | 已认证并解析的投递：`kind` / `source` / `deliveryId` / `event` / `receivedAt`（epoch ms）|
+| `WebhookModelSelection` | 可选显式模型路由：`provider` / `model` / `maxTokens?` |
+| `WebhookSessionRequest` | 唯一内置动作的载荷（见 §五）|
+| `WebhookRule<K>` | 注册的规则接口：`id` + `kind` + `run(delivery, signal)` |
+
+### 3.3 运行时类 `WebhookRuntime extends Service`
+
+| 成员 | 签名 | 语义 |
+| --- | --- | --- |
+| `register(rule)` | `(rule: WebhookRule<K>) => () => Promise<void>` | 注册一条可信程序化规则；返回可 await 的 effect disposer（取消 + 排空该规则的活动回调）|
+| `dispatch(delivery)` | `(delivery: VerifiedWebhookDelivery<K>) => void` | 对当前每条匹配 kind 的规则启动调用，快照后**立即返回**，不等回调落定 |
+| `startInvocation` | private | 单次受控调用，接在注册 teardown 上 |
+| `disposeRegistration` | private | 记忆化 teardown：隐藏 → abort → 排空 |
+| 生命周期 | — | `ctx.effect(() => async () => { closing = true; 排空全部规则 })` |
+
+关键语义：
+- `dispatch` 对 delivery 做 `snapshotDelivery`（校验 kind/source/deliveryId/receivedAt）→ `snapshotJsonValue` + `deepFreeze`（不可变共享）。
+- **fire-and-forget**：HTTP 适配器 `202` 即返回，不等待规则或会话。
+- **无内置去重**：`deliveryId` 仅作 provenance；重复投递会重复跑规则 → 重复建会话（幂等由规则自理）。
+- 注册是 effect；disposer 先隐藏再 abort 活动回调再 drain。规则必须配合 `signal`（同进程忽略取消的代码无法被安全强停）。
+
+---
+
+## 四、`dsh-webhook-github` 公开 API 盘点
+
+### 4.1 导出面
+
+- `name = 'webhook-github'`（Cordis 函数插件名）；`apply(ctx, config)`。
+- `inject = ['webServer', 'webhookRuntime', 'credentials']`。
+- `Config`（Schemastery schema）：`source`（string，适配器实例名）、`path`（string，绝对非根精确路径）、
+  `secretEnv`（`credential-ref` 角色，含共享密钥的 credential 引用）、`maxBodyBytes`（正整数 body 上限）。
+- `assertConfig`（内部）：额外校验 `source` 非空且无首尾空白、`path` 必须以 `/` 开头、非 `/`、无尾 `/`/`?`/`#`。
+- 对 `dsh-webhook` 的 `WebhookEventMap` 声明合并 `github: GitHubWebhookEvent`。
+
+### 4.2 类型导出
+
+| 导出 | 说明 |
+| --- | --- |
+| `GitHubJsonObject` | 签名后的 GitHub JSON 对象（rule 自行做事件字段校验）|
+| `GitHubWebhookEvent` | `name`（原始 `X-GitHub-Event`）+ `payload`（原样 JSON）|
+| `createGitHubWebhookHandler(ctx, cfg)` | 返回 `WebRoute['handler']`（可独立测试的路由工厂）|
+| re-export `EmitterWebhookEvent(Name)` | 来自 `@octokit/webhooks` |
+
+### 4.3 HTTP 契约（入站）
+
+只接受 `POST application/json`；限长读 body → 要求头 → 解析密钥 → **HMAC 校验后才解析 JSON**。
+
+| 状态 | 含义 |
+| --- | --- |
+| `202` | 已认证 JSON 被内存派发（不代表建了会话）|
+| `400` | 缺头 / 非法 UTF-8 / 非法 JSON / 非顶层对象 |
+| `401` | 签名无效 |
+| `405` | 非 POST |
+| `413` | body 超限 |
+| `415` | media type 非 application/json |
+| `503` | credential 或 webhookRuntime 不可用 |
+
+- 必需头：`X-Hub-Signature-256`、`X-GitHub-Delivery`、`X-GitHub-Event`。
+- 密钥经 `ctx.credentials.resolve(secretEnv)` 每次请求实时解析（轮换即生不重载插件）。
+- 校验顺序：method → content-type → body 限长读取 → 头齐全 → resolve credential → `Webhooks({secret}).verify(body, sig)` → `parsePayload` → 构造 delivery → `ctx.webhookRuntime.dispatch(delivery)` → `202`。
+- 安全：不记录 secret/signature/payload；拒绝 before/after 无歧义。
+- 已知限制：无 TLS（依赖反向代理/tunnel）、仅泛化 payload 校验（事件字段校验归规则）、无下游工作确认、
+  拒绝表单编码。
+
+---
+
+## 五、会话创建流程（规则 → Session）
+
+`WebhookSessionRequest` 必填：`workspacePath`（绝对路径）、`title`、`prompt`（非空）、`agentPreset`、`permissionPreset`；
+可选 `model {provider, model, maxTokens?}`。
+
+创建时序（`createWebhookSession`，核心内聚实现）：
+1. `resolveRequest`：快照校验规则返回值（必填串非空、`workspacePath` 绝对、`model.maxTokens` 为正安全整数）。
+2. 解析 preset：`permissionPresets.resolve` + `agentPresets.resolve` + `standingKeyFor`；`signal.throwIfAborted()`。
+3. `workspaceRegistry.create(workspacePath)` → 取得/创建 Web Workspace。
+4. `agents.create({ sessionId: webhook-<uuid>, signal, meta:{cwd: workspace.path, agentPreset}, agentOptions, setup })`。
+5. `setup` 内 `agentPresets.mount(agentCtx, preset.id)` + 安装「初始模型选择」钩子（首个持久请求头前生效）。
+6. `workspace.attachSession(sessionId)` → `permissionPresets.set(session, permissionPreset)` →
+   `sessionTitle.rename(session, title)` → `agent.followup(userMessage)`（`source.kind:'webhook'`）。
+7. **提交点**：`followup` 成功即完成；后续交由普通 Agent/Session 行为接管（不等 idle、不解析回复、不发布完成态）。
+8. 失败回滚：未 attach 则 dispose Agent；attach 后 pre-prompt 失败则 best-effort `detachSession` + `dispose`。
+
+---
+
+## 六、桌面端集成点核对（对照现有代码）
+
+桌面端要运行 webhook，只需以宿主插件的形式加载 `dsh-webhook` + `dsh-webhook-github` + 一条用户规则插件，
+其依赖的服务平面在 `dsh-tauri-worktree` / `dsh-tauri-session` 中**已被同一套核心接口使用**：
+
+| | rule runtime 需要 | 桌面端现状（对照） |
+| --- | --- | --- |
+| `ctx.agents.create` | 建 Agent/会话 | `host/service/handoff.ts` `ctx.agents.create({sessionId, seed, meta, agentOptions, setup})` 同款 |
+| `ctx.agentPresets` | `resolve` / `mount` / `composeFrom` | handoff `presets?.composedPreset / composeFrom` |
+| `ctx.workspaceRegistry` | `create` / `resolveByPath` / `attachSession` | session.ts / handoff 同款 |
+| `ctx.webServer.register` | 注册 GitHub 精确路由 | `host/apply.ts` `ctx.webServer.register(route)` 同款 |
+| `ctx.credentials` | 解析 GitHub secret | 桌面端设置面板已具备 credentials 平面（`Settings/Credentials`）|
+| `ctx.sessionTitle` / `ctx.permissionPresets` | 命名/授权 | 核心标准服务，仓库 host 面可用 |
+
+**结论**：无需新增桌面壳补丁或 Rust bridge；webhook 可完全作为一个宿主插件族落地，容量与建模路径与
+`dsh-tauri-worktree` 一致。唯一前置是**运行核心需为 alpha 线**（`dsh-webhook` 包在 rc.2 不存在）。
+
+---
+
+## 七、能力探测与兼容/降级（rc.2 vs alpha）
+
+- rc.2（`0.1.1-rc.2`，桌面端默认捆绑）：**无** `dsh-webhook(-github)`，`ctx.webhookRuntime?.` 为 undefined。
+- alpha（`0.1.2-alpha.\*`）：具备完整 `WebhookRuntime` 与 GitHub 适配器。
+- 降级阶梯（沿用 `AGENTS.md`）：
+  1. 官方公开 API 优先：直接在宿主插件 `apply` 内用 `ctx.webhookRuntime` / 注入 `webhookRuntime`。
+  2. 能力探测：`typeof ctx.webhookRuntime?.dispatch === 'function'` / 对 `ctx.get?.('webhookRuntime')`。
+  3. 缺能力时**显式降级**：webhook 设置项隐藏（`未启用`）、规则列表置灰、日志输出「webhook 核心不可用，需 alpha 线」，绝不静默半工作。
+- 由于 `dsh-webhook` 是**`Service`**（`ctx.effect` 注册 + 生命周期），开发时应走 `ctx.get('webhookRuntime')` /
+  `ctx.webhookRuntime`（Service 注入语义），与插件既有的 `webhookRuntime` peerDependency 声明一致。
+
+---
+
+## 八、最小闭环 PoC 落地路径（可选）
+
+> 官方 GitHub 复审指南（上游 `deepseek-ai/deepseek-harness` 的 `docs/user/guide/github-review.md`）展示了
+> 规则模块 + 专用入口端口 + secret 配置 + Workspace 路由的组合。
+
+1. 在 `packages/` 新增宿主插件（如 `dsh-tauri-webhook`），`peerDependencies` 声明
+   `dsh-webhook` / `dsh-webhook-github`（alpha.3），并加入 `pnpm-workspace.yaml` `catalog:dsh`。
+2. 组装顺序（`apply`）：装载 `dsh-webhook`（含其全部注入服务）→ 装载 `dsh-webhook-github`（配
+   `source/path/secretEnv/maxBodyBytes`）→ 注册一条规则。
+3. 规则示例（GitHub `push` → 建会话）：`run(delivery, signal)` 里校验 `delivery.event.name === 'push'`，
+   返回 `WebhookSessionRequest{ workspacePath, title, prompt, agentPreset, permissionPreset }`。
+   建议在 repo push 的目标工作树目录（`~/.dsh/worktrees/...`）建会话，复用 `dsh-tauri-worktree` 的工作树根。
+4. 密钥配置：`secretEnv` 引用桌面板 `Settings` 里已配置的 GitHub credential；**不要**落明文。
+5. 入口：`maxBodyBytes` 给合理上限；桌面端 `webServer` 为 loopback，需用户在网关/隧道（如 Tailscale/ngrok +
+   反代）暴露 HTTPS 并转发 `X-Hub-Signature-256` 原样头。
+6. 验证：向本地 `/path` POST 一条签名 `push` 事件 → 观察 202 → `ctx.sessions` 出现新会话（`source.kind='webhook'`）。
+7. **边界**：无内置去重（重复 push 会重复建会话，规则自行按 `deliveryId` 或 commit sha 幂等）；
+   fire-and-forget（202 不代表建会话成功）；无 TLS（生产必须反代）。
+
+### UI 与管理（PoC 通过后，再作二期）
+- 在设置面板增加「Webhook 规则管理」：增删规则、查看 delivery 记录（`WebhookDeliveryId` 血缘）、密钥配置。
+- 复用 `dsh-api-settings-controller` 读写核心设置/credentials，按 `AGENTS.desktop.md` i18n（扁平 key、中英同步）。
+
+---
+
+## 九、风险与限制清单
+
+- **版本线耦合**：仅 alpha 可用；桌面端默认 rc.2 核心无此能力 → 能力探测 + 显式降级必须。
+- **无持久化/队列**：进程内 fire-and-forget，崩溃丢未落定回调；无 replay/retry。
+- **无去重**：重复投递重复建会话（规则幂等自持）。
+- **无完成回调**：HTTP 202 与规则落定都不回报 Agent 成功/idle/输出。
+- **Workspace 可能空转保留**：建会话失败时空 Workspace 仍保留（可能被并发调用者复用，刻意为之）。
+- **规则须配合取消**：signal 观察；忽略取消的代码无法被安全强停。
+- **TLS/网络**：loopback 入站，需外部反代/tunnel + 原样签名头转发。
+
+---
+
+## 十、后续动作（PR / 主线）
+
+- [x] 产出 `dsh-webhook(-github)` 接口盘点单（本文档）。
+- [ ] （可选，独立 PR）最小闭环 PoC：GitHub 事件 → 自动建会话（需 `packages/dsh-tauri-webhook` + catalog 加包 + 设置密钥）。
+- [ ] `4.优化计划.alpha.plan.md` Phase 3「Webhook 集成」勾选/更新（评估完成，落地待核心线与 UI 排期）。
+
+---
+
+## 附：关键参考
+
+- 议题：#287；关联 PR：#284（alpha.3 迁移主线，已合并）。
+- 计划书：`docs/plugins/4.优化计划.alpha.plan.md` §2.2 / §3.2 / Phase 3。
+- 包实测物：npm `@deepseek-ai/dsh-webhook`、`@deepseek-ai/dsh-webhook-github`（alpha.2==alpha.3，逐字节一致）。
+- 上游复审指南：`deepseek-ai/deepseek-harness` `docs/user/guide/github-review.md`。
+- 仓库内部会话/工作区先例：`packages/dsh-tauri-worktree/src/host/service/{handoff,session}.ts`、`host/apply.ts`。


### PR DESCRIPTION
Closes #287

## 目标
产出 `@deepseek-ai/dsh-webhook` / `@deepseek-ai/dsh-webhook-github` 的**接口盘点单**（记录到 `docs/`），
并评估「外部事件 → 自动建会话」的桌面端落地路径。Webhook 相关能力属 Phase 3「预留，不阻塞主线」。

## 变更
- **新增** `docs/plugins/5.优化计划.webhook-集成.盘点.md` —— 基于 npm **实际发布物**
  （`0.1.2-alpha.2` / `0.1.2-alpha.3`，二者实现逐字节一致）核实的完整公开 API 盘点：
  - `dsh-webhook`：`WebhookRuntime`（`register` / `dispatch`）、类型导出
    （`WebhookRuleId/SourceId/DeliveryId`、`VerifiedWebhookDelivery`、`WebhookRule`、
    `WebhookSessionRequest`、`WebhookModelSelection`）、`dsh-llm` message-source 声明合并（`source.kind:'webhook'`）。
  - `dsh-webhook-github`：`name/apply/inject/Config`、`GitHubWebhookEvent`、`createGitHubWebhookHandler`、
    完整 HTTP 入站契约（HMAC 校验顺序 + 8 种状态码语义）。
  - 会话创建流程（`workspaceRegistry.create` → `agents.create` → `attachSession` → `sessionTitle` →
    `agent.followup` 提交点 + 失败回滚），与仓库既有 `dsh-tauri-worktree` `handoff.ts` 使用同一套核心接口。
  - 桌面端集成点核对、能力探测（rc.2 无此包 → 显式降级）、最小闭环 PoC 落地路径、风险清单。
- `docs/plugins/4.优化计划.alpha.plan.md` Phase 3：将「Webhook 集成」评估项标记完成，确认 host 平面兼容
  （`agents/agentPresets/permissionPresets/workspaceRegistry/webServer/credentials`），PoC 与规则管理 UI 列为后续独立项。

## 验收对照
- [x] 产出 `dsh-webhook(-github)` 接口盘点单（记录到 docs/）
- [ ] 最小闭环 PoC（可选，本文档给出落地路径，留待后续独立 PR；需 alpha 线核心 + 新增 `dsh-tauri-webhook` 插件）
- [x] 不阻塞主线（维持「预留」定位）

## 验证
纯文档变更（markdown），未改动 TS/Rust 源码，无需 lint/typecheck/test/build。
环境已清理：npm 临时解包目录已删除。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented Webhook interface compatibility with the desktop host.
  * Added an inventory of Webhook APIs, GitHub inbound HTTP contracts, session creation flow, and service dependencies.
  * Clarified alpha availability and explicit capability degradation for rc.2.
  * Documented optional proof-of-concept paths and associated limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->