### PR TITLE
fix: verify harness is stopped before backup restore

### DIFF
--- a/src/components/config-backup.tsx
+++ b/src/components/config-backup.tsx
@@ -22,6 +22,23 @@ function formatSize(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)}`
 }
 
+/** 轮询 health check 确认 DSH 服务已真正停止，避免文件锁冲突。 */
+async function waitForHarnessStopped(timeoutMs = 10_000, intervalMs = 500): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await invoke('proxy_health_check')
+      // 服务仍在运行，继续等待
+    }
+    catch {
+      // health check 失败说明服务已停止
+      return
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs))
+  }
+  // 超时后继续执行（shutdown 可能仍在进行中）
+}
+
 export function ConfigBackup({ onBack }: ConfigBackupProps) {
   const { t } = useTranslation()
   const { backups, loading, error, createBackup, restoreBackup, deleteBackup, busy, creating, restoring, deleting } = useBackups()
@@ -58,12 +75,14 @@ export function ConfigBackup({ onBack }: ConfigBackupProps) {
     try {
       // 先停止 DSH 服务（释放 profile 目录的文件锁）
       toast(t('backup.restored_stopped_toast'), { variant: 'accent' })
-      try {
-        await invoke('shutdown_harness')
-      }
-      catch (e) {
-        console.warn('[ConfigBackup] shutdown_harness failed (may already be stopped):', e)
-      }
+      await invoke('shutdown_harness')
+      // 验证服务已真正停止，避免在运行时操作文件导致锁冲突
+      await waitForHarnessStopped()
+    }
+    catch (e) {
+      console.warn('[ConfigBackup] shutdown_harness failed (may already be stopped):', e)
+    }
+    try {
       await restoreBackup(timestamp, false)
       // 还原后自动启动 DSH 服务（后台异步，不阻塞 UI）
       invoke('launch_harness').catch((e) => {

--- a/src/components/config-backup.tsx
+++ b/src/components/config-backup.tsx
@@ -22,21 +22,32 @@ function formatSize(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)}`
 }
 
-/** 轮询 health check 确认 DSH 服务已真正停止，避免文件锁冲突。 */
+/** 轮询 health check 确认 DSH 服务已真正停止，避免文件锁冲突。
+ *  - 使用剩余 timeout 约束 in-flight 的 probe，防止无限挂起
+ *  - 仅当 health check 明确失败（非 transient 错误）时才视为已停止
+ *  - 超时后继续执行（shutdown 可能仍在进行中）
+ */
 async function waitForHarnessStopped(timeoutMs = 10_000, intervalMs = 500): Promise<void> {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
+    const remaining = timeoutMs - (Date.now() - start)
+    if (remaining <= 0)
+      break
+    const timeoutPromise = new Promise<never>((_, reject) => setTimeout(() => reject(new Error('probe timeout')), remaining))
     try {
-      await invoke('proxy_health_check')
+      await Promise.race([invoke('proxy_health_check'), timeoutPromise])
       // 服务仍在运行，继续等待
     }
-    catch {
-      // health check 失败说明服务已停止
-      return
+    catch (e) {
+      // probe 超时视为已停止
+      if (e instanceof Error && e.message === 'probe timeout')
+        return
+      // 非 transient 错误视为已停止；transient 错误（502 等）继续重试
+      if (!(e instanceof Error) || !/502|ECONNREFUSED|ETIMEDOUT/i.test(e.message))
+        return
     }
     await new Promise(resolve => setTimeout(resolve, intervalMs))
   }
-  // 超时后继续执行（shutdown 可能仍在进行中）
 }
 
 export function ConfigBackup({ onBack }: ConfigBackupProps) {
@@ -72,16 +83,16 @@ export function ConfigBackup({ onBack }: ConfigBackupProps) {
     catch {
       return
     }
+    // 先停止 DSH 服务（释放 profile 目录的文件锁）
+    toast(t('backup.restored_stopped_toast'), { variant: 'accent' })
     try {
-      // 先停止 DSH 服务（释放 profile 目录的文件锁）
-      toast(t('backup.restored_stopped_toast'), { variant: 'accent' })
       await invoke('shutdown_harness')
-      // 验证服务已真正停止，避免在运行时操作文件导致锁冲突
-      await waitForHarnessStopped()
     }
     catch (e) {
       console.warn('[ConfigBackup] shutdown_harness failed (may already be stopped):', e)
     }
+    // 无论 shutdown 成功与否，都验证服务已真正停止
+    await waitForHarnessStopped()
     try {
       await restoreBackup(timestamp, false)
       // 还原后自动启动 DSH 服务（后台异步，不阻塞 UI）


### PR DESCRIPTION
## Summary

Previously, `shutdown_harness` failure was caught and logged, then `restoreBackup` proceeded immediately. If the harness wasn't actually stopped, the restore could operate on locked files.

## Fix

- Add `waitForHarnessStopped()` that polls `proxy_health_check` until the service stops (or timeout after 10s)
- Replace nested try-catch with sequential try-catch blocks for clearer control flow

## Typecheck

✅ `pnpm typecheck` passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration restore reliability by confirming the service has stopped before restoring files, even when shutdown reports an error.
  * Added retries for temporary health-check failures, including connection and timeout errors.
  * Ensured stop checks respect a 10-second deadline and do not wait indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->