### PR TITLE
feat(core): warn before downloading core versions above rc.2

### DIFF
--- a/src/components/config-core.tsx
+++ b/src/components/config-core.tsx
@@ -6,7 +6,9 @@ import { invoke } from '@tauri-apps/api/core'
 import { Fragment, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { If } from 'react-if-lite'
+import { useCoreBreakingConfirm } from '@/hooks/use-core-breaking-confirm'
 import { store } from '@/store'
+import { compareVersions } from '@/utils/core-version'
 import { toast } from '@/utils/toast'
 import { useDshCores } from '../hooks/use-dsh-cores'
 import { DownloadCoreDialog } from './download-core-dialog'
@@ -32,19 +34,10 @@ import { PanelState } from './panel-state'
  * - 每行展示核心入口（cli path，超长省略号 + 限制宽度）。
  */
 
-/** rc.2 基准版本：高于该版本的核心引入破坏性更改，可能影响第三方插件 */
-const RC2_BASELINE = '0.1.1-rc.2'
-
-/** 判断核心版本是否高于 rc.2 基准（引入破坏性更改） */
-function isAboveRc2(version: string): boolean {
-  if (!version)
-    return false
-  return compareVersions(version, RC2_BASELINE) > 0
-}
-
 export function ConfigCore() {
   const [dialogHolder, openDialog] = useOverlay(Modal, { type: 'holder' })
   const [downloadDialogHolder, openDownloadDialog] = useOverlay(DownloadCoreDialog, { type: 'holder' })
+  const { holder: coreBreakingHolder, confirmCoreBreaking } = useCoreBreakingConfirm()
 
   const { t } = useTranslation()
   const { cores, loading, error, setActiveCore, updateLocalCore, downloadCore, removeCore, refreshCores, busy } = useDshCores()
@@ -143,24 +136,9 @@ export function ConfigCore() {
     if (busy)
       return
     // rc.2 以上版本引入破坏性更改，可能影响第三方插件 → 下载前先弹出确认。
-    // 该提示固定以 rc.2 为基准（与推荐版本逻辑无关），仅用于告知用户，
-    // 并提示可随时在核心面板切回 rc.2。
-    if (isAboveRc2(core.version)) {
-      try {
-        await openDialog({
-          status: 'warning',
-          title: t('core.above_rc2_warning_title'),
-          description: (
-            <p>
-              {t('core.above_rc2_warning_desc', { version: RC2_BASELINE })}
-            </p>
-          ),
-        })
-      }
-      catch {
-        return
-      }
-    }
+    // 取消则中止，确认后继续；该提示与推荐版本逻辑无关，仅告知用户可随时切回 rc.2。
+    if (!(await confirmCoreBreaking(core.version)))
+      return
     // 下载过程在对话框内展示进度 + 日志（复用 install-progress 事件流）；
     // 对话框 confirm（下载成功）或 cancel（失败后点关闭）都会结束本次等待。
     try {
@@ -412,6 +390,7 @@ export function ConfigCore() {
 
       {dialogHolder}
       {downloadDialogHolder}
+      {coreBreakingHolder}
     </div>
   )
 }
@@ -419,61 +398,4 @@ export function ConfigCore() {
 /** 版本展示：优先版本号，缺失回落来源 id */
 function displayVersion(version: HarnessCore): string {
   return version.version || (version.source === 'local' ? 'local' : 'app')
-}
-
-/**
- * 简化 semver 比较（不引入额外依赖），可处理 `0.1.1-rc.2` / `0.1.1` 格式。
- * 返回值：负数 a < b，0 相等，正数 a > b。
- */
-function compareVersions(a: string, b: string): number {
-  const parse = (value: string) => {
-    let v = value
-    while (v.startsWith('dsh-') || v.startsWith('src-'))
-      v = v.replace(/^(?:src|dsh)-/, '')
-    if (v.includes('-')) {
-      const candidate = v.slice(0, v.lastIndexOf('-'))
-      if (/^\d+\.\d+\.\d+(?:-[0-9A-Z.-]+)?$/i.test(candidate))
-        v = candidate
-    }
-    const [core, pre = ''] = v.split('-', 2)
-    const nums = core.split('.').map(n => parseInt(n, 10) || 0)
-    return { nums, pre }
-  }
-  const pa = parse(a)
-  const pb = parse(b)
-  for (let i = 0; i < 3; i++) {
-    const x = pa.nums[i] ?? 0
-    const y = pb.nums[i] ?? 0
-    if (x !== y)
-      return x < y ? -1 : 1
-  }
-  // 无预发布号 > 有预发布号
-  if (!pa.pre && !pb.pre)
-    return 0
-  if (!pa.pre)
-    return 1
-  if (!pb.pre)
-    return -1
-  // 预发布号按点分段比较：数字按数值、非数字按字典序
-  const paParts = pa.pre.split('.').map(p => (Number.isNaN(Number(p)) ? p : Number(p)))
-  const pbParts = pb.pre.split('.').map(p => (Number.isNaN(Number(p)) ? p : Number(p)))
-  const len = Math.max(paParts.length, pbParts.length)
-  for (let i = 0; i < len; i++) {
-    const x = paParts[i]
-    const y = pbParts[i]
-    if (x === undefined)
-      return -1
-    if (y === undefined)
-      return 1
-    if (x === y)
-      continue
-    if (typeof x === 'number' && typeof y === 'number')
-      return x < y ? -1 : 1
-    if (typeof x === 'number')
-      return -1
-    if (typeof y === 'number')
-      return 1
-    return x < y ? -1 : 1
-  }
-  return 0
 }

--- a/src/components/config-core.tsx
+++ b/src/components/config-core.tsx
@@ -31,6 +31,17 @@ import { PanelState } from './panel-state'
  * - 本地核心更新：通过用户包管理器 CLI（npm install -g @latest / pnpm add -g @latest）。
  * - 每行展示核心入口（cli path，超长省略号 + 限制宽度）。
  */
+
+/** rc.2 基准版本：高于该版本的核心引入破坏性更改，可能影响第三方插件 */
+const RC2_BASELINE = '0.1.1-rc.2'
+
+/** 判断核心版本是否高于 rc.2 基准（引入破坏性更改） */
+function isAboveRc2(version: string): boolean {
+  if (!version)
+    return false
+  return compareVersions(version, RC2_BASELINE) > 0
+}
+
 export function ConfigCore() {
   const [dialogHolder, openDialog] = useOverlay(Modal, { type: 'holder' })
   const [downloadDialogHolder, openDownloadDialog] = useOverlay(DownloadCoreDialog, { type: 'holder' })
@@ -131,6 +142,25 @@ export function ConfigCore() {
   async function onDownload(core: HarnessCore) {
     if (busy)
       return
+    // rc.2 以上版本引入破坏性更改，可能影响第三方插件 → 下载前先弹出确认。
+    // 该提示固定以 rc.2 为基准（与推荐版本逻辑无关），仅用于告知用户，
+    // 并提示可随时在核心面板切回 rc.2。
+    if (isAboveRc2(core.version)) {
+      try {
+        await openDialog({
+          status: 'warning',
+          title: t('core.above_rc2_warning_title'),
+          description: (
+            <p>
+              {t('core.above_rc2_warning_desc', { version: RC2_BASELINE })}
+            </p>
+          ),
+        })
+      }
+      catch {
+        return
+      }
+    }
     // 下载过程在对话框内展示进度 + 日志（复用 install-progress 事件流）；
     // 对话框 confirm（下载成功）或 cancel（失败后点关闭）都会结束本次等待。
     try {

--- a/src/components/config-debug.tsx
+++ b/src/components/config-debug.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next'
 import { If } from 'react-if-lite'
 import { useStore } from 'valtio-define'
 import { useAppConfig } from '@/hooks/use-app-config'
+import { useCoreBreakingConfirm } from '@/hooks/use-core-breaking-confirm'
 import { store } from '@/store'
 import { writeClipboardText } from '@/utils/clipboard'
 import { toast } from '@/utils/toast'
@@ -42,6 +43,7 @@ export function ConfigDebug() {
   const { t, i18n } = useTranslation()
   const { serviceRunning, busyAction } = useStore(store.harness)
   const { updateInfo } = useStore(store.harnessUpdater)
+  const { holder: coreBreakingHolder, confirmCoreBreaking } = useCoreBreakingConfirm()
 
   // 端口编辑态：用户尚未输入时为 undefined，由 `data?.port ?? 3080` 提供初值。
   // 初值不写入 state（避免 queryFn 副作用 / effect 同步），渲染与保存时统一
@@ -93,6 +95,13 @@ export function ConfigDebug() {
       console.error('[ConfigDebug] copy logs failed:', err)
       toast(t('messages.logs_copy_failed'), { variant: 'danger' })
     }
+  }
+
+  /** 「存在新版本」：先按 rc.2 破坏性更改确认（高于 rc.2 则先拦截），再展示更新提示 */
+  async function handleShowNewVersion() {
+    if (updateInfo && !(await confirmCoreBreaking(updateInfo.tag)))
+      return
+    store.harnessUpdater.showToast()
   }
 
   const { mutate: onClearLogs } = useMutation({
@@ -182,6 +191,7 @@ export function ConfigDebug() {
 
   return (
     <div className="space-y-3">
+      {coreBreakingHolder}
       <div className="space-y-1.5">
         <div className="flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-wider text-muted">
@@ -261,7 +271,7 @@ export function ConfigDebug() {
           <Info term={t('ui.dsh_version')}>
             <span>{info?.dsh_version ?? '-'}</span>
             <If cond={updateInfo}>
-              <Link className="ml-2 text-[10px] text-accent" onClick={store.harnessUpdater.showToast}>
+              <Link className="ml-2 text-[10px] text-accent" onClick={handleShowNewVersion}>
                 {t('menu.new_version')}
                 <ChevronRight className="scale-75" />
               </Link>

--- a/src/hooks/use-core-breaking-confirm.tsx
+++ b/src/hooks/use-core-breaking-confirm.tsx
@@ -1,0 +1,40 @@
+import { useOverlay } from '@overlastic/react'
+import { useTranslation } from 'react-i18next'
+import { Modal } from '@/components/modal'
+import { CORE_BREAKING_BASELINE, isCoreBreakingVersion } from '@/utils/core-version'
+
+/**
+ * rc.2 以上版本的下载前确认：若目标核心版本高于 rc.2 基准（引入破坏性更改、
+ * 可能影响第三方插件），先弹出确认对话框；取消则中止，确认后继续。
+ *
+ * 该逻辑与「推荐版本」逻辑无关，仅用于提示用户，提示可随时在核心中切回 rc.2。
+ * 三个入口（核心面板下载、核心「发现新版本」toast、debug「存在新版本」链接）
+ * 共用此一份逻辑。
+ */
+export function useCoreBreakingConfirm() {
+  const [holder, openDialog] = useOverlay(Modal, { type: 'holder' })
+  const { t } = useTranslation()
+
+  /** 返回 true=继续下载，false=用户取消。版本高于 rc.2 时弹确认框，否则直接放行 */
+  async function confirmCoreBreaking(version: string): Promise<boolean> {
+    if (!isCoreBreakingVersion(version))
+      return true
+    try {
+      await openDialog({
+        status: 'warning',
+        title: t('core.above_rc2_warning_title'),
+        description: (
+          <p>
+            {t('core.above_rc2_warning_desc', { version: CORE_BREAKING_BASELINE })}
+          </p>
+        ),
+      })
+      return true
+    }
+    catch {
+      return false
+    }
+  }
+
+  return { holder, confirmCoreBreaking }
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -251,6 +251,8 @@
   "core.switch_confirm_desc": "Switch to the {{version}} version? The running engine will change to this copy.",
   "core.recommended_warning_title": "Warning",
   "core.recommended_warning_desc": "The current recommended version is “{{version}}”. Switching to this version may cause software errors. Continue switching?",
+  "core.above_rc2_warning_title": "Warning",
+  "core.above_rc2_warning_desc": "Versions above {{version}} contain breaking changes that may cause third-party plugin errors. Confirm the update? You can switch back to {{version}} in the core at any time.",
   "core.activate_toast": "Switched to {{version}}",
   "core.uninstalled_toast": "Uninstalled {{version}}",
   "core.remove_confirm_title": "Uninstall version",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -251,6 +251,8 @@
   "core.switch_confirm_desc": "切换至 {{version}} 版本吗？运行中的引擎将切换为该副本。",
   "core.recommended_warning_title": "警告",
   "core.recommended_warning_desc": "当前推荐版本是 “{{version}}”，切换到该版本可能导致软件异常，确定切换吗？",
+  "core.above_rc2_warning_title": "警告",
+  "core.above_rc2_warning_desc": "{{version}} 以上的版本引入破坏性更改，可能导致第三方插件异常，确定更新吗？你可随时在核心中切换回 {{version}}。",
   "core.activate_toast": "已切换到 {{version}}",
   "core.uninstalled_toast": "已卸载 {{version}}",
   "core.remove_confirm_title": "卸载版本",

--- a/src/layout/components/harness-updater.tsx
+++ b/src/layout/components/harness-updater.tsx
@@ -1,16 +1,25 @@
 import { useWatch } from '@hairy/react-lib'
 import { useStore } from 'valtio-define'
+import { useCoreBreakingConfirm } from '@/hooks/use-core-breaking-confirm'
 import { store } from '@/store'
 
-/** 右下角"发现新版本"提示条：状态与操作直接来自 updater store */
+/** 右下角“发现新版本”提示条：状态与操作直接来自 updater store */
 export function HarnessUpdater() {
   const { updateInfo, updating } = useStore(store.harnessUpdater)
+  const { holder, confirmCoreBreaking } = useCoreBreakingConfirm()
 
   useWatch([updateInfo, updating], () => {
     if (!updateInfo || updating)
-      return null
-    store.harnessUpdater.showToast()
+      return
+    // 高于 rc.2 时先弹破坏性更改确认，取消则不提示更新（不进入下载）
+    void showAfterConfirm(updateInfo.tag)
   }, { immediate: true })
 
-  return null
+  async function showAfterConfirm(tag: string) {
+    if (!(await confirmCoreBreaking(tag)))
+      return
+    store.harnessUpdater.showToast()
+  }
+
+  return holder
 }

--- a/src/utils/core-version.ts
+++ b/src/utils/core-version.ts
@@ -1,0 +1,68 @@
+/**
+ * 核心(dsh)版本判断：以 rc.2 为硬编码基准，高于该基准的版本引入破坏性更改、
+ * 可能影响第三方插件。该判断与「推荐版本」逻辑无关，仅作为用户提示的阈值。
+ */
+export const CORE_BREAKING_BASELINE = '0.1.1-rc.2'
+
+/**
+ * 简化 semver 比较（不引入额外依赖），可处理 `0.1.1-rc.2` / `0.1.1` 以及
+ * release tag（`dsh-`/`src-` 前缀、末尾 `-<commit>` 后缀）。
+ * 返回值：负数 a < b，0 相等，正数 a > b。
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (value: string) => {
+    let v = value
+    while (v.startsWith('dsh-') || v.startsWith('src-'))
+      v = v.replace(/^(?:src|dsh)-/, '')
+    if (v.includes('-')) {
+      const candidate = v.slice(0, v.lastIndexOf('-'))
+      if (/^\d+\.\d+\.\d+(?:-[0-9A-Z.-]+)?$/i.test(candidate))
+        v = candidate
+    }
+    const [core, pre = ''] = v.split('-', 2)
+    const nums = core.split('.').map(n => parseInt(n, 10) || 0)
+    return { nums, pre }
+  }
+  const pa = parse(a)
+  const pb = parse(b)
+  for (let i = 0; i < 3; i++) {
+    const x = pa.nums[i] ?? 0
+    const y = pb.nums[i] ?? 0
+    if (x !== y)
+      return x < y ? -1 : 1
+  }
+  // 无预发布号 > 有预发布号
+  if (!pa.pre && !pb.pre)
+    return 0
+  if (!pa.pre)
+    return 1
+  if (!pb.pre)
+    return -1
+  // 预发布号按点分段比较：数字按数值、非数字按字典序
+  const paParts = pa.pre.split('.').map(p => (Number.isNaN(Number(p)) ? p : Number(p)))
+  const pbParts = pb.pre.split('.').map(p => (Number.isNaN(Number(p)) ? p : Number(p)))
+  const len = Math.max(paParts.length, pbParts.length)
+  for (let i = 0; i < len; i++) {
+    const x = paParts[i]
+    const y = pbParts[i]
+    if (x === undefined)
+      return -1
+    if (y === undefined)
+      return 1
+    if (x === y)
+      continue
+    if (typeof x === 'number' && typeof y === 'number')
+      return x < y ? -1 : 1
+    if (typeof x === 'number')
+      return -1
+    if (typeof y === 'number')
+      return 1
+    return x < y ? -1 : 1
+  }
+  return 0
+}
+
+/** 判断核心版本（版本串或 release tag）是否高于 rc.2 基准（引入破坏性更改） */
+export function isCoreBreakingVersion(version: string): boolean {
+  return !!version && compareVersions(version, CORE_BREAKING_BASELINE) > 0
+}


### PR DESCRIPTION
## 概述 / Summary

在用户下载/更新一个**高于 rc.2 基准（硬编码 `0.1.1-rc.2`）的核心(dsh)版本**前，弹出警告确认对话框，提示该版本引入破坏性更改、可能导致第三方插件异常，并告知可随时在核心中切换回 rc.2。该提示与**推荐版本逻辑无关**，仅用于告知用户。

Adds a confirmation dialog before downloading/updating a **core (dsh) version above the hardcoded rc.2 baseline (`0.1.1-rc.2`)**. It warns the release introduces breaking changes which may cause third-party plugin errors and that users can switch back to rc.2 in the core at any time. The prompt is independent of the recommend-version logic; it only informs the user.

## 一份逻辑，三个入口调用 / One logic, three entry points

共享逻辑 `useCoreBreakingConfirm()`（`src/hooks/use-core-breaking-confirm.tsx`，经 `useOverlay(Modal)`，遵循 desktop AGENTS），被三个核心版本更新入口调用：

Shared `useCoreBreakingConfirm()` (via `useOverlay(Modal)`, per desktop AGENTS) is used by all three core-version update entry points:

1. **核心面板手动下载** — `config-core.tsx` `onDownload`（下载弹窗前）。 Core panel manual download — `config-core.tsx` `onDownload` (before the download dialog).
2. **核心「发现新版本」toast 触发** — `harness-updater.tsx`（弹提示条前）。 Core "new version" toast trigger — `harness-updater.tsx` (before showing the toast).
3. **debug 面板「存在新版本」链接** — `config-debug.tsx` `handleShowNewVersion`（展示更新提示前）。 Debug panel "new version" link — `config-debug.tsx` `handleShowNewVersion` (before showing the update hint).

取消 → 中止下载/更新；确认 → 继续。`compareVersions` 收敛到 `src/utils/core-version.ts` 共享。 Cancel → abort; confirm → continue. `compareVersions` centralized in `src/utils/core-version.ts`.

## 行为要点 / Behavior notes

- 仅当目标版本 `> 0.1.1-rc.2` 时弹框（`isCoreBreakingVersion`，正确处理 `dsh-`/`src-` 前缀与 `-commit` 后缀的 tag）。
- 独立于推荐版本逻辑：固定硬编码基准，不引用 `recommendedVersion` / `aboveRecommended`。
- 不改动 `onActivate` 既有「高风险版本」警告（那是推荐版本逻辑）。

## 校验 / Validation

- `pnpm typecheck` ✅
- `npx eslint <changed files>` ✅
- `pnpm test -- --run` ✅（21 files / 164 tests）

## 改动文件 / Files changed

- `src/components/config-core.tsx`
- `src/components/config-debug.tsx`
- `src/layout/components/harness-updater.tsx`
- `src/hooks/use-core-breaking-confirm.tsx`（新增 / new）
- `src/utils/core-version.ts`（新增 / new）
- `src/i18n/locales/en-US.json`
- `src/i18n/locales/zh-CN.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings and confirmation steps before downloading or applying core versions newer than `0.1.1-rc.2`.
  * Canceling or dismissing the confirmation now prevents the download or update notification.
  * Added English and Simplified Chinese guidance about potential breaking changes, third-party plugin compatibility, and rollback options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->