### PR TITLE
fix: move hardcoded language names to i18n

### DIFF
--- a/src/components/config-debug.tsx
+++ b/src/components/config-debug.tsx
@@ -366,8 +366,8 @@ export function ConfigDebug() {
             </Select.Trigger>
             <Select.Popover className="rounded-md">
               <ListBox>
-                <ListBox.Item className="rounded-md min-h-8!" id="zh-CN" textValue="中文">中文</ListBox.Item>
-                <ListBox.Item className="rounded-md min-h-8!" id="en-US" textValue="English">English</ListBox.Item>
+                <ListBox.Item className="rounded-md min-h-8!" id="zh-CN" textValue={t('ui.languages.zh')}>{t('ui.languages.zh')}</ListBox.Item>
+                <ListBox.Item className="rounded-md min-h-8!" id="en-US" textValue={t('ui.languages.en')}>{t('ui.languages.en')}</ListBox.Item>
               </ListBox>
             </Select.Popover>
           </Select>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -111,6 +111,8 @@
   "ui.iframe_error": "Cannot load the DeepSeek Harness interface.",
   "ui.ensure_running": "Please make sure the service is running at {{url}}.",
   "ui.language": "Language",
+  "ui.languages.zh": "Chinese",
+  "ui.languages.en": "English",
   "ui.connection_status": "Connection",
   "ui.running": "Running",
   "ui.stopped": "Stopped",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -111,6 +111,8 @@
   "ui.iframe_error": "无法加载 DeepSeek Harness 界面。",
   "ui.ensure_running": "请确认服务正在 {{url}} 运行。",
   "ui.language": "语言",
+  "ui.languages.zh": "中文",
+  "ui.languages.en": "English",
   "ui.connection_status": "连接状态",
   "ui.running": "运行中",
   "ui.stopped": "已停止",


### PR DESCRIPTION
## Summary

The language selector in `config-debug.tsx` hardcoded '中文' and 'English' as display labels. These strings did not respond to language switching.

## Fix

- Add `ui.languages.zh` and `ui.languages.en` keys to both locale files
- Replace hardcoded strings with `t()` calls in `config-debug.tsx`
- In Chinese mode: shows '中文 / English'
- In English mode: shows 'Chinese / English'

## Typecheck

✅ `pnpm typecheck` passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Language options in the settings now display translated labels based on the selected interface language.
  * Added localized labels for Chinese and English in both English and Chinese translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->