### PR TITLE
fix(clipboard): stop Wayland crash when copying run logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@overlastic/react": "catalog:runtime",
     "@tanstack/react-query": "catalog:runtime",
     "@tauri-apps/api": "catalog:tauri",
-    "@tauri-apps/plugin-clipboard-manager": "catalog:tauri",
     "i18next": "catalog:runtime",
     "react": "catalog:runtime",
     "react-dom": "catalog:runtime",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,9 +183,6 @@ catalogs:
     '@tauri-apps/cli':
       specifier: ^2.11.4
       version: 2.11.4
-    '@tauri-apps/plugin-clipboard-manager':
-      specifier: ^2.3.2
-      version: 2.3.2
   testing:
     vitest:
       specifier: ^4.1.11
@@ -284,9 +281,6 @@ importers:
       '@tauri-apps/api':
         specifier: catalog:tauri
         version: 2.11.1
-      '@tauri-apps/plugin-clipboard-manager':
-        specifier: catalog:tauri
-        version: 2.3.2
       i18next:
         specifier: catalog:runtime
         version: 26.3.6(typescript@5.8.3)
@@ -3166,9 +3160,6 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
-
-  '@tauri-apps/plugin-clipboard-manager@2.3.2':
-    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -8573,10 +8564,6 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
-
-  '@tauri-apps/plugin-clipboard-manager@2.3.2':
-    dependencies:
-      '@tauri-apps/api': 2.11.1
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,7 +93,6 @@ catalogs:
   tauri:
     '@tauri-apps/api': ^2.11.1
     '@tauri-apps/cli': ^2.11.4
-    '@tauri-apps/plugin-clipboard-manager': ^2.3.2
   # 测试
   testing:
     vitest: ^4.1.11

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -870,7 +870,6 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
- "tauri-plugin-clipboard-manager",
  "tauri-plugin-fs",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -4476,21 +4475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
 dependencies = [
  "auto-launch",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "tauri-plugin-clipboard-manager"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
-dependencies = [
- "arboard",
- "log",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,6 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-store = "2"
-tauri-plugin-clipboard-manager = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-autostart = "2"
 image = { version = "0.25", default-features = false, features = [ "png" ] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,7 +27,6 @@
     "opener:allow-open-url",
     "opener:allow-default-urls",
     "opener:allow-reveal-item-in-dir",
-    "store:default",
-    "clipboard-manager:allow-write-text"
+    "store:default"
   ]
 }

--- a/src-tauri/src/bridge/clipboard.rs
+++ b/src-tauri/src/bridge/clipboard.rs
@@ -1,10 +1,24 @@
-//! 原生剪贴板图片读取（Linux/WebKitGTK 贴图回退）。
+//! 原生剪贴板读写（Linux/WebKitGTK 贴图回退 + Wayland 安全文本写入）。
 //!
+//! ## 读取（图片）
 //! WebKitGTK 不通过 Web API（`ClipboardEvent.clipboardData.items/files`）暴露
 //! `image/*` 剪贴板条目，导致桌面端内嵌的 dsh iframe 中输入框「贴图」无效
 //! （浏览器里却正常）。本命令在 Rust 侧用 `arboard` 读取系统剪贴板图片、编码为
 //! PNG data URL 返回；注入到 iframe 的桥脚本（`desktop::paste::PASTE_SHIM_JS`）
 //! 拿到该 data URL 后重新派发 `paste` 事件，让 dsh 聊天框按正常贴图路径处理。
+//!
+//! ## 写入（文本）
+//! 前端的「复制日志 / 复制服务地址」等操作统一走本模块的写入命令，而不是
+//! `tauri-plugin-clipboard-manager`：后者在**应用启动时**就在主线程上创建并持有
+//! 一个长生命周期 `arboard::Clipboard`（`init()` 内 `Clipboard::new()`），在
+//! Linux Wayland 会话里一旦合成器不支持 `ext-data-control`/`wlr-data-control`
+//! （`arboard` 只会打印「Falling back to the X11 clipboard protocol」警告并回退），
+//! 该持有实例要么进入脆弱状态、要么在交互式 `set_text` 时阻塞/崩溃（用户反馈
+//! 「复制运行日志软件崩溃」）。这里的实现改为**每次操作**在 `spawn_blocking`
+//! 中**惰性新建**一个短期 `arboard::Clipboard`，用完即弃：
+//! - 不阻塞异步运行时与 UI（Linux 上创建 / 写入需连显示服务器）；
+//! - 不复用跨操作的长生命周期句柄，规避 Wayland 回退后的挂死 / 崩溃；
+//! - Wayland 不支持时 `arboard` 自动回退 X11，仍是尽力而为，不抛出。
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 
@@ -76,4 +90,24 @@ pub async fn read_clipboard_image(
         .map_err(|e| format!("CLIPBOARD_IMAGE_TASK: {e}"))??;
 
     Ok(result)
+}
+
+/// 把纯文本写入系统剪贴板。
+///
+/// 实现与 [`read_clipboard_image`] 一致：在 `spawn_blocking` 里**惰性新建**短期
+/// `arboard::Clipboard` 完成 `set_text`，用完即弃。避免重复 `tauri-plugin-clipboard-manager`
+/// 在启动时持有单例 `arboard::Clipboard` 所造成的 Linux Wayland 崩溃/挂死
+/// （详见本模块头注释）。Wayland 合成器不支持 data-control 时 `arboard` 自行回退
+/// X11；仅当两者都不可用才返回 `Err`（前缀 `CLIPBOARD_TEXT_`），由前端提示复制失败。
+#[tauri::command]
+pub async fn write_clipboard_text(text: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let mut clipboard =
+            arboard::Clipboard::new().map_err(|e| format!("CLIPBOARD_TEXT_ACCESS: {e}"))?;
+        clipboard
+            .set_text(text)
+            .map_err(|e| format!("CLIPBOARD_TEXT_WRITE: {e}"))
+    })
+    .await
+    .map_err(|e| format!("CLIPBOARD_TEXT_TASK: {e}"))?
 }

