### PR TITLE
fix(dsh-tauri-worktree): per-session ledger files + atomic-write EPERM retry (same-group worktrees no longer clash)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Build Plugins
+        run: pnpm build:plugins
+
       # 主逻辑在 Rust 侧，这里仅确认前端纯函数测试通过
       - name: Unit test
         run: pnpm run test -- --run

--- a/packages/dsh-tauri-worktree/src/host/apply.ts
+++ b/packages/dsh-tauri-worktree/src/host/apply.ts
@@ -19,8 +19,10 @@ import { completeWorktreeHandoff } from './service/handoff.js'
 import { unregisterWorktreeWorkspace, worktreeKey } from './service/operation.js'
 import {
   clearPendingCheckoutContext,
-  loadCheckoutContextsSync,
-  loadLedgerSync,
+  listBindingsSync,
+  loadBindingSync,
+  loadCheckoutContextSync,
+  migrateLegacyLedger,
 } from './storage/index.js'
 import { createToolSet } from './tools/index.js'
 
@@ -62,11 +64,14 @@ export function apply(ctx: HostContext, config: PluginConfig = {}): void {
     void hooks.callHook('session:turn-end', session, event)
   })
 
-  // 2) 自愈旧版本遗留：只注销普通 Workspace 记录，不删除工作树或会话。
+  // 2) 旧版本遗留自愈：拆除整表 ledger.json（一次性迁移到按会话文件），并只注销
+  //    普通 Workspace 记录，不删工作树或会话。
   ctx.effect(() => {
-    const ledger = loadLedgerSync(worktreesRoot)
-    void Promise.all(Object.values(ledger).map(binding => unregisterWorktreeWorkspace(ctx, binding.worktreePath)))
-  }, 'dsh-tauri-worktree: unregister legacy worktree workspaces')
+    void Promise.all([
+      migrateLegacyLedger(worktreesRoot),
+      Promise.all(listBindingsSync(worktreesRoot).map(binding => unregisterWorktreeWorkspace(ctx, binding.worktreePath))),
+    ])
+  }, 'dsh-tauri-worktree: unregister legacy worktree workspaces + migrate ledger')
 
   // 3) 检出后的第一条用户消息：作为 DSH dynamic runtime context 注入，而不是
   // 主动 followup 启动额外 turn。目标会话的 header.cwd 已绑定 projectPath。
