### PR TITLE
fix(plugin): snapshot restore decodes gzip archives correctly

### DIFF
--- a/src-tauri/src/service/backup/archive.rs
+++ b/src-tauri/src/service/backup/archive.rs
@@ -3,9 +3,12 @@
 //! 归档格式：`tar::Builder` + `zstd::stream::Encoder` 创建 `.tar.zst` 单文件，
 //! `zstd::stream::Decoder` + `tar::Archive` 解压。zstd 多线程压缩比 gzip 快
 //! 3-5 倍、压缩率更优。解压前逐条目校验路径不跳出目标目录（防路径穿越）。
+//!
+//! 除 zstd 外，也提供 `extract_archive_gzip`（复用同一条目安全校验逻辑）供
+//! 插件快照等使用 gzip 压缩的 tar.tgz 解码（见 `service::plugin::snapshot`）。
 
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
 
 /// 创建符号链接（平台差异处理）。
@@ -168,10 +171,31 @@ pub fn extract_archive(archive: &Path, dest: &Path) -> Result<(), String> {
     let dec = zstd::stream::Decoder::new(file)
         .map_err(|e| format!("BACKUP_EXTRACT_DECODER: {e}"))?;
     let mut archive = tar::Archive::new(dec);
+    extract_tar_entries(&mut archive, dest)
+}
+
+/// 解压 gzip 压缩的 tar.tgz 归档到 `dest` 目录（复用与 `extract_archive` 相同的
+/// 逐条目路径逃逸防护与符号链接拒绝逻辑）。
+///
+/// 供插件快照（`service::plugin::snapshot`，快照归档使用 gzip）暂存/还原时解压。
+pub fn extract_archive_gzip(archive: &Path, dest: &Path) -> Result<(), String> {
+    fs::create_dir_all(dest).map_err(|e| format!("BACKUP_EXTRACT_MKDIR: {e}"))?;
+    let file = fs::File::open(archive).map_err(|e| format!("BACKUP_EXTRACT_OPEN: {e}"))?;
+    let dec = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(dec);
+    extract_tar_entries(&mut archive, dest)
+}
+
+/// 从 tar 归档安全解压所有条目到 `dest`（压缩格式无关）。
+///
+/// 逐个条目：拒绝含 `..` 的路径（防逃逸）、拒绝硬链接、目录直接创建、
+/// 符号链接按 target 创建、普通文件先写临时文件再原子 rename。自定义
+/// 解压（替代 `entry.unpack`）是为了规避 macOS 上的 tar bug。
+fn extract_tar_entries<R: Read>(archive: &mut tar::Archive<R>, dest: &Path) -> Result<(), String> {
     // 禁用 ownership 保留：归档里 uid/gid 可能是 root（uid=0），非 root 用户无法 chown
     archive.set_preserve_ownerships(false);
 
-    // 单次遍历：避免重复调用 archive.entries() 导致 zstd decoder 状态错乱
+    // 单次遍历：避免重复调用 archive.entries() 导致 decoder 状态错乱
     for entry in archive.entries().map_err(|e| format!("BACKUP_EXTRACT_ENTRIES: {e}"))? {
         let mut entry = entry.map_err(|e| format!("BACKUP_EXTRACT_ENTRY: {e}"))?;
         let path = entry.path().map_err(|e| format!("BACKUP_EXTRACT_PATH: {e}"))?.into_owned();

--- a/src-tauri/src/service/plugin/snapshot.rs
+++ b/src-tauri/src/service/plugin/snapshot.rs
@@ -16,7 +16,7 @@
 //! 还原为三阶段 + 回滚：
 //! 1. 预检：id 校验 + 快照存在 + 归档完整性 + 操作锁 + 停止服务；
 //! 2. 暂存：同盘解压到 `.staging-*` 并校验（package.json 可解析、无逃逸、
-//!   拒绝符号链接——复用 `archive::extract_archive`）；
+//!   拒绝符号链接——复用 `archive::extract_archive_gzip`）；
 //! 3. 切换：真实目录 → `.backup-*` rename，暂存包体 → 真实目录 rename，
 //!   校验后清理备份；任一步失败则反转已做步骤（备份还原回原位）。
 //!
@@ -622,8 +622,9 @@ pub async fn restore(app_handle: &AppHandle, id: &str) -> Result<(), String> {
     let _ = fs::remove_dir_all(&staging);
     let _ = fs::remove_dir_all(&backup);
 
-    // 阶段 2：暂存解压（复用 archive::extract_archive：拒绝逃逸/符号链接）
-    if let Err(e) = crate::service::backup::archive::extract_archive(&archive_path, &staging) {
+    // 阶段 2：暂存解压（复用 archive::extract_archive_gzip：快照归档为 gzip 压缩；
+    // 共享 archive::extract_tar_entries，拒绝逃逸/符号链接）
+    if let Err(e) = crate::service::backup::archive::extract_archive_gzip(&archive_path, &staging) {
         let _ = fs::remove_dir_all(&staging);
         return Err(e);
     }
@@ -811,9 +812,9 @@ mod tests {
         })
         .unwrap();
 
-        // 还原到新目录
+        // 还原到新目录（快照归档为 gzip，用 extract_archive_gzip 解压）
         let target = dir.join("restored");
-        crate::service::backup::archive::extract_archive(&archive, &target).unwrap();
+        crate::service::backup::archive::extract_archive_gzip(&archive, &target).unwrap();
         let pkg = target.join(PACKAGE_PREFIX);
         assert!(pkg.join("package.json").is_file());
         assert!(pkg.join("lib").join("index.js").is_file());


### PR DESCRIPTION
## 问题

CI `Rust tests (macos-14)` 失败：

```
service::plugin::snapshot::tests::archive_round_trip_restores_package_content
panicked at src/service/plugin/snapshot.rs:816:77:
called `Result::unwrap()` on an `Err` value: "BACKUP_EXTRACT_ENTRY: Unknown frame descriptor"
```

**根因**：插件快照归档是 **gzip** 压缩（`flate2::write::GzEncoder`，`read_manifest` / `count_archive_package` 也都用 gzip 读取），但 `restore` 的暂存解压和 round-trip 测试却调用了 `archive::extract_archive` —— 该函数用 **zstd** 解码器解压，把 gzip 字节喂给 zstd 解码器导致 `Unknown frame descriptor`。这不仅是测试失败，生产环境的插件还原（restore）同样会失败。

## 修复

- `src-tauri/src/service/backup/archive.rs`：把逐条目的安全解压逻辑（路径逃逸防护 / 拒绝硬链接 / 符号链接 / 临时文件+原子 rename）抽取为泛型 `extract_tar_entries<R: Read>`，两个入口共享同一套校验：
  - `extract_archive`（zstd，备份 `.tar.zst`）行为不变；
  - 新增 `extract_archive_gzip`（gzip `tar.tgz`）供快照使用。
- `src-tauri/src/service/plugin/snapshot.rs`：
  - `restore` 暂存阶段改用 `extract_archive_gzip`；
  - round-trip 测试改用 `extract_archive_gzip`。

## 验证

- `cargo test --all-features --locked`：431 passed, 0 failed（含此前失败的 `archive_round_trip_restores_package_content` 与 `backup::archive` 全部用例）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for restoring backups stored as gzip-compressed tar archives.
  - Snapshot restoration now supports gzip-compressed backup archives.

- **Bug Fixes**
  - Improved backup archive extraction consistency across supported compression formats.
  - Existing zstd-compressed archive extraction continues to work through the shared extraction process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->