### PR TITLE
chore: release v0.10.3-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.2",
+  "version": "0.10.3-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.2"
+version = "0.10.3-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.2"
+version = "0.10.3-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.2",
+  "version": "0.10.3-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.3-beta.1` (`0.10.2` → `0.10.3-beta.1`).

### Features

- **core**: warn before downloading core versions above rc.2 (#323) (62a6760)
- **dsh-tauri-panel-scheduler**: 支持定时任务面板插件 (#317) (1eac658)
- **plugin**: 单插件原子快照 snapshot & restore (#303, #318) (4395578)

### Bug Fixes

- **plugin internal**: Clean up the old profile rollback directory and fix pnpm errors (073a211)
- show target version in plugin upgrade chip (#325) (3e4fecb)
- move hardcoded language names to i18n (#326) (d73aa8b)
- **workflow**: remove unsupported dsh host flag (#330) (bc4b18a)
- verify harness is stopped before backup restore (#329) (90d32fd)
- **plugin**: uninstall orphaned internal plugins whose link dir vanished (#321) (3fa3e42)
- **plugin**: snapshot restore decodes gzip archives correctly (#322) (ca4094b)
- **10**: 备份 + 克隆 5 问题综合修复 (#271) (47c840a)
- **dsh-tauri-worktree**: per-session ledger files + atomic-write EPERM retry (same-group worktrees no longer clash) (#315) (8d1f380)
- **workflow**: retry duplicate loader startup on Unix (#304) (1608772)

### Documentation

- **dsh-tauri-worktree**: add worktree deletion reliability optimization plan (#320) (04997eb)
- **webhook**: add dsh-webhook(-github) interface inventory for issue #287 (#313) (f23646e)
- **sdk**: Phase 3 SDK stdio 桥接口盘点单与复用性评估 (#286, #312) (0642dbb)

### Other Changes

- Update README.en.md (49febde)
- Update README.md (cf05fee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.10.3-beta.1** across release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->