### PR TITLE
fix(plugin): 内置插件 link 目录不存在时直接卸载

### DIFF
--- a/src-tauri/src/service/plugin/internal/manifest.rs
+++ b/src-tauri/src/service/plugin/internal/manifest.rs
@@ -189,6 +189,17 @@ pub(super) fn remove_stale_plugin_entry(entry: &Path) -> std::io::Result<()> {
     std::fs::remove_file(entry)
 }
 
+/// 判断某依赖值是否为「本地目录链接」形式（`link:` / `file:`）。
+///
+/// 内置插件统一以 `link:<捆绑目录绝对路径>` 安装；`file:` 是协议切换前的历史遗留
+/// 同义形式。用于启动自愈：当捆绑目录已不存在（如 debug 下切换 git 分支、某内置
+/// 插件源码目录消失）时，只有 `link:`/`file:` 依赖才意味着「这是我们装的本地链接」，
+/// 可以把悬空引用卸载；registry/git 引用（如 `dsh-tauri@0.2.0`、`github:x/y`）是用户
+/// 独立安装，绝不能误卸。路径值不做存在性判断，只判前缀。
+pub(super) fn is_local_link_dep(spec: &str) -> bool {
+    spec.starts_with("link:") || spec.starts_with("file:")
+}
+
 /// 判断 pnpm 写入 profile 的依赖值与期望的 `link:` 捆绑路径是否一致。
 ///
 /// 容忍：`link:`/`file:` 前缀缺失或两者混写（历史遗留 `file:` 安装值）；Windows
