### PR TITLE
chore: release v0.10.3-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.3-beta.1",
+  "version": "0.10.3-beta.2",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.3-beta.1"
+version = "0.10.3-beta.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.3-beta.1"
+version = "0.10.3-beta.2"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.3-beta.1",
+  "version": "0.10.3-beta.2",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.3-beta.2` (`0.10.3-beta.1` → `0.10.3-beta.2`).

### Bug Fixes

- **plugins**: load scheduler runtime via platform loader (#336) (b035b64)

### Documentation

- **plugins**: 内置插件 UI 收敛优化方案 (#335) (6be918d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.10.3-beta.2** across supported release configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->