@@ -77,7 +82,7 @@ export function apply(ctx: HostContext, config: PluginConfig = {}): void {
       const sessionId = context?.scope?.session?.id
       if (!sessionId)
         return ''
-      const checkout = loadCheckoutContextsSync(worktreesRoot)[sessionId]
+      const checkout = loadCheckoutContextSync(worktreesRoot, sessionId)
       if (!checkout)
         return ''
       injectedCheckoutContexts.add(sessionId)
@@ -102,8 +107,7 @@ export function apply(ctx: HostContext, config: PluginConfig = {}): void {
       const sessionId = session?.id
       if (!sessionId)
         return ''
-      const ledger = loadLedgerSync(worktreesRoot)
-      const binding = ledger[sessionId]
+      const binding = loadBindingSync(worktreesRoot, sessionId)
       if (!binding)
         return ''
       return (

--- a/packages/dsh-tauri-worktree/src/host/routes/index.ts
+++ b/packages/dsh-tauri-worktree/src/host/routes/index.ts
@@ -16,7 +16,7 @@ import { gitToplevel } from '../service/git.js'
 import { checkoutToLocalAndHandback, inheritSessionIntoWorktree } from '../service/handoff.js'
 import { discardWorktree, ensureWorktree, worktreeKey } from '../service/operation.js'
 import { findSession, resolveProjectPath } from '../service/session.js'
-import { loadLedger } from '../storage/index.js'
+import { loadBinding } from '../storage/index.js'
 
 /** 构建路由列表。 */
 export function buildRoutes(ctx: HostContext, config: PluginConfig): any[] {
@@ -29,8 +29,7 @@ export function buildRoutes(ctx: HostContext, config: PluginConfig): any[] {
       handler: routeHandler(async (body, req) => {
         const url = new URL(req.url ?? '/', 'http://localhost')
         const sessionId = String(url.searchParams.get('sessionId') ?? body.sessionId ?? '')
-        const ledger = await loadLedger(worktreesRoot)
-        const binding = ledger[sessionId] ?? null
+        const binding = await loadBinding(worktreesRoot, sessionId)
         const activeBinding = binding && existsSync(binding.worktreePath) ? binding : null
         const session = findSession(ctx, sessionId)
         const projectPath = binding?.projectPath ?? (await resolveProjectPath(ctx, session))
@@ -106,8 +105,7 @@ export function buildRoutes(ctx: HostContext, config: PluginConfig): any[] {
         const sessionId = String(body.sessionId ?? '')
         if (!sessionId)
           return [400, { error: '缺少 sessionId' }]
-        const ledger = await loadLedger(worktreesRoot)
-        const binding = ledger[sessionId]
+        const binding = await loadBinding(worktreesRoot, sessionId)
         if (!binding)
           return [404, { error: '未找到绑定的工作树' }]
         const workspace = await ctx.workspaceRegistry.resolveByPath(binding.projectPath)

--- a/packages/dsh-tauri-worktree/src/host/service/operation.ts
+++ b/packages/dsh-tauri-worktree/src/host/service/operation.ts
@@ -5,7 +5,8 @@
  * 规则（与宿主侧 AGENTS.md 一致）：
  *   - 破坏性 Git 操作必须检查每一步结果，失败时保留可恢复的 binding/ledger；
  *   - 绝不静默覆盖用户已有分支或未提交改动；
- *   - ledger 的 load-modify-save 在单操作内完成，两个并发操作由路由层串行约束。
+ *   - binding 按会话独立落盘（ledger/<sessionId>.json），读写只碰自己的文件，
+ *     同组多工作树的 create/checkout/discard 不再共享整表文件，天然避免并发覆盖。
  */
 
 import type {
@@ -20,7 +21,7 @@ import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { join } from 'pathe'
 import { WORKTREE_BRANCH_NAME_PATTERN } from '../constants/index.js'
-import { loadLedger, saveLedger } from '../storage/index.js'
+import { listBindings, loadBinding, removeBinding, saveBinding } from '../storage/index.js'
 import {
   applyStagedPatch,
   carryStagedChanges,
@@ -73,8 +74,7 @@ export async function ensureWorktree(
   const dirname = projectDirname(projectPath)
   const path = worktreePath(worktreesRoot, hash, dirname)
 
-  const ledger = await loadLedger(worktreesRoot)
-  const existing = ledger[sessionId]
+  const existing = await loadBinding(worktreesRoot, sessionId)
   if (existing && existsSync(existing.worktreePath)) {
     return { ok: true, binding: existing, existed: true, log: [] }
   }
@@ -142,12 +142,11 @@ export async function ensureWorktree(
     createdAt: new Date().toISOString(),
     log,
   }
-  ledger[sessionId] = binding
-  // ledger 落盘失败时回滚刚创建的 git worktree 与分支，避免留下未被 ledger 引用的
-  // 孤儿目录（失败重试会以新 sessionId 再建一份，累积成「多点几次多出一堆工作树」）。
-  // saveLedger 内部已对瞬时 EPERM 做退避重试，这里兜底覆盖其余硬失败（如权限/磁盘）。
+  // 绑定落盘失败时回滚刚创建的 git worktree 与分支，避免留下未被 ledger 引用的
+  // 孤儿目录。saveBinding 只原子写本会话自己的文件，不再整表读写；saveBinding 内部
+  // 已对瞬时 EPERM 做退避重试，这里兜底覆盖其余硬失败（如权限/磁盘）。
   try {
-    await saveLedger(worktreesRoot, ledger)
+    await saveBinding(worktreesRoot, sessionId, binding)
   }
   catch {
     const rollbackFailures: string[] = []
@@ -172,11 +171,16 @@ export async function ensureWorktree(
 
 /** 解析工作树绑定（兼容 sessionId 或 worktreeHashDirname 定位）。 */
 export async function resolveBinding(worktreesRoot: string, sessionId?: string, key?: string): Promise<{ binding: Binding | null }> {
-  const ledger = await loadLedger(worktreesRoot)
-  if (sessionId && ledger[sessionId])
-    return { binding: ledger[sessionId] }
+  // 主路径：按会话直读自己的 ledger 文件（多工作树同组时也能精确命中）。
+  if (sessionId) {
+    const bySession = await loadBinding(worktreesRoot, sessionId)
+    if (bySession)
+      return { binding: bySession }
+  }
+  // 回退：按 [hash]/[dirname] key 遍历。仅会话 id 对不上时走全量扫描。
   if (key) {
-    for (const binding of Object.values(ledger)) {
+    const all = await listBindings(worktreesRoot)
+    for (const binding of all) {
       if (binding.hash && binding.dirname && `${binding.hash}/${binding.dirname}` === key) {
         return { binding }
       }
@@ -355,10 +359,8 @@ export async function checkoutToLocal(
     return { ok: false, error: `删除工作树失败，绑定已保留以便重试：${removed.error}` }
   await git(['worktree', 'prune'], root, { signal: opts.signal })
 
-  // 5) 解除绑定。
-  const ledger = await loadLedger(worktreesRoot)
-  delete ledger[binding.sessionId]
-  await saveLedger(worktreesRoot, ledger)
+  // 5) 解除绑定：只删本会话的 ledger 文件，互不干扰同组其他工作树。
+  await removeBinding(worktreesRoot, binding.sessionId)
 
   return { ok: true, branch, projectPath: root, worktreePath: binding.worktreePath }
 }
@@ -394,9 +396,7 @@ export async function discardWorktree(
     await git(['branch', '-D', binding.branchName], binding.projectPath, { signal: opts.signal })
   }
 
-  const ledger = await loadLedger(worktreesRoot)
-  delete ledger[binding.sessionId]
-  await saveLedger(worktreesRoot, ledger)
+  await removeBinding(worktreesRoot, binding.sessionId)
 
   return { ok: true, worktreePath: binding.worktreePath }
 }

--- a/packages/dsh-tauri-worktree/src/host/service/operation.ts
+++ b/packages/dsh-tauri-worktree/src/host/service/operation.ts
@@ -143,7 +143,26 @@ export async function ensureWorktree(
     log,
   }
   ledger[sessionId] = binding
-  await saveLedger(worktreesRoot, ledger)
+  // ledger 落盘失败时回滚刚创建的 git worktree 与分支，避免留下未被 ledger 引用的
+  // 孤儿目录（失败重试会以新 sessionId 再建一份，累积成「多点几次多出一堆工作树」）。
+  // saveLedger 内部已对瞬时 EPERM 做退避重试，这里兜底覆盖其余硬失败（如权限/磁盘）。
+  try {
+    await saveLedger(worktreesRoot, ledger)
+  }
+  catch {
+    const rollbackFailures: string[] = []
+    const removed = await git(['worktree', 'remove', '--force', path], root, { signal: opts.signal })
+    if (!removed.ok)
+      rollbackFailures.push(`移除工作树失败：${removed.error}`)
+    await git(['worktree', 'prune'], root, { signal: opts.signal })
+    if (branchName) {
+      const dropped = await git(['branch', '-D', branchName], root, { signal: opts.signal })
+      if (!dropped.ok)
+        rollbackFailures.push(`删除分支失败：${dropped.error}`)
+    }
+    const suffix = rollbackFailures.length > 0 ? `；回滚不完整：${rollbackFailures.join('；')}` : '，已回滚'
+    return { ok: false, error: `保存工作树记录失败${suffix}` }
+  }
 
   // 不注册成普通 DSH Workspace：否则「新建会话」会复用 blank worktree 会话，
   // 造成默认进入工作树。隔离会话直接以 sessions.create({ cwd }) 绑定此路径。

--- a/packages/dsh-tauri-worktree/src/host/storage/index.test.ts
+++ b/packages/dsh-tauri-worktree/src/host/storage/index.test.ts
@@ -1,0 +1,117 @@
+/**
+ * host/storage/index.test.ts — 按会话分文件的 binding ledger 契约：
+ * 独立读写互不干扰、单会话删除、旧整表一键迁移幂等。
+ */
+
+import type { Binding } from '../types'
+import { randomUUID } from 'node:crypto'
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'pathe'
+import { describe, expect, it } from 'vitest'
+import {
+  listBindings,
+  listBindingsSync,
+  loadBinding,
+  loadBindingSync,
+  migrateLegacyLedger,
+  removeBinding,
+  saveBinding,
+} from './index'
+
+function tempRoot(): string {
+  return join(tmpdir(), `dsh-worktree-storage-${randomUUID()}`)
+}
+
+function makeBinding(sessionId: string, hash = 'hash-a'): Binding {
+  return {
+    sessionId,
+    sourceSessionId: 'source-a',
+    hash,
+    dirname: 'repo',
+    worktreePath: join(tmpdir(), `wt-${sessionId}`),
+    projectPath: '/tmp/repo',
+    branchName: 'dsh/x',
+    ownsBranch: true,
+    createdAt: new Date().toISOString(),
+    log: [],
+  }
+}
+
+describe('按会话分文件的 binding ledger', () => {
+  it('saveBinding/loadBinding/loadBindingSync 往返一致', async () => {
+    const root = tempRoot()
+    const binding = makeBinding('session-1')
+    await saveBinding(root, 'session-1', binding)
+    await expect(loadBinding(root, 'session-1')).resolves.toEqual(binding)
+    expect(loadBindingSync(root, 'session-1')).toEqual(binding)
+  })
+
+  it('同组不同会话各自读写互不干扰；覆盖只作用于自己的文件', async () => {
+    const root = tempRoot()
+    const a = makeBinding('session-a', 'hash-a')
+    const b = makeBinding('session-b', 'hash-b')
+    await saveBinding(root, 'session-a', a)
+    await saveBinding(root, 'session-b', b)
+    await saveBinding(root, 'session-a', { ...a, branchName: 'dsh/updated' })
+
+    await expect(loadBinding(root, 'session-a')).resolves.toMatchObject({ branchName: 'dsh/updated' })
+    await expect(loadBinding(root, 'session-b')).resolves.toEqual(b)
+    // 未写入的会话读不到（不因别人写入而串扰）。
+    await expect(loadBinding(root, 'session-none')).resolves.toBeNull()
+  })
+
+  it('removeBinding 只删指定会话，其余保留', async () => {
+    const root = tempRoot()
+    await saveBinding(root, 'session-a', makeBinding('session-a'))
+    await saveBinding(root, 'session-b', makeBinding('session-b'))
+    await removeBinding(root, 'session-a')
+
+    await expect(loadBinding(root, 'session-a')).resolves.toBeNull()
+    await expect(loadBinding(root, 'session-b')).resolves.toMatchObject({ sessionId: 'session-b' })
+    // 再次删除不存在项视为成功。
+    await expect(removeBinding(root, 'session-a')).resolves.toBeUndefined()
+  })
+
+  it('listBindings / listBindingsSync 枚举当前全部绑定', async () => {
+    const root = tempRoot()
+    await saveBinding(root, 'session-x', makeBinding('session-x', 'hash-x'))
+    await saveBinding(root, 'session-y', makeBinding('session-y', 'hash-y'))
+
+    const synced = listBindingsSync(root)
+    expect(synced.map(b => b.sessionId).sort()).toEqual(['session-x', 'session-y'])
+    const asyncAll = await listBindings(root)
+    expect(asyncAll.map(b => b.sessionId).sort()).toEqual(['session-x', 'session-y'])
+  })
+
+  it('旧整表 ledger.json 一次性迁移到按会话文件并删除旧文件（幂等）', async () => {
+    const root = tempRoot()
+    mkdirSync(root, { recursive: true })
+    const legacy = {
+      'session-1': makeBinding('session-1', 'hash-1'),
+      'session-2': makeBinding('session-2', 'hash-2'),
+    }
+    writeFileSync(join(root, 'ledger.json'), JSON.stringify(legacy, null, 2))
+
+    await migrateLegacyLedger(root)
+    // 已拆散并按会话可读。
+    await expect(loadBinding(root, 'session-1')).resolves.toMatchObject({ sessionId: 'session-1' })
+    await expect(loadBinding(root, 'session-2')).resolves.toMatchObject({ sessionId: 'session-2' })
+    // 旧整表已删除；每个会话独立 .json 存在于 ledger/ 下。
+    expect(existsSync(join(root, 'ledger.json'))).toBe(false)
+    const files = readdirSync(join(root, 'ledger')).sort()
+    expect(files).toEqual(['session-1.json', 'session-2.json'])
+    // 幂等：再次迁移不抛错且文件不变。
+    writeFileSync(join(root, 'ledger.json'), JSON.stringify(legacy))
+    await expect(migrateLegacyLedger(root)).resolves.toBeUndefined()
+    await expect(loadBinding(root, 'session-1')).resolves.toMatchObject({ sessionId: 'session-1' })
+  })
+
+  it('无旧整表且无 ledger/ 目录时迁移与读取均安全', async () => {
+    const root = tempRoot()
+    await expect(migrateLegacyLedger(root)).resolves.toBeUndefined()
+    await expect(loadBinding(root, 'any')).resolves.toBeNull()
+    expect(listBindingsSync(root)).toEqual([])
+    expect(existsSync(join(root, 'ledger.json'))).toBe(false)
+  })
+})

--- a/packages/dsh-tauri-worktree/src/host/storage/index.ts
+++ b/packages/dsh-tauri-worktree/src/host/storage/index.ts
@@ -1,72 +1,226 @@
 /**
  * host/storage.ts — 工作树宿主状态的持久化：binding ledger + 一次性检出上下文。
  *
- * 适配 unstorage(fs)：读写走 dsh-tauri 共享的 createAtomicFsStorage（tmp+rename
- * 原子写，unstorage fs driver 的 setItem 是直接 writeFile，不能保证读者看不到
- * 半份 JSON）。同步读面（loadLedgerSync / loadCheckoutContextsSync）保留给
+ * 为什么按会话分文件：旧实现把全部 binding 挤进单个 `ledger.json`（load-modify-save
+ * 整表读写）。同一组会话下多个工作树的 create/checkout/discard 会并发 load-modify-save
+ * 同一文件，互相覆盖并反复踩 rename 的 EPERM 锁竞争（「多点几次多出一堆工作树」）。
+ * 这里改为每个会话独立文件 `ledger/<sessionId>.json`，读改写只作用于单个会话，天然消除
+ * 共享文件竞争，无需额外加锁。
+ *
+ * key 形态：unstorage 以 `:` 作层级分隔符，driver 把它还原成 `/`（见 dsh-tauri 的
+ * createAtomicFsStorage）。故「ledger:sess-id.json」落在 `base/ledger/sess-id.json`。
+ * 原子写走 dsh-tauri 共享的 createAtomicFsStorage（tmp+rename）。
+ *
+ * 迁移：旧版本遗留的 `ledger.json` / `checkout-context.json` 整表文件在首次运行时拆分成
+ * 按会话文件并删除，幂等。同步读面对迁移前的窗口做「旧文件单键回退」。同步面保留给
  * 工具 execute 与 systemPrompt 渲染路径（小文件同步读可接受）。
  */
 
-import type { CheckoutContext, CheckoutContexts, Ledger } from '../types/index.js'
-import { readFileSync } from 'node:fs'
+import type { Binding, CheckoutContext } from '../types/index.js'
+import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs'
 import { createAtomicFsStorage } from 'dsh-tauri'
 import { join } from 'pathe'
 
-const LEDGER_KEY = 'ledger.json'
-const CHECKOUT_CONTEXT_KEY = 'checkout-context.json'
+const LEDGER_DIR = 'ledger'
+const CHECKOUT_CONTEXT_DIR = 'checkout-context'
+/** 旧版本整表文件（迁移后删除）。 */
+const LEGACY_LEDGER_KEY = 'ledger.json'
+const LEGACY_CHECKOUT_CONTEXT_KEY = 'checkout-context.json'
 
 function store(worktreesRoot: string) {
   return createAtomicFsStorage(worktreesRoot)
 }
 
-function parseRecord<T>(value: string): Record<string, T> {
-  const parsed: unknown = JSON.parse(value)
-  return parsed && typeof parsed === 'object' ? parsed as Record<string, T> : {}
+/** 会话 id → 按会话文件的相对路径（不含 base）。 */
+function sessionFile(sessionId: string): string {
+  return `${LEDGER_DIR}/${sessionId}.json`
 }
 
-export async function loadLedger(worktreesRoot: string): Promise<Ledger> {
+function checkoutContextFile(sessionId: string): string {
+  return `${CHECKOUT_CONTEXT_DIR}/${sessionId}.json`
+}
+
+/** 解析单个对象；文件缺失或内容损坏返回 null。 */
+function parseBinding(raw: string): Binding | null {
   try {
-    const value = await store(worktreesRoot).getItem<Ledger>(LEDGER_KEY)
-    return value && typeof value === 'object' ? value : {}
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === 'object'
+      ? parsed as Binding
+      : null
   }
   catch {
-    return {}
+    return null
   }
 }
 
-export function loadLedgerSync(worktreesRoot: string): Ledger {
+function parseCheckoutContext(raw: string): CheckoutContext | null {
   try {
-    return parseRecord<Ledger[string]>(readFileSync(join(worktreesRoot, LEDGER_KEY), 'utf8')) as Ledger
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === 'object'
+      ? parsed as CheckoutContext
+      : null
   }
   catch {
-    return {}
+    return null
   }
 }
 
-export async function saveLedger(worktreesRoot: string, ledger: Ledger): Promise<void> {
-  await store(worktreesRoot).setItem(LEDGER_KEY, `${JSON.stringify(ledger, null, 2)}\n`)
-}
+// ---------------------------------------------------------------------------
+// binding ledger（按会话独立文件）
+// ---------------------------------------------------------------------------
 
-export function loadCheckoutContextsSync(worktreesRoot: string): CheckoutContexts {
+/**
+ * 同步读取某会话的 binding。优先按会话文件；对迁移前窗口回退旧整表 `ledger.json`。
+ * 文件缺失/损坏一律返回 null（绝不让只读渲染路径抛错）。
+ */
+export function loadBindingSync(worktreesRoot: string, sessionId: string): Binding | null {
   try {
-    const raw = readFileSync(join(worktreesRoot, CHECKOUT_CONTEXT_KEY), 'utf8')
-    return parseRecord<CheckoutContext>(raw) as CheckoutContexts
+    const raw = readFileSync(join(worktreesRoot, sessionFile(sessionId)), 'utf8')
+    const binding = parseBinding(raw)
+    if (binding)
+      return binding
   }
   catch {
-    return {}
+    /* 会话文件缺失则回退旧整表 */
   }
+  return legacyLedgerEntrySync(worktreesRoot, sessionId)
 }
 
-export async function setPendingCheckoutContext(worktreesRoot: string, sessionId: string, context: CheckoutContext): Promise<void> {
-  const contexts = loadCheckoutContextsSync(worktreesRoot)
-  contexts[sessionId] = context
-  await store(worktreesRoot).setItem(CHECKOUT_CONTEXT_KEY, `${JSON.stringify(contexts, null, 2)}\n`)
+/** 从旧整表 `ledger.json` 取单键（迁移前的只读回退；不在此处落盘）。 */
+function legacyLedgerEntrySync(worktreesRoot: string, sessionId: string): Binding | null {
+  try {
+    const raw = readFileSync(join(worktreesRoot, LEGACY_LEDGER_KEY), 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') {
+      const entry = (parsed as Record<string, unknown>)[sessionId]
+      return entry && typeof entry === 'object' ? entry as Binding : null
+    }
+  }
+  catch {
+    /* 旧文件缺失/损坏按无绑定处理 */
+  }
+  return null
 }
 
-export async function clearPendingCheckoutContext(worktreesRoot: string, sessionId: string): Promise<void> {
-  const contexts = loadCheckoutContextsSync(worktreesRoot)
-  if (!contexts[sessionId])
+/** 异步读绑定：先保证旧整表已迁移，再读按会话文件。 */
+export async function loadBinding(worktreesRoot: string, sessionId: string): Promise<Binding | null> {
+  await migrateLegacyLedger(worktreesRoot)
+  return loadBindingSync(worktreesRoot, sessionId)
+}
+
+/** 原子写某个会话的 binding（幂等：同会话重复写只覆盖自己的文件）。 */
+export async function saveBinding(worktreesRoot: string, sessionId: string, binding: Binding): Promise<void> {
+  await store(worktreesRoot).setItem(
+    sessionFile(sessionId),
+    `${JSON.stringify(binding, null, 2)}\n`,
+  )
+}
+
+/** 删除某个会话的 binding（不存在时视为成功）。 */
+export async function removeBinding(worktreesRoot: string, sessionId: string): Promise<void> {
+  await store(worktreesRoot).removeItem(sessionFile(sessionId))
+}
+
+/** 同步枚举全部 binding（仅自愈/按 key 寻址等「需要全量」的路径使用）。 */
+export function listBindingsSync(worktreesRoot: string): Binding[] {
+  const results: Binding[] = []
+  const dir = join(worktreesRoot, LEDGER_DIR)
+  let names: string[]
+  try {
+    names = readdirSync(dir)
+  }
+  catch {
+    return results // ledger/ 目录尚不存在
+  }
+  for (const name of names) {
+    // 只认本方案的 `<sessionId>.json` 叶文件，忽略迁移残留的 tmp/目录项。
+    if (!name.endsWith('.json'))
+      continue
+    try {
+      const binding = parseBinding(readFileSync(join(dir, name), 'utf8'))
+      if (binding)
+        results.push(binding)
+    }
+    catch {
+      /* 单个文件损坏不阻断其余 */
+    }
+  }
+  return results
+}
+
+/** 异步枚举全部 binding；先迁移旧整表再枚举，保证结果完整。 */
+export async function listBindings(worktreesRoot: string): Promise<Binding[]> {
+  await migrateLegacyLedger(worktreesRoot)
+  return listBindingsSync(worktreesRoot)
+}
+
+// ---------------------------------------------------------------------------
+// 旧整表迁移
+// ---------------------------------------------------------------------------
+
+/** 旧版本整表 migration：拆分到按会话文件后删除旧文件。幂等（旧文件不存在即跳过）。 */
+export async function migrateLegacyLedger(worktreesRoot: string): Promise<void> {
+  const legacyPath = join(worktreesRoot, LEGACY_LEDGER_KEY)
+  if (!existsSync(legacyPath))
     return
-  delete contexts[sessionId]
-  await store(worktreesRoot).setItem(CHECKOUT_CONTEXT_KEY, `${JSON.stringify(contexts, null, 2)}\n`)
+  const s = store(worktreesRoot)
+  try {
+    const raw = readFileSync(legacyPath, 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') {
+      for (const [sessionId, entry] of Object.entries(parsed as Record<string, unknown>)) {
+        if (!entry || typeof entry !== 'object')
+          continue
+        await s.setItem(sessionFile(sessionId), `${JSON.stringify(entry, null, 2)}\n`)
+      }
+    }
+    // 所有按会话文件落盘成功后，才删旧整表（提交点）。
+    rmSync(legacyPath, { force: true })
+  }
+  catch {
+    // 迁移失败不动旧文件，保留可重试状态；分文件写入均幂等，重跑安全。
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 一次检出上下文（按会话独立文件）
+// ---------------------------------------------------------------------------
+
+/** 同步读取某会话的一次性检出上下文（迁移前回退旧整表）。 */
+export function loadCheckoutContextSync(worktreesRoot: string, sessionId: string): CheckoutContext | null {
+  try {
+    const raw = readFileSync(join(worktreesRoot, checkoutContextFile(sessionId)), 'utf8')
+    const context = parseCheckoutContext(raw)
+    if (context)
+      return context
+  }
+  catch {
+    /* 会话文件缺失则回退旧整表 */
+  }
+  try {
+    const raw = readFileSync(join(worktreesRoot, LEGACY_CHECKOUT_CONTEXT_KEY), 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') {
+      const entry = (parsed as Record<string, unknown>)[sessionId]
+      if (entry && typeof entry === 'object')
+        return entry as CheckoutContext
+    }
+  }
+  catch {
+    /* 旧文件缺失/损坏按无上下文处理 */
+  }
+  return null
+}
+
+/** 写入某会话的一次性检出上下文（原子写，只碰自己的文件）。 */
+export async function setPendingCheckoutContext(worktreesRoot: string, sessionId: string, context: CheckoutContext): Promise<void> {
+  await store(worktreesRoot).setItem(
+    checkoutContextFile(sessionId),
+    `${JSON.stringify(context, null, 2)}\n`,
+  )
+}
+
+/** 清除某会话的一次性检出上下文（不存在时视为成功）。 */
+export async function clearPendingCheckoutContext(worktreesRoot: string, sessionId: string): Promise<void> {
+  await store(worktreesRoot).removeItem(checkoutContextFile(sessionId))
 }

--- a/packages/dsh-tauri-worktree/src/host/tools/index.ts
+++ b/packages/dsh-tauri-worktree/src/host/tools/index.ts
@@ -11,7 +11,7 @@ import { homedir } from 'node:os'
 import { join } from 'pathe'
 import { checkoutToLocal, ensureWorktree } from '../service/operation.js'
 import { resolveProjectPath } from '../service/session.js'
-import { loadLedgerSync } from '../storage/index.js'
+import { loadBindingSync } from '../storage/index.js'
 
 /** 文本渲染助手：渲染成模型可见文本。 */
 function textBlock(text: string): Array<{ type: 'text', text: string }> {
@@ -73,7 +73,7 @@ export function createToolSet(
         const sourceSession = sourceAgent?.session
         if (!sourceAgent || !sourceSession)
           return { ok: false, error: 'create_worktree requires a current agent session' }
-        if (loadLedgerSync(worktreesRoot)[sourceSession.id])
+        if (loadBindingSync(worktreesRoot, sourceSession.id))
           return { ok: false, error: 'The current session is already in a worktree' }
 
         const targetSessionId = `session-${randomUUID()}`

--- a/packages/dsh-tauri/src/host/storage/index.test.ts
+++ b/packages/dsh-tauri/src/host/storage/index.test.ts
@@ -43,6 +43,27 @@ describe('createAtomicFsStorage setItem/getItem', () => {
     // unstorage fs getItem 会自动 JSON.parse，故按解析后的对象断言。
     await expect(store.getItem('ledger.json')).resolves.toEqual({ ok: true })
   })
+
+  it('冒号子目录 key 落到独立文件且互不干扰（按会话分文件的基础）', async () => {
+    const dir = tempDir()
+    const store = createAtomicFsStorage(dir)
+    await store.setItem('ledger:session-a.json', '{ "a": 1 }\n')
+    await store.setItem('ledger:session-b.json', '{ "b": 2 }\n')
+    await store.setItem('ledger:session-a.json', '{ "a": 3 }\n')
+
+    // 各自独立可读，且覆盖只作用于自己的文件。
+    await expect(store.getItem('ledger:session-a.json')).resolves.toEqual({ a: 3 })
+    await expect(store.getItem('ledger:session-b.json')).resolves.toEqual({ b: 2 })
+
+    // 枚举只暴露本方案的 `<sessionId>.json` 叶子键。
+    const keys = await store.getKeys()
+    expect([...keys].sort()).toEqual(['ledger:session-a.json', 'ledger:session-b.json'])
+
+    // removeItem 只删指定会话文件。
+    await store.removeItem('ledger:session-a.json')
+    await expect(store.hasItem('ledger:session-a.json')).resolves.toBe(false)
+    await expect(store.hasItem('ledger:session-b.json')).resolves.toBe(true)
+  })
 })
 
 describe('原子写 EPERM 锁竞争重试', () => {

--- a/packages/dsh-tauri/src/host/storage/index.test.ts
+++ b/packages/dsh-tauri/src/host/storage/index.test.ts
@@ -1,0 +1,109 @@
+/**
+ * host/storage/index.test.ts — 原子写契约：EPERM 锁竞争重试 + 内容落盘 + 临时清理。
+ */
+
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createAtomicFsStorage, writeAtomic } from './index'
+
+/** 每个用例独立的临时目录，避免跨用例污染。 */
+function tempDir(): string {
+  return join(tmpdir(), `dsh-storage-test-${randomUUID()}`)
+}
+
+describe('writeAtomic', () => {
+  it('写入目标文件并保持内容完整', async () => {
+    const dir = tempDir()
+    const target = join(dir, 'ledger.json')
+    const value = '{ "a": 1 }\n'
+
+    await expect(writeAtomic(target, value)).resolves.toBeUndefined()
+    await expect(
+      (await import('node:fs/promises')).readFile(target, 'utf8'),
+    ).resolves.toBe(value)
+  })
+
+  it('在同目录已存在同名临时文件时也不互相覆盖（每次用独立临时名）', async () => {
+    const dir = tempDir()
+    const target = join(dir, 'ledger.json')
+    await writeAtomic(target, 'first')
+    await writeAtomic(target, 'second')
+    await expect(
+      (await import('node:fs/promises')).readFile(target, 'utf8'),
+    ).resolves.toBe('second')
+  })
+})
+
+describe('createAtomicFsStorage setItem/getItem', () => {
+  it('对象序列化往返一致', async () => {
+    const store = createAtomicFsStorage(tempDir())
+    await store.setItem('ledger.json', '{ "ok": true }\n')
+    // unstorage fs getItem 会自动 JSON.parse，故按解析后的对象断言。
+    await expect(store.getItem('ledger.json')).resolves.toEqual({ ok: true })
+  })
+})
+
+describe('原子写 EPERM 锁竞争重试', () => {
+  const retries = 2
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('rename 前几次抛 EPERM 时退避重试，最终成功落盘', async () => {
+    const dir = tempDir()
+    const target = join(dir, 'ledger.json')
+
+    // 包内直接 import 的 rename 无法被 vi.mock 轻易替换，改用模块级 mock 拦截。
+    vi.doMock('node:fs/promises', async (importOriginal) => {
+      const original = await importOriginal<typeof import('node:fs/promises')>()
+      let attempts = 0
+      return {
+        ...original,
+        rename: vi.fn(async (...args: Parameters<typeof original.rename>) => {
+          if (attempts++ < retries) {
+            const err = new Error('operation not permitted') as NodeJS.ErrnoException
+            err.code = 'EPERM'
+            throw err
+          }
+          return original.rename(...args)
+        }),
+      }
+    })
+    // 从被 mock 的模块重新导入被测对象，确保其内部引用同一 rename。
+    vi.resetModules()
+    const { writeAtomic: writeAtomicRetry } = await import('./index')
+
+    await expect(writeAtomicRetry(target, 'finally-ok')).resolves.toBeUndefined()
+    await expect(
+      (await import('node:fs/promises')).readFile(target, 'utf8'),
+    ).resolves.toBe('finally-ok')
+  })
+
+  it('超过重试上限后抛出并清理临时文件', async () => {
+    const dir = tempDir()
+    const target = join(dir, 'ledger.json')
+
+    vi.doMock('node:fs/promises', async (importOriginal) => {
+      const original = await importOriginal<typeof import('node:fs/promises')>()
+      return {
+        ...original,
+        rename: vi.fn(async () => {
+          const err = new Error('operation not permitted') as NodeJS.ErrnoException
+          err.code = 'EPERM'
+          throw err
+        }),
+      }
+    })
+    vi.resetModules()
+    const { writeAtomic: writeAtomicFail } = await import('./index')
+
+    await expect(writeAtomicFail(target, 'nope')).rejects.toMatchObject({ code: 'EPERM' })
+    const { readdir } = await import('node:fs/promises')
+    const leftovers = await readdir(dir).catch(() => [])
+    expect(leftovers).toEqual([])
+  })
+})

--- a/packages/dsh-tauri/src/host/storage/index.ts
+++ b/packages/dsh-tauri/src/host/storage/index.ts
@@ -75,16 +75,26 @@ function isRenameLockError(error: unknown): boolean {
 }
 
 /**
- * 创建「原子写 + unstorage」的文件存储：key 即 base 下的相对路径。
+ * unstorage key 相对路径解析：unstorage 以 `:` 作为 key 层级分隔符（fs driver 的
+ * `r(key) = join(base, key.replace(/:/g, '/'))`），若自定义 setItem 不还原会把 `:` 原样
+ * 拼进路径，Windows 上 `:` 是非法字符导致 EINVAL/ENOENT。这里与 fs driver 保持同一
+ * 还原，使 `ledger:session-a.json` 落到 `base/ledger/session-a.json`。
+ */
+function resolveKeyPath(base: string, key: string): string {
+  return join(base, key.replace(/:/g, '/'))
+}
+
+/**
+ * 创建「原子写 + unstorage」的文件存储：key 即 base 下的相对路径（`:` 为子目录分隔符）。
  * 调用方写入时传对象或预序列化字符串均可；getItem 自动 JSON.parse。
  * @param base 存储根目录（不存在时按需创建）。
- * @returns unstorage Storage（键为相对路径）。
+ * @returns unstorage Storage（键为相对路径，可用 `:` 表达子目录）。
  */
 export function createAtomicFsStorage(base: string): Storage {
   const driver: FsDriverShape = {
     ...fsDriver({ base }),
     async setItem(key: string, value: string) {
-      await writeAtomic(join(base, key), value)
+      await writeAtomic(resolveKeyPath(base, key), value)
     },
   }
   return createStorage({ driver })

--- a/packages/dsh-tauri/src/host/storage/index.ts
+++ b/packages/dsh-tauri/src/host/storage/index.ts
@@ -8,18 +8,71 @@
  * 为什么包原子写：unstorage 的 fs driver `setItem` 是直接 writeFile，读者可能读到
  * 半份 JSON；本项目既有保证是 tmp+rename（临时文件写全后原子改名）。这里以自定义
  * driver 组合 fs driver：读/枚举/watch 语义不变，写路径恢复原子保证。
+ *
+ * 为什么对 rename 做带退避的重试：Windows 下「tmp 写全后 rename 覆盖目标文件」的原子
+ * 写法并不稳定——Node 的 rename 底层用 MoveFileEx(MOVEFILE_REPLACE_EXISTING)，当目标
+ * 文件正被另一个句柄打开（未共享删除访问，典型如同步读面 loadLedgerSync 尚未关闭，
+ * 或上一次写仍在收尾）时会以 EPERM 失败；句柄释放后重试即成功，正好匹配「工作树
+ * 偶尔失败、点多几次就好」的现象。这里用有界退避重试覆盖这种瞬时锁竞争，同时保留
+ * tmp+rename 的原子语义（读者永远看不到半份 JSON）。非 Windows 平台 rename 覆盖是
+ * 原子的，补偿很小，故不按平台分支。
  */
 
 import type { Storage } from 'unstorage'
 import { randomUUID } from 'node:crypto'
-import { mkdir, rename, writeFile } from 'node:fs/promises'
+import { mkdir, rename, unlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
+import { setTimeout as sleep } from 'node:timers/promises'
 import { createStorage } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs'
 
 /** fs driver 的可写子面（setItem 替换点）。 */
 type FsDriverShape = ReturnType<typeof fsDriver>
+
+/** tmp+rename 落盘时对瞬时锁竞争（EPERM）的最大重试次数。 */
+const RENAME_MAX_RETRIES = 8
+/** 每次重试前的退避延迟（毫秒）。 */
+const RENAME_RETRY_DELAY_MS = 25
+
+/**
+ * 以 tmp+rename 原子写覆盖 target；Windows 下目标被瞬时占用时按有界退避重试。
+ *
+ * 独立导出以便单测锁定重试/原子性契约（包公开面仍只有 createAtomicFsStorage）。
+ */
+export async function writeAtomic(target: string, value: string): Promise<void> {
+  await mkdir(dirname(target), { recursive: true })
+  const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`
+  try {
+    await writeFile(temporary, value, 'utf8')
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await rename(temporary, target)
+        return
+      }
+      catch (error) {
+        // 非锁语义的硬失败（权限/不存在/来源消失等）直接抛出，不吞掉。
+        if (attempt >= RENAME_MAX_RETRIES || !isRenameLockError(error))
+          throw error
+        await sleep(RENAME_RETRY_DELAY_MS)
+      }
+    }
+  }
+  catch (error) {
+    // 覆盖失败时清理残留临时文件；unlink 失败可忽略（可能已被删/权限变化）。
+    await unlink(temporary).catch(() => {})
+    throw error
+  }
+}
+
+/** 是否为「目标被占用」一类的瞬时 rename 失败（平台相关的 EPERM）。 */
+function isRenameLockError(error: unknown): boolean {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as NodeJS.ErrnoException).code
+    return code === 'EPERM'
+  }
+  return false
+}
 
 /**
  * 创建「原子写 + unstorage」的文件存储：key 即 base 下的相对路径。
@@ -31,11 +84,7 @@ export function createAtomicFsStorage(base: string): Storage {
   const driver: FsDriverShape = {
     ...fsDriver({ base }),
     async setItem(key: string, value: string) {
-      const target = join(base, key)
-      await mkdir(dirname(target), { recursive: true })
-      const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`
-      await writeFile(temporary, value, 'utf8')
-      await rename(temporary, target)
+      await writeAtomic(join(base, key), value)
     },
   }
   return createStorage({ driver })


### PR DESCRIPTION
## 问题

Windows 下工作树操作偶尔报
`EPERM: operation not permitted, rename '...ledger.json.<pid>.<uuid>.tmp' -> '...ledger.json'`，
点了多次才好。用户还观察到：**同一组会话创建多个工作树后，检出变得更难**，且旧绑定像「共同修改了一个文件」那样互相踩。

根因有两层：
1. **瞬时锁竞争**：`createAtomicFsStorage` 用「tmp 写全后 rename 覆盖目标」原子写。Windows 上 Node 的 `rename`
   底层是 `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`，当目标文件正被另一句柄打开（同步读面尚未释放 / 上一次写收尾中）
   时以 `EPERM` 失败；句柄一释放重试即可成功。
2. **结构性并发**：`ensureWorktree`/`checkoutToLocal`/`discardWorktree` 都整表 `loadLedger`→改→`saveLedger`
   写同一个 `ledger.json`。同一组会话下多个工作树的 create/checkout 并发 load-modify-save 同一文件，互相覆盖并反复踩 EPERM；
   且 `git worktree add` 先建目录、`saveLedger` 后写，失败点击会留下未被 ledger 引用的孤儿目录，累积成「点多几次多出一堆工作树」。

## 修复

1. **`dsh-tauri` `createAtomicFsStorage`**：对瞬时锁竞争做有界退避重试（仅 EPERM），保留 tmp+rename 原子语义；
   失败时清理残留临时文件；并修复 unstorage `:` key 分隔符到路径分隔符的映射，使子目录 key（按会话分文件）可用。
2. **`dsh-tauri-worktree`：按会话独立 ledger 文件**——每个 binding 存 `ledger/<sessionId>.json`，
   create/checkout/discard 只读写自己的文件，天然消除共享文件竞争、无需加锁；`checkout-context` 同样按会话分文件。
3. **迁移**：旧整表 `ledger.json` 首次运行一键拆分成按会话文件并删除，幂等；同步读面对迁移前窗口做「旧文件单键回退」。
4. **`ensureWorktree`**：绑定落盘失败时回滚刚创建的 git worktree/分支，避免孤儿目录。
5. **单元测试**：EPERM 重试、子目录 key 写隔离、按会话读写互不干扰、单会话删除、枚举、旧整表迁移幂等。

## 文件

- `packages/dsh-tauri/src/host/storage/index.ts`（driver：重试 + 子目录 key 映射）
- `packages/dsh-tauri/src/host/storage/index.test.ts`
- `packages/dsh-tauri-worktree/src/host/storage/index.ts`（按会话 ledger + 迁移）
- `packages/dsh-tauri-worktree/src/host/storage/index.test.ts`
- `packages/dsh-tauri-worktree/src/host/service/operation.ts`
- `packages/dsh-tauri-worktree/src/host/routes/index.ts`
- `packages/dsh-tauri-worktree/src/host/apply.ts`
- `packages/dsh-tauri-worktree/src/host/tools/index.ts`

## 检查

- `pnpm --filter dsh-tauri typecheck` OK
- `pnpm --filter dsh-tauri-worktree typecheck` OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved worktree status, attach, checkout, and discard behavior by isolating bindings and checkout information per session.
  - Added automatic migration of existing worktree data, preserving compatibility with previously stored configurations.
  - Improved storage reliability for session keys containing colons and transient filesystem rename failures.
  - Prevented actions in one session from incorrectly affecting another session’s worktree state.

- **Quality Improvements**
  - Expanded coverage for storage, migration, isolation, and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->