@@ -373,6 +384,18 @@ mod tests {
 
         assert!(std::fs::symlink_metadata(&entry).is_err());
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn local_link_dep_detects_only_directory_specs() {
+        // link:/file: 前缀 → 本地目录链接（含历史遗留 file: 形式）
+        assert!(is_local_link_dep("link:C:/Apps/dsh/resources/internal-plugins/dsh-tauri"));
+        assert!(is_local_link_dep("file:/Applications/.../dsh-tauri-ui"));
+        // 无前缀的裸路径、registry 版本、git 引用都不是本地链接，绝不能误卸
+        assert!(!is_local_link_dep("dsh-tauri@0.2.0"));
+        assert!(!is_local_link_dep("github:dsh-market/dshmarket"));
+        assert!(!is_local_link_dep("workspace:*"));
+        assert!(!is_local_link_dep(""));
     }
 
     #[test]

--- a/src-tauri/src/service/plugin/internal/mod.rs
+++ b/src-tauri/src/service/plugin/internal/mod.rs
@@ -26,7 +26,7 @@ use super::process::{new_process_owner, ProcessOwner};
 use crate::config;
 
 use manifest::{
-    dedupe_profile_bundles, dep_matches_spec, internal_plugin_entry_is_ready,
+    dedupe_profile_bundles, dep_matches_spec, internal_plugin_entry_is_ready, is_local_link_dep,
     remove_duplicate_bundle_entries_from_patch, remove_internal_plugins_from_manifest,
     remove_stale_plugin_entry, write_profile_manifest,
 };
@@ -528,15 +528,36 @@ async fn ensure_inner(
     }
 
     let mut need: Vec<(String, String, PathBuf)> = Vec::new();
+    // 本分支要「直接卸载」的孤儿内置插件（安装包名）：其捆绑目录已不存在且仍以
+    // `link:`/`file:` 本地依赖形式安装在 profile 里。见下方 bundle 缺失分支的说明。
+    let mut orphans: Vec<String> = Vec::new();
     for preset in internal {
         let Some(bundled) = bundled_plugin_dir(app_handle, &preset.id) else {
             // 未找到内置插件目录：release 说明构建期 build:plugins 未打包（发布
             // 缺陷，由 build:plugins 响亮失败）；debug 自动发现 packages/* 中非私有
             // 且含 dsh 对象的包，未命中时跳过（「找不到则不装」）。
-            log::warn!(
-                "INTERNAL_PLUGIN_BUNDLE_MISSING: {}（release 需构建期 build:plugins；debug 无匹配的 packages/* 包）",
-                preset.id
-            );
+            //
+            // debug 下这是「切换 git 分支导致某内置插件源码消失」的典型场景：上一
+            // 分支把它以 `link:<packages/<id>>` 装进 profile，当前分支不再有该目录，
+            // 悬空链接指向不存在的源。此时重装无从谈起（无源），且残留悬空链接会让
+            // loader 无法解析。因此只要它仍以本地链接（`link:`/`file:`）形式安装在
+            // profile 里，就直接卸载该插件；registry/git 等非本地依赖（用户独立安装
+            // 的同名包）绝不误卸。
+            let name = installed_name(preset).to_string();
+            let is_orphan = dependencies
+                .get(&name)
+                .is_some_and(|spec| is_local_link_dep(spec));
+            if is_orphan {
+                log::warn!(
+                    "INTERNAL_PLUGIN_BUNDLE_MISSING_UNINSTALLING: {name}（link 指向的捆绑目录已不存在，卸载悬空内置插件）"
+                );
+                orphans.push(name);
+            } else {
+                log::warn!(
+                    "INTERNAL_PLUGIN_BUNDLE_MISSING: {}（release 需构建期 build:plugins；debug 无匹配的 packages/* 包）",
+                    preset.id
+                );
+            }
             continue;
         };
         let name = installed_name(preset).to_string();
@@ -558,6 +579,23 @@ async fn ensure_inner(
             // 254 退出；先只清理 node_modules 入口（绝不跟随链接删除目标），再
             // 走常规 add，令 pnpm 从当前捆绑目录重建链接。
             need.push((preset.id.clone(), name, entry));
+        }
+    }
+    // 卸载孤儿内置插件：best-effort、离线精准，不依赖 node/pnpm（其源目录已
+    // 不存在，走 `dsh plugin remove` 也没有可安装的本地链接可删）。与弃用插件
+    // 自动卸载同一模式：任何失败只记告警，绝不阻断本轮其余重装或整体启动。
+    if !orphans.is_empty() {
+        log::info!("Uninstalling orphaned internal preset plugins: {orphans:?}");
+        for name in &orphans {
+            if !super::recovery::is_actionable_plugin_ref(name) {
+                log::warn!(
+                    "INTERNAL_PLUGIN_ORPHAN_SKIPPED: {name}（核心/官方包不执行孤儿卸载）"
+                );
+                continue;
+            }
+            if let Err(e) = super::uninstall_recovery(app_handle, name) {
+                log::warn!("INTERNAL_PLUGIN_ORPHAN_UNINSTALL_FAILED: {name}: {e}");
+            }
         }
     }
     if need.is_empty() {


### PR DESCRIPTION
## 背景 / Why

开发期频繁切换 git 分支（debug 构建下内置插件来自仓库根 `packages/*` 的自动发现）：切到一台没有某内置插件源码的分支时，该插件在上一分支已被以 `link:<packages/<id>>` 装进 profile。当前分支缺失该目录后，`bundled_plugin_dir` 返回 `None`，旧逻辑只打 `INTERNAL_PLUGIN_BUNDLE_MISSING` 日志并跳过——残留的悬空链接无法被 loader 解析，形成损坏状态且无自愈手段。

## 改动 / What

新增「孤儿内置插件直接卸载」：

- `src-tauri/src/service/plugin/internal/manifest.rs`：新增 `is_local_link_dep(spec)`，只认 `link:`/`file:` 前缀（本地目录链接），用于区分「我们装的本地链接」与「用户独立安装的同名包」。附带测试。
- `src-tauri/src/service/plugin/internal/mod.rs`：在 `ensure_inner` 的 bundle-missing 分支改为——若该内置插件仍以 `link:`/`file:` 本地依赖形式出现在 profile 依赖里，则收集进 `orphans`；循环结束后用现有离线 `uninstall_recovery` best-effort 直接卸载。

## 安全护栏 / Safety

- 只卸载本地链接依赖，registry/git（`dsh-tauri@0.2.0`、`github:x/y`）同名包绝不误卸；
- 经 `is_actionable_plugin_ref` 检查，`@deepseek-ai/*` 核心包跳过；
- 卸载失败只记告警，不阻断本轮其余重装与整体启动（与 `uninstall_deprecated_plugins` 同一模式）；
- 离线精准卸载，link 悬空也不依赖 node/pnpm，保留其它插件与配置。

## 验证 / Verification

- `cargo check` 通过（无与本次改动相关警告）
- `cargo test plugin::internal`：12 项全过（含新增测试）
- `cargo test service::plugin`：159 项全过；`plugin::recovery`：13 项全过
- `cargo fmt --check` 对本次两个文件无 diff；`cargo clippy` 无本次文件告警

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically cleans up internally installed plugins when their bundled source is no longer available.
  * Removes affected plugins only when they were installed from local linked sources; plugins installed from registries or Git remain unchanged.
  * Continues processing remaining plugin reinstalls and application startup even if cleanup encounters an error.
  * Improved handling of local dependency references, including legacy local file links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->