--- a/src-tauri/src/bridge/system_os.rs
+++ b/src-tauri/src/bridge/system_os.rs
@@ -8,7 +8,6 @@ use crate::config;
 use crate::logger;
 use crate::service::core;
 use tauri::AppHandle;
-use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_opener::OpenerExt;
 
 /// 健康检查（通过 Rust 代理，避免 WebView CORS 问题）
@@ -38,13 +37,14 @@ pub async fn open_in_browser(app_handle: AppHandle) -> Result<(), String> {
 }
 
 /// 复制 Harness 服务地址到剪贴板
+///
+/// 走 `bridge::clipboard::write_clipboard_text`（惰性短期 `arboard` 句柄），规避
+/// Linux Wayland 合成器不支持 data-control 时 `tauri-plugin-clipboard-manager`
+/// 单例剪贴板导致的崩溃/挂死（同「复制日志」）。
 #[tauri::command]
 pub async fn copy_service_url(app_handle: AppHandle) -> Result<(), String> {
     let url = config::get_dsh_service_url(config::get_store_dat_setting(&app_handle).port);
-    app_handle
-        .clipboard()
-        .write_text(url)
-        .map_err(|e| e.to_string())
+    crate::bridge::write_clipboard_text(url).await
 }
 
 /// 在系统文件管理器中定位指定文件（Session 日志下载完成后的"在文件夹中显示"）

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -575,6 +575,7 @@ pub fn handler() -> impl Fn(Invoke<Wry>) -> bool + Send + Sync + 'static {
         crate::bridge::get_desktop_about,
         crate::bridge::open_external_url,
         crate::bridge::read_clipboard_image,
+        crate::bridge::write_clipboard_text,
         crate::desktop::notification::show_native_notification,
         crate::bridge::log_frontend,
     ]
@@ -694,6 +695,4 @@ pub fn builder() -> tauri::Builder<tauri::Wry> {
         .plugin(tauri_plugin_fs::init())
         // Simple Store plugin
         .plugin(tauri_plugin_store::Builder::new().build())
-        // Clipboard plugin
-        .plugin(tauri_plugin_clipboard_manager::init())
 }

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,5 +1,14 @@
-import { writeText } from '@tauri-apps/plugin-clipboard-manager'
+import { invoke } from '@tauri-apps/api/core'
 
+/**
+ * 把纯文本写入系统剪贴板。
+ *
+ * 走原生 `write_clipboard_text` 命令（`bridge::clipboard`），而不再用
+ * `@tauri-apps/plugin-clipboard-manager`：后者在应用启动时于主线程创建并持有单例
+ * `arboard::Clipboard`，在 Linux Wayland 合成器不支持 `ext-data-control`/
+ * `wlr-data-control` 时会导致「复制运行日志」崩溃/挂死。原生命令按次在
+ * `spawn_blocking` 中惰性新建短期剪贴板句柄，用完即弃，规避该崩溃。
+ */
 export function writeClipboardText(text: string): Promise<void> {
-  return writeText(text)
+  return invoke<void>('write_clipboard_text', { text })
 }

