### PR TITLE
fix: show target version in plugin upgrade chip

### DIFF
--- a/src/components/config-plugin.tsx
+++ b/src/components/config-plugin.tsx
@@ -449,10 +449,11 @@ export function ConfigPlugin() {
                         <span className="flex items-center gap-1">
                           <If cond={busy?.id === plugin.id && busy.action === 'update'} then={<Spinner size="sm" color="current" />} />
                           {t('plugins.upgrade')}
-                          {/* TODO: hash 会超出长度 */}
-                          {/* <If cond={plugin.latestVersion != null && plugin.error == null}>
-                            <span className="font-mono text-[10px] opacity-80">{plugin.latestVersion}</span>
-                          </If> */}
+                          <If cond={plugin.latestVersion != null && plugin.error == null}>
+                            <span className="font-mono text-[10px] opacity-80 max-w-[80px] truncate">
+                              {plugin.latestVersion!.length >= 40 ? `${plugin.latestVersion!.slice(0, 8)}…` : plugin.latestVersion}
+                            </span>
+                          </If>
                         </span>
                       </Chip>
                     </If>

--- a/src/components/config-plugin.tsx
+++ b/src/components/config-plugin.tsx
@@ -451,7 +451,7 @@ export function ConfigPlugin() {
                           {t('plugins.upgrade')}
                           <If cond={plugin.latestVersion != null && plugin.error == null}>
                             <span className="font-mono text-[10px] opacity-80 max-w-[80px] truncate">
-                              {plugin.latestVersion!.length >= 40 ? `${plugin.latestVersion!.slice(0, 8)}…` : plugin.latestVersion}
+                              {plugin.latestVersion && plugin.latestVersion.length >= 40 ? `${plugin.latestVersion.slice(0, 8)}…` : plugin.latestVersion}
                             </span>
                           </If>
                         </span>


### PR DESCRIPTION
## Summary

The plugin upgrade chip showed only "Upgrade" text with no version indicator. The code that would display the version was commented out with a TODO about overflow.

## Fix

Uncomment the version display with smart truncation:
- Hashes (40+ chars): show first 8 chars + ellipsis (e.g. `a1b2c3d4…`)
- Semver (short): show as-is (e.g. `0.10.1`)
- `max-w-[80px] truncate` as safety net against overflow

## Typecheck

✅ `pnpm typecheck` passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rendering errors when a plugin’s latest version is unavailable.
  * Preserved shortened display formatting for long version values, improving readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->