### PR TITLE
docs(plugins): 内置插件 UI 收敛优化方案

### DIFF
--- a/docs/plugins/8.优化计划.内置插件UI收敛.md
+++ b/docs/plugins/8.优化计划.内置插件UI收敛.md
@@ -1,0 +1,246 @@
+# 内置插件 UI 收敛优化方案
+
+> 目标：消除 `packages/*` 之间从官方源码 / 彼此 Copy 的重复 UI 实现，把所有通用组件、通用样式变量统一收敛到 `dsh-tauri-ui` 的共享 `client` 面，其他插件经 `dsh-tauri-ui/client` 复用。官方组件可用的优先引用官方组件（Icon 除外）。本方案是**计划文档**，不含最终代码，供实施时对照执行。
+
+---
+
+## 一、现状盘点（问题清单）
+
+通过通读 `packages/*` 的 `client/components/`、`client/styles/`、`client/constants/`，确认存在以下重复：
+
+### 1.1 逐字 / 近逐字重复的组件
+
+| 组件 | 重复位置 | 差异点 | 说明 |
+| --- | --- | --- | --- |
+| **`MenuSelect`**（官方「触发按钮 + primitives `Menu`」下拉） | `dsh-tauri-session` + `dsh-tauri-panel-scheduler` | 仅触发按钮 class（`K.menuSelect` vs `K.selector`）与图标组件（自绘 `IconChevronDown` vs 官方 `IconChevronDownOutline14`）不同，逻辑逐字相同 | 两个插件的 `comments` 甚至互相引用对方为范本 |
+| **`styles/index.ts` 顶部颜色变量串** | `panel-scheduler` + `panel-extension`（至少 2 处） | `const primary = 'var(--dsw-alias-label-primary)'` 等逐字重复 | 样式文件「通用 --dsw-alias-* 令牌串」在每个插件各自重抄一遍 |
+| **自绘 inline SVG 图标**（`icons.tsx`） | `panel` / `panel-extension` / `panel-placeholder` / `panel-scheduler` / `session` / `worktree` / `ui` | 从 Gravity 源或官方 bundle path 抄录，各自维护 | 每插件一份 `icons.tsx`，无统一来源表 |
+| **`IconProps` 类型** | `panel` / `panel-extension` / `session` / `panel-placeholder` | 各 `client/types` 里各声明一份 | 可合并为共享类型 |
+| **官方控件复刻样式规则**（input / 36px 胶囊按钮 / pill selector / focusRing / selectInput 下箭头 data-uri / focus 环） | `panel-scheduler` / `panel-extension` / `session` / `worktree` 的 `styles/index.ts` | 大量 `.xxx-input`、`.xxx-btn`、`.xxx-selector` 等基于同一批官方样式值 | 布局规则无法完全二合一，但「令牌、data-uri、focusRing」等**样式常量**可统一 |
+
+> **根因**：各插件从官方源码（`dsh-web-frontend` bundle、`dsh-automation` 面板、Gravity icons）独立抄录样式值 / SVG path / 下拉模式，缺少一个「共享组件 + 共享常量」的落点，也没有「来源标注」约定。修一处不改别处易漂移。
+
+### 1.2 已确立的正确范式（应推广）
+
+- **`dsh-tauri/client` 已是「插件入口 + 全 workspace 客户端共享工具」双面 barrel**（见 `packages/dsh-tauri/src/client/index.ts`：`CssRender` / `createHooks` / `store` / `controller` / date-fns / types）。这是 `dsh-tauri-ui/client` 应仿照的既有模式。
+- **`dsh-tauri-ui/src/client/components/nav-icon.tsx` 已示范「优先用官方 primitives 图标」**（`IconSettingsOutline16` 等，经 ModuleLoader 解析、与官方同源、自动跟随上游），并自带来源注释。
+- **组件文件命名已规范**为 kebab-case（`menu-select.tsx` / `action-item.tsx` / `width-handle.tsx`…），无 PascalCase。
+- 布局样式仍按 AGENTS.plugins.md 用 css-render、插件前缀 class（`disc.plugins.md:223` 禁 css module hash），挂载仅在 `apply()` 的 effect 中。
+
+---
+
+## 二、方案目标与取舍
+
+### 2.1 发布面设计：`dsh-tauri-ui/client` 兼具「插件入口」与「共享组件库」双面
+
+参照 `dsh-tauri/client` 的成功先例，让 `dsh-tauri-ui` 的 `client` barrel 同时承担：
+
+1. **插件本体**（现设置侧边栏的 `apply` / `name` / `inject`、`seat` / `sidebar` / `trigger`）。
+2. **共享 UI 组件库**：图标、`MenuSelect`、通用控件、footer/header 等被其他插件复用。
+3. **共享样式常量**：`--dsw-alias-*` 令牌串、focusRing、data-uri 等，经 `styles` 对象包装导出（`styles.primary`…，见 Phase C）。
+
+**关键改造**：`packages/dsh-tauri-ui/tsdown.config.ts` 需像 `dsh-tauri` 那样在 `client` 上开 `dts: true`，产出 `dist/client.d.cts` 类型声明，使 `./client` export 可被其他包 `import` 且类型成立。
+
+### 2.2 依赖方向（单向，防耦合反转）
+
+```
+其他插件 client ──import──▶ dsh-tauri-ui/client   （允许）
+dsh-tauri-ui/client ──不可──▶ 其他插件的 client   （禁止）
+```
+
+- 共享组件/常量只允许**下钻依赖** `dsh-tauri/client`（`CssRender` 等）与 `@deepseek-ai/*`（primitives / renderer）。
+- `dsh-tauri-ui/client` 不得反向引用某插件私有 `constants` / `types` / `hooks`，否则产生环。
+- 插件私有部分仍留在各插件 `client/components/`，只有**≥2 处复用 / 协议级通用**的才迁入 `dsh-tauri-ui`。
+
+### 2.3 「优先官方组件，Icon 除外」的采纳规则
+
+| 类别 | 策略 |
+| --- | --- |
+| 官方 `@deepseek-ai/dsh-client-ui-primitives` 已有组件 | **优先直接引用**（`Menu` / `Modal` / `Button` / `Input` / `StateDot` / `Toast`…）。共享 `dsh-tauri-ui` 里**不重复封装**官方已提供的原子组件 |
+| 官方没有、但有通用模式的（如 `MenuSelect` = Menu+触发按钮） | 在 `dsh-tauri-ui` 封装一次，各插件复用 |
+| **图标（Icon）** | **全局统一：`dsh-tauri-ui` 安装 `@gravity-ui/icons`（React 源，`import { Cloud } from '@gravity-ui/icons'` 按需命名导入），并经 `dsh-tauri-ui/client` 暴露给所有模块。** 所有插件一律经 `dsh-tauri-ui/client` 引用图标，**不再各自自绘 SVG、不再手抄 Gravity path、不再散装维护 `icons.tsx`**。官方 primitives 中如有同款语义图标（如 chevron），优先用官方；缺失的才从 `@gravity-ui/icons` 取 |
+| 样式令牌 / 官方控件样式值 | 迁入 `dsh-tauri-ui` 的样式常量模块，注释标注来源文件（`ModelsSection.module.css` / `LanguageRow.module.css` 等） |
+
+#### 2.3.1 图标统一：`@gravity-ui/icons` 接入
+
+- **来源**：[`@gravity-ui/icons`](https://cdn.jsdelivr.net/npm/@gravity-ui/icons@2.18.0/README.md)（已在 `pnpm-workspace.yaml` 的 `catalog:runtime`，`^2.21.0`）。React 源提供两类导入（见 [README](https://www.npmjs.com/package/@gravity-ui/icons)）：
+  ```ts
+  import Cloud from '@gravity-ui/icons/Cloud'      // 子路径默认导出
+  import { Cloud } from '@gravity-ui/icons'          // barrel 命名导出
+  ```
+- **按需导入**：只 `import` 用到的图标名，配合 tree-shaking，不整包引入 `@gravity-ui/icons` 进产物。
+- **归属与内联**：`@gravity-ui/icons` 由 **`dsh-tauri-ui` 单点安装并内联**到其 `client` bundle（见 Phase A / D），其他插件**禁止直接 `import '@gravity-ui/icons'`**，一律 `import { … } from 'dsh-tauri-ui/client'` 转发。dsh-tauri-tsdown 需把 `@gravity-ui/icons` 纳入 client 内联列表，否则 ModuleLoader 查表失败。
+- **一致性兜底**：若某个图标官方 primitives 与 `@gravity-ui/icons` 视觉需保持一致（同款同 path），以 `@gravity-ui/icons` 为准，注释标明「官方同款」。
+
+### 2.4 不做什么（边界）
+
+- **布局样式不回收到单一 style 里**：各插件面板布局/几何差异大，强行合并反而难维护；只统一「令牌/常量/data-uri/focusRing」，布局规则仍按 css-render 留在各插件。
+- **不新建 `constants(css 变量) + styles/index.ts` 的间接层**（用户明确反对）：直接用字符串常量，命名即值，见 §3.3。
+- **不引入新 UI 依赖**（heroui / tailwind 仅在桌面壳 `src/` 用，**不**进入插件 client bundle，避免破坏 loader 模块表）。
+- **不复用桌面壳 `src/components`**：那是 Tauri 壳的 React 栈（Tailwind 4 + heroui），与插件 client 的 css-render 运行时不同调，跨体系复用的成本/风险不划算。
+
+---
+
+## 三、落地实施清单
+
+### Phase A — `dsh-tauri-ui` 的共享 client 面搭建（插件入口 + 共享库双面）
+
+#### A1. `dsh-tauri-tsdown` 新增共享面配置
+
+`dsh-tauri-tsdown` 需支持「双面 client」：一个插件包同时产出**插件入口 bundle**（ModuleLoader 包裹的 `.cjs`，含 `apply`）与**共享库面**（可被其他插件 `import` 的 ESM + 类型）。参照 `dsh-tauri/client` 先例，具体配置：
+
+- **`dsh-tauri-tsdown/src/index.mjs`**：
+  - `dshExternal` 追加条目 `'dsh-tauri-ui/client'` —— 使消费插件把该共享面当 external，不重复内联进各自 bundle，而是在 ModuleLoader 模块表解析一次。
+  - `dshClientInline` 追加 `@gravity-ui/icons`（`/^@gravity-ui\/icons$/` 或 `(/-.*)?` 覆盖子路径）—— 让 `dsh-tauri-ui/client` 把图标包内联进产物，避免残留 `require('@gravity-ui/icons')` 查表失败。
+  - 暴露一个开 `dts: true` 的开关，允许插件在 client 上产出 `dist/client.d.cts`（当前 `defineDshConfig` 默认 `client.dts: false`）。
+- **`packages/dsh-tauri-ui/tsdown.config.ts`**：`client` 设 `dts: true`，产出 `dist/client.d.cts`，使 `./client` export 具备可导入类型；`@gravity-ui/icons` 进入内联。
+
+#### A2. 双面目录落位（沿用 AGENTS.plugins.md 收敛规则）
+
+- `src/client/components/`：共享组件与共享图标，每文件一个 kebab-case 组件。
+  - `src/client/components/icons.tsx`：`export * from '@gravity-ui/icons'` 的**转发 barrel**（+ 官方 primitives 图标再导出），统一经 `dsh-tauri-ui/client` 暴露。
+- `src/client/theme.ts`（新）：共享样式常量（见 Phase C）。
+- `src/client/types/`：共享 `IconProps`、`MenuSelectOption`/`MenuSelectProps` 等。
+
+#### A3. `src/client/index.ts` barrel 双面
+
+在保留插件 `apply`/`name`/`inject` 导出的同时，追加：
+
+```ts
+export * from './components'        // 共享组件 + 图标转发（含 @gravity-ui/icons 再导出）
+export { styles } from './theme'    // 共享样式常量（styles 对象包装，非散落导出）
+export type * from './types'        // IconProps / MenuSelectProps 等
+```
+
+即：`dsh-tauri-ui/client` **既是设置侧栏插件的浏览器 half，也是全 workspace 的 UI 共享库**（与 `dsh-tauri/client` 的工具共享面同构）。
+
+### Phase B — 通用组件迁移与去重
+
+**B1. `MenuSelect` 收敛**（两端逐字重复，最高优先）：
+
+- 在 `dsh-tauri-ui` 实现**带 `variant` 的通用 `MenuSelect`**（pill / default 两种触发样式），props 采用官方 `MenuEntry` 语义，**图标默认用官方 `IconChevronDownOutline14`**，把两插件唯一的样式差异收进 `variant`。
+- `dsh-tauri-session` / `dsh-tauri-panel-scheduler` 改为 `import { MenuSelect } from 'dsh-tauri-ui/client'`，删除各自 `menu-select.tsx` 与本地 `IconChevronDown`（或仅保留官方无替代的图标）。
+- 校验点：两个插件的 aria-label / 触发按钮 class 行为保持不变（回归其 slot / 选择功能）。
+
+**B2. 图标全局统一（`@gravity-ui/icons`）**：
+
+- `dsh-tauri-ui` 安装 `@gravity-ui/icons`（`catalog:runtime`），`src/client/components/icons.tsx` 做**转发 barrel**：`export { Cloud, … } from '@gravity-ui/icons'`（按需命名导入），并经 `dsh-tauri-ui/client` 暴露。官方 primitives 同款语义图标（chevron/check/warning 等）仍优先用官方组件，缺失的从 `@gravity-ui/icons` 转发。
+- 各插件删除各自 `components/icons.tsx` 里被 `@gravity-ui/icons` 覆盖的自绘/抄录 SVG，改为 `import { … } from 'dsh-tauri-ui/client'`。不再手抄 Gravity path，不再维护散装来源表（`@gravity-ui/icons` 包自带上游修订历史）。
+- 官方 primitives 完全覆盖的图标（如 chevron）直接用官方；`@gravity-ui/icons` 无、官方也无的极个别特制图标（如品牌 FishMark）保留在 `dsh-tauri-ui` 本地并有来源注释，不散落各插件。
+
+**B3. 其余可复用容器**：
+
+- 若后续发现 ≥2 处使用同一「官方控件复刻 + 布局」组合（如 36px 胶囊按钮 `Btn`/`BtnPrimary`/`BtnDanger` 的 class 组合、search icon 定位 wrapper、Tabs、ERROR/EMPTY 状态文案），在 `dsh-tauri-ui` 封装成 `components/` 或暴露样式常量，逐个迭代，**不一次大爆炸重写**。
+
+### Phase C — 通用样式 / 变量字符串统一
+
+> 用户要求：**不要 `constants(css 变量) + styles/index.ts` 间接层**，直接写字符串常量。命名即值。**不散落导出，统一经 `styles` 对象包装一层**，消费方用命名空间访问，避免顶层命名冲突。
+
+在 `dsh-tauri-ui` 新建样式常量模块（`src/client/theme.ts`），导出**单个 `styles` 对象**（CSS 令牌串 / 几何值 / data-uri / focusRing），所有值用字符串直接字面量：
+
+```ts
+// dsh-tauri-ui/src/client/theme.ts
+/** --dsw-alias-* 令牌串（来源：dsh web-frontend design tokens，官方两级主题自动适配）。 */
+export const styles = {
+  primary:     'var(--dsw-alias-label-primary)',
+  secondary:   'var(--dsw-alias-label-secondary)',
+  tertiary:    'var(--dsw-alias-label-tertiary)',
+  dimmed:      'var(--dsw-alias-label-dimmed)',
+  borderL2:    'var(--dsw-alias-border-l2)',
+  borderL3:    'var(--dsw-alias-border-l3)',
+  borderL4:    'var(--dsw-alias-border-l4)',
+  brand:       'var(--dsw-alias-brand-primary)',
+  business:    'var(--dsw-alias-state-business-primary)',
+  layer1:      'var(--dsw-alias-bg-layer-1)',
+  layer3:      'var(--dsw-alias-bg-layer-3)',
+  hover:       'var(--dsw-alias-interactive-bg-hover)',
+  hoverSolid:  'var(--dsw-alias-interactive-bg-hover-solid)',
+  hoverDanger: 'var(--dsw-alias-interactive-bg-hover-danger)',
+  error:       'var(--dsw-alias-state-error-primary)',
+  success:     'var(--dsw-alias-state-success-primary)',
+  primaryFill:  'var(--dsw-alias-button-primary-fill)',
+  primaryHover: 'var(--dsw-alias-button-primary-hover)',
+  primaryFg:    'var(--dsw-alias-label-primary-foreground)',
+  /** 官方共用焦点环（2px border-l3 描边）。来源：官方 focus-visible 样式。 */
+  focusRing: { boxShadow: '0 0 0 2px var(--dsw-alias-border-l3)', outline: 'none' },
+  /** selectInput 下箭头 data-uri（官方 ModelsSection 原样）。 */
+  chevronSelectSvg: `url("data:image/svg+xml,%3Csvg ...`)`,
+} as const
+```
+
+> `styles` 用 `as const` 锁定值；`focusRing` 为 readonly 对象，传 css-render 时可 `as CSSProperties` 或浅拷贝。设计上有意**不拆 `constants(css 变量)+styles` 两文件**：单一 `styles` 对象即值即命名，随官方令牌新增原子扩展，不建冗余间接层。
+
+各插件 `styles/index.ts` 顶部改为：
+
+```ts
+import { styles } from 'dsh-tauri-ui/client'
+const { primary, secondary, borderL2, focusRing } = styles
+// 或直接 styles.primary / styles.focusRing 命名空间访问
+```
+
+删除本地重复声明。**布局/几何规则仍留在各插件 css-render 节点**，只抽「值」。
+
+### Phase D — 依赖声明与模块表
+
+1. `dsh-tauri-ui` 的 plugin `client` 的 `dsh.client.inject` / `external` 维持现状（它自己是插件）。
+2. 消费插件的 `package.json` 增加 `dsh-tauri-ui` 为依赖（`workspace:*`）。
+3. **构建期 external**：消费插件 client 在构建时按 `dshExternal` 已把 `dsh-tauri/client` 当 external；对 `dsh-tauri-ui/client` 同理应视为跨模块共享面（在 `dsh-tauri-tsdown` 的 `dshExternal` 追加 `dsh-tauri-ui/client`），让共享代码不被重复内联进各插件 bundle，而是在 ModuleLoader 模块表里解析一次。
+   - 校验：`pnpm build` 部署后各插件 client bundle 不含 `dsh-tauri-ui` 共享体副本，且运行时 `import { MenuSelect } from 'dsh-tauri-ui/client'` 能解析。
+4. **`@gravity-ui/icons` 单点内联**：`dsh-tauri-tsdown` 的 `dshClientInline` 追加 `@gravity-ui/icons`，仅 `dsh-tauri-ui/client` 内联图标包；其他插件 `import { … } from 'dsh-tauri-ui/client'`，**禁止直接 `import '@gravity-ui/icons'`**（模块表查不到会报 "missed the module table"）。
+
+---
+
+## 四、风险与对策
+
+| 风险 | 对策 |
+| --- | --- |
+| `dsh-tauri-ui/client` 双面（插件入口 + 共享库）让 bundle 体积/入口变重 | `dsh-tauri` 已有同构先例（见 §1.2），可接受；共享体天然只在第一次被链接插件解析 |
+| 迁移 `MenuSelect` 改变触发按钮 class → 影响既有 css | 收敛时把两插件差异收进 `variant`，class 名保持插件前缀稳定，回归功能 |
+| 官方 primitives 图标缺失、自绘 SVG 需长期跟随上游 | 已弃用自绘：图标统一走 `@gravity-ui/icons` 单点内联转发（见 Phase A/D），官方 primitives 同款优先官方；移除手抄 SVG，不再散装维护 |
+| 共享样式常量 `primary`/`secondary` 等过泛、易与消费方本地变量撞名 | 统一经 `styles` **对象包装**访问（`styles.primary`），不散落顶层导出；消费方可 `const { primary } = styles` 选择性解构 |
+| `dshExternal` 追加 `dsh-tauri-ui/client` 影响现有插件构建 | 追加后增量验证各插件 `typecheck` + `build`；若某个插件依赖的版本间有循环则拆分「共享库子包」 |
+| 过度收敛：把仅单体使用的组件也迁入，制造单向依赖噪音 | 严格门槛：**≥2 处复用或协议级通用**才迁入；其余留本地 |
+| 桌面壳的 heroui/Tailwind 组件被误用作插件 UI 依赖 | 明确边界（§2.4）：插件 client 只用 css-render + primitives + 共享 `dsh-tauri-ui` |
+
+---
+
+## 五、验收清单
+
+- [ ] `dsh-tauri-ui/client` 产出 `dist/client.d.cts`，其他插件能 `import { MenuSelect, ... } from 'dsh-tauri-ui/client'` 且类型成立；`dsh-tauri-ui/client` 兼具插件入口（apply/name/inject）与共享库（组件/图标/主题/类型）双面。
+- [ ] 图标统一：`@gravity-ui/icons` 由 `dsh-tauri-ui/client` 转发（按需命名导入），各插件不再自绘/手抄 SVG、不再本地维护 `icons.tsx`；官方 primitives 已覆盖的图标（chevron 等）直接用官方。
+- [ ] 各插件 `styles/index.ts` 不再重复声明 `--dsw-alias-*` 令牌串，统一经 `styles` 对象（`styles.primary` 等）从 `dsh-tauri-ui/client` 访问；无散落顶层导出、无 `constants(css 变量)+styles/index.ts` 间接层。
+- [ ] `MenuSelect` 只有一份实现，`dsh-tauri-session` / `dsh-tauri-panel-scheduler` 改为引用共享版，本地副本删除。
+- [ ] 官方已有的原子组件（`Menu`/`Modal`/`Button`/`Input`/`StateDot`/`Toast`）在 `dsh-tauri-ui` **不重复封装**，直接引用。
+- [ ] 依赖方向单向：`dsh-tauri-ui/client` 不反向依赖任何插件私有模块。
+- [ ] `dsh-tauri-tsdown` 的 `dshExternal` 含 `dsh-tauri-ui/client`，构建产物无共享体重复内联。
+- [ ] `pnpm run lint --fix`、`pnpm run typecheck`（含各包 `pnpm --filter <pkg> typecheck`）、`pnpm run test -- --run`、`pnpm run build` 全绿；桌面端加载验证两个面板（session / scheduler / extension）回归正常。
+- [ ] 迁移每个组件都满足「≥2 处复用或协议级通用」门槛，无仅单体组件混入。
+- [ ] 各插件 README 与 `docs/AGENTS.plugins.md` 补充「共享组件/常量从 `dsh-tauri-ui/client` 获取」的约定。
+
+---
+
+## 六、来源对照表（便于官方源码同步）
+
+| 共享项 | 官方来源 | 同步时依据 |
+| --- | --- | --- |
+| `--dsw-alias-*` 令牌 | dsh web-frontend design tokens | 提取值是否仍存在；以官方两级主题实测为准 |
+| input / selectInput / iconButton / 36px 胶囊按钮 | `dsh-automation` `ModelsSection.module.css` | 对应 css module |
+| pill selector | `LanguageRow.module.css` | 对应 css module |
+| selectInput 下箭头 data-uri | 官方 `ModelsSection` data-uri | 原样字符串比对 |
+| focusRing | 官方 focus-visible 样式值 | 取值比对 |
+| 图标（`@gravity-ui/icons` React 源） | 上游包自带修订历史，无需手工同步 | 升级 catalog 版本；`dsh-tauri-ui/client` 转发 barrel 保持导出名稳定 |
+
+> 每处共享实现顶部注释应写明「来源 + 提取位置 + 同步提示」，见 Phase B2 / Phase C 示例。
+
+---
+
+## 七、文件索引
+
+- 共享面模板：`packages/dsh-tauri/src/client/index.ts`（双面 barrel 先例）
+- 双面配置改造：`packages/dsh-tauri-tsdown/src/index.mjs`（`dshExternal` 加 `dsh-tauri-ui/client`；`dshClientInline` 加 `@gravity-ui/icons`；client 开 `dts`）、`packages/dsh-tauri-ui/tsdown.config.ts`
+- 分享面改造：`packages/dsh-tauri-ui/src/client/index.ts`（插件入口 + 共享库 barrel）
+- 共享组件落位：`packages/dsh-tauri-ui/src/client/components/`（`menu-select.tsx`、`icons.tsx` 转发 barrel 等）
+- 图标来源：`@gravity-ui/icons`（`catalog:runtime` `^2.21.0`，React 命名导入），`dsh-tauri-ui/client` 单点内联转发
+- 共享样式常量：`packages/dsh-tauri-ui/src/client/theme.ts`（新建，导出单一 `styles` 对象）
+- 共享类型：`packages/dsh-tauri-ui/src/client/types/`（`IconProps`、`MenuSelectProps` 等）
+- 现有重复源（迁移对象）：`packages/dsh-tauri-session/…/menu-select.tsx`、`packages/dsh-tauri-panel-scheduler/…/menu-select.tsx`、及各自 `components/icons.tsx`、`styles/index.ts`


### PR DESCRIPTION
解决 `packages/*` 之间从官方源码/彼此 Copy 的重复 UI 实现，把所有通用组件、通用样式变量统一收敛到 `dsh-tauri-ui` 共享 `client` 面。

## 核心决策

1. **图标全局统一**：`dsh-tauri-ui` 安装 `@gravity-ui/icons`（React 源，按需命名导入），经 `dsh-tauri-ui/client` 暴露给所有模块；各插件不再自绘/手抄 SVG、不再散装维护 `icons.tsx`。
2. **dsh-tauri-ui/client 双面**：插件入口 + 共享组件库。`dsh-tauri-tsdown` 新增配置（`dshExternal` 加 `dsh-tauri-ui/client`；`dshClientInline` 内联 `@gravity-ui/icons`；client 开 `dts` 产 `.d.cts`）。
3. **共享样式常量**：经 `styles` 对象包装导出（`styles.primary` / `styles.secondary` / `styles.focusRing` …），不建 `constants(css 变量)+styles/index.ts` 间接层。
4. **去重**：`MenuSelect` 等逐字重复组件收敛；官方 primitives 已有组件优先引用、不重复封装（Icon 除外）。

## 现状盘点（实证）

- `MenuSelect` 在 `dsh-tauri-session` / `dsh-tauri-panel-scheduler` 逐字重复。
- `--dsw-alias-*` 令牌串在多个插件 `styles/index.ts` 重复声明。
- 每插件一份自绘 `icons.tsx`（Gravity 源/官方 bundle path 抄录）。

详见文档 `docs/plugins/8.优化计划.内置插件UI收敛.md`（Plan-only，含 Phase A–D、风险对策、验收清单、来源对照表、文件索引）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - 新增内置插件 UI 统一优化计划。
  - 记录共享组件、图标、样式规范和类型的统一方案，帮助各插件保持一致的视觉体验。
  - 补充依赖迁移、构建配置、风险应对措施、验收标准及相关官方资料索引。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->