--- a/test/clipboard.test.ts
+++ b/test/clipboard.test.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from 'node:fs'
-import { writeText } from '@tauri-apps/plugin-clipboard-manager'
+import { invoke } from '@tauri-apps/api/core'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { writeClipboardText } from '../src/utils/clipboard'
 
-vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
-  writeText: vi.fn(),
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
 }))
 
 const CLIPBOARD_CALL_SITES = [
@@ -33,17 +33,17 @@ describe('clipboard integration', () => {
     }
   })
 
-  it('writes the exact text through the native clipboard plugin', async () => {
-    vi.mocked(writeText).mockResolvedValue()
+  it('writes the exact text through the native clipboard command', async () => {
+    vi.mocked(invoke).mockResolvedValue(undefined as never)
 
     await expect(writeClipboardText('diagnostic logs')).resolves.toBeUndefined()
 
-    expect(writeText).toHaveBeenCalledExactlyOnceWith('diagnostic logs')
+    expect(invoke).toHaveBeenCalledExactlyOnceWith('write_clipboard_text', { text: 'diagnostic logs' })
   })
 
   it('propagates native clipboard failures to the caller', async () => {
     const failure = new Error('clipboard unavailable')
-    vi.mocked(writeText).mockRejectedValue(failure)
+    vi.mocked(invoke).mockRejectedValue(failure)
 
     await expect(writeClipboardText('diagnostic logs')).rejects.toBe(failure)
   })


### PR DESCRIPTION
## 问题

用户反馈在 **Linux Wayland** 会话里点击「复制运行日志」（Help 菜单 → Run Logs）时软件崩溃，控制台报错：

```
Tried to initialize the wayland data control protocol clipboard, but failed.
Falling back to the X11 clipboard protocol. The error was: Unknown error while
interacting with the clipboard: A required Wayland protocol (ext-data-control,
or wlr-data-control version 1) is not supported by the compositor
```

## 根因

`tauri-plugin-clipboard-manager` 在 **应用启动时**（`init()` 内 `Clipboard::new()`）
于主线程创建并**持有一个长生命周期** `arboard::Clipboard` 单例。在 Wayland 合成器
不支持 `ext-data-control` / `wlr-data-control` 时，`arboard` 仅打印
「Falling back to the X11 clipboard protocol」警告并回退 X11；一旦该持久句柄在后续
交互式 `set_text`（复制日志）时被复用，就会在 Wayland 回退路径上阻塞/崩溃。

## 修复

不再依赖全局 clipboard 插件，改为与既有 `read_clipboard_image` 完全一致的模式：
**每次操作**在 `spawn_blocking` 中**惰性新建**短期 `arboard::Clipboard` 写入后即弃。

- `bridge/clipboard.rs`：新增 `write_clipboard_text` 命令（前缀 `CLIPBOARD_TEXT_`）。
- 前端 `writeClipboardText`（`src/utils/clipboard.ts`）：改走
  `invoke('write_clipboard_text')`，不再用 `@tauri-apps/plugin-clipboard-manager`。
- `copy_service_url`（`system_os.rs`）：同样改走安全的原生命令。
- 移除 `tauri-plugin-clipboard-manager` 依赖、capability 与前端 npm 包。

收益：不阻塞异步运行时与 UI、不复用跨操作的长期句柄；Wayland 不支持时 `arboard`
自行回退 X11，仅在两者都不可用时返回干净错误由前端提示，绝不崩溃。

## 验证

- `cargo check` ✅
- `cargo test --lib`：435 通过（1 个既有 concurrency 时序 flaky 用例，单独跑通过，与本改动无关）
- `pnpm typecheck` ✅
- `pnpm vitest run test/clipboard.test.ts`：3/3 ✅
- `pnpm lint`：0 errors ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard text copying now uses the application’s native clipboard handling.
  * Improved clipboard compatibility across Linux Wayland and X11 environments.
  * Clipboard errors are reported more clearly when access or writing fails.

* **Bug Fixes**
  * Service URL copying now reliably routes through the native clipboard implementation.

* **Tests**
  * Updated clipboard coverage to verify successful writes and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->