### PR TITLE
fix(core): self-heal packaged core runtime plugins & native deps after core upgrade

### DIFF
--- a/src-tauri/src/service/core/mod.rs
+++ b/src-tauri/src/service/core/mod.rs
@@ -21,6 +21,7 @@
 //! - [`version`]：预打包核心多版本管理（列出 / 切换 / 下载 / 卸载）
 
 mod local;
+mod runtime;
 mod source;
 mod version;
 
@@ -29,3 +30,4 @@ pub use local::{local_core_package_dir, update_local_core};
 #[allow(unused_imports)]
 pub use source::{active_dsh_binary, active_source, active_version, CoreSource, HarnessCore};
 pub use version::{download_version, list, remove_version, set_active};
+pub(crate) use runtime::prepare_active_runtime;

--- a/src-tauri/src/service/core/runtime.rs
+++ b/src-tauri/src/service/core/runtime.rs
@@ -1,0 +1,556 @@
+//! 活动预打包核心的运行时自愈：补齐插件入口并检查原生可选依赖。
+//!
+//! dsh 的 loader 以核心安装目录作为裸包解析根，而 profile 中的插件实际位于
+//! `$DSH_HOME/profiles/<profile>/node_modules`，应用内置插件则位于安装包资源目录。
+//! 核心版本切换只移动 `dependencies/dsh`，不会自动重建这些入口，因此每次启动都要
+//! 在启动 dsh 前按当前核心重新建立安全的目录链接。用户自行安装的 local 核心不归
+//! 桌面端管理，明确跳过本模块。
+
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tauri::AppHandle;
+
+use super::source::CoreSource;
+
+const NATIVE_REPAIR_TIMEOUT: Duration = Duration::from_secs(120);
+const NODE_PROBE_SCRIPT: &str = "process.stdout.write(process.platform + ':' + process.arch)";
+const NATIVE_IMPORT_SCRIPT: &str = "await import('sharp'); await import('koffi')";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NodeTarget {
+    platform: String,
+    arch: String,
+}
+
+/// 在启动预打包核心前修复其插件入口并验证 sharp/koffi 原生依赖。
+///
+/// 该函数是幂等的：已有正确链接和可加载的原生模块不会触发写入或联网。原生包
+/// 缺失时只按核心清单中的 optionalDependencies 动态构造安装参数，避免把某一台
+/// 机器的版本、平台或架构写死在桌面端。失败返回诊断错误，调用方不应继续启动
+/// 一个已知无法加载的 dsh 进程。
+ pub(crate) async fn prepare_active_runtime(app_handle: &AppHandle) -> Result<(), String> {
+    if crate::service::core::active_source(app_handle) != CoreSource::App {
+        log::debug!("Skipping core runtime repair for user-owned local core");
+        return Ok(());
+    }
+
+    let core_root = crate::config::get_dsh_install_path(app_handle);
+    let node = crate::config::get_node_binary_path(app_handle);
+    if !core_root.is_dir() {
+        return Err(format!(
+            "CORE_RUNTIME_NOT_FOUND: bundled core directory is missing: {}",
+            core_root.display()
+        ));
+    }
+    if !node.is_file() {
+        return Err(format!(
+            "CORE_RUNTIME_NODE_NOT_FOUND: Node.js runtime is missing: {}",
+            node.display()
+        ));
+    }
+
+    link_required_plugins(app_handle, &core_root)?;
+
+    let target = detect_node_target(&node, &core_root).await?;
+    if native_imports_ready(&node, &core_root).await {
+        log::debug!(
+            "Bundled core native dependencies are ready for {}:{}",
+            target.platform,
+            target.arch
+        );
+        return Ok(());
+    }
+
+    let packages = native_package_plan(&core_root, &target);
+    if packages.is_empty() {
+        return Err(format!(
+            "CORE_NATIVE_DEPENDENCY_UNRESOLVED: no optional package version matches {}:{} in {}",
+            target.platform,
+            target.arch,
+            core_root.display()
+        ));
+    }
+
+    log::warn!(
+        "CORE_NATIVE_DEPENDENCY_REPAIR: importing sharp/koffi failed for {}:{}, installing {:?}",
+        target.platform,
+        target.arch,
+        packages
+    );
+    install_native_packages(&core_root, &target, &packages).await?;
+    if !native_imports_ready(&node, &core_root).await {
+        return Err(format!(
+            "CORE_NATIVE_DEPENDENCY_REPAIR_FAILED: sharp/koffi still cannot load for {}:{} in {}",
+            target.platform,
+            target.arch,
+            core_root.display()
+        ));
+    }
+    Ok(())
+}
+
+/// 从活动 profile 与应用内置清单收集需要在核心根下解析的包，并逐个建立入口。
+fn link_required_plugins(app_handle: &AppHandle, core_root: &Path) -> Result<(), String> {
+    let core_node_modules = core_root.join("node_modules");
+    std::fs::create_dir_all(&core_node_modules).map_err(|e| {
+        format!(
+            "CORE_PLUGIN_NODE_MODULES_CREATE_FAILED: {}: {e}",
+            core_node_modules.display()
+        )
+    })?;
+
+    let presets = crate::service::plugin::load_presets(app_handle);
+    let internal_ids: HashSet<String> = presets
+        .iter()
+        .filter(|preset| preset.internal)
+        .map(|preset| crate::service::plugin::installed_name(preset).to_string())
+        .collect();
+
+    // 内置插件必须始终从当前安装包资源（debug 时为 workspace 源码）取源，不能信任
+    // profile 中旧版本遗留的 link 路径。这样应用升级后旧 link 会被精确替换。
+    for preset in presets.iter().filter(|preset| preset.internal) {
+        let name = crate::service::plugin::installed_name(preset);
+        let Some(source) = crate::service::plugin::bundled_plugin_dir(app_handle, &preset.id)
+        else {
+            log::warn!(
+                "CORE_PLUGIN_BUNDLE_MISSING: bundled source unavailable for {name}, skipping core link"
+            );
+            continue;
+        };
+        ensure_package_link(name, &source, &core_node_modules)?;
+    }
+
+    let profile = crate::service::plugin::profile_dir(app_handle);
+    let manifest_path = profile.join("package.json");
+    let Ok(raw) = std::fs::read_to_string(&manifest_path) else {
+        return Ok(());
+    };
+    let manifest = serde_json::from_str::<serde_json::Value>(&raw)
+        .map_err(|e| format!("CORE_PLUGIN_PROFILE_MANIFEST_INVALID: {manifest_path:?}: {e}"))?;
+
+    let mut names = HashSet::new();
+    if let Some(dependencies) = manifest.get("dependencies").and_then(|v| v.as_object()) {
+        names.extend(dependencies.keys().cloned());
+    }
+    if let Some(bundles) = manifest
+        .get("dsh")
+        .and_then(|v| v.get("profile"))
+        .and_then(|v| v.get("bundles"))
+        .and_then(|v| v.as_array())
+    {
+        names.extend(bundles.iter().filter_map(|v| v.as_str().map(str::to_owned)));
+    }
+
+    // Core 自有依赖（尤其 @deepseek-ai/*）由发行包自己提供，不能被 profile 中同名
+    // 条目覆盖。internal 已按当前资源处理，剩余名字才从 profile 入口解析。
+    for name in names {
+        if internal_ids.contains(&name) || !is_safe_package_name(&name) {
+            continue;
+        }
+        let source = profile.join("node_modules").join(&name);
+        if !source.join("package.json").is_file() {
+            log::warn!(
+                "CORE_PLUGIN_PROFILE_ENTRY_MISSING: {} is referenced by {}, source {} is unavailable",
+                name,
+                manifest_path.display(),
+                source.display()
+            );
+            continue;
+        }
+        ensure_package_link(&name, &source, &core_node_modules)?;
+    }
+    Ok(())
+}
+
+/// 为 npm 包名建立目录链接；真实目录/文件从不覆盖，避免误删核心自有依赖。
+fn ensure_package_link(name: &str, source: &Path, node_modules: &Path) -> Result<(), String> {
+    if !is_safe_package_name(name) {
+        return Err(format!("CORE_PLUGIN_NAME_INVALID: {name}"));
+    }
+    let source = source.canonicalize().map_err(|e| {
+        format!(
+            "CORE_PLUGIN_SOURCE_INVALID: {} ({name}): {e}",
+            source.display()
+        )
+    })?;
+    if !source.is_dir() || !source.join("package.json").is_file() {
+        return Err(format!(
+            "CORE_PLUGIN_SOURCE_INVALID: {name} is not a package directory: {}",
+            source.display()
+        ));
+    }
+    let package_name = read_package_name(&source.join("package.json"))?;
+    if package_name.as_deref() != Some(name) {
+        return Err(format!(
+            "CORE_PLUGIN_SOURCE_NAME_MISMATCH: requested {name}, source declares {}",
+            package_name.unwrap_or_else(|| "<missing>".to_string())
+        ));
+    }
+
+    let destination = node_modules.join(name);
+    let parent = destination
+        .parent()
+        .ok_or_else(|| format!("CORE_PLUGIN_DESTINATION_INVALID: {name}"))?;
+    ensure_non_link_directory(parent, node_modules)?;
+
+    let existing = match std::fs::symlink_metadata(&destination) {
+        Ok(metadata) => Some(metadata),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(format!("CORE_PLUGIN_DESTINATION_STAT_FAILED: {destination:?}: {e}")),
+    };
+    if let Some(metadata) = existing {
+        if !metadata.file_type().is_symlink() {
+            log::debug!(
+                "CORE_PLUGIN_ENTRY_OCCUPIED: keeping core-owned entry {}",
+                destination.display()
+            );
+            return Ok(());
+        }
+        let matches = std::fs::read_link(&destination)
+            .ok()
+            .map(|target| {
+                let resolved = if target.is_absolute() {
+                    target
+                } else {
+                    destination.parent().unwrap_or(Path::new(".")).join(target)
+                };
+                resolved.canonicalize().ok().as_deref() == Some(source.as_path())
+            })
+            .unwrap_or(false);
+        if matches {
+            return Ok(());
+        }
+        remove_link_only(&destination)?;
+    }
+
+    create_directory_link(&source, &destination).map_err(|e| {
+        format!(
+            "CORE_PLUGIN_LINK_FAILED: {} -> {}: {e}",
+            source.display(),
+            destination.display()
+        )
+    })?;
+    log::info!(
+        "CORE_PLUGIN_LINKED: {} -> {}",
+        destination.display(),
+        source.display()
+    );
+    Ok(())
+}
+
+/// 校验并创建 scope 目录；目录本身不能是链接，防止目的地逃逸核心根。
+fn ensure_non_link_directory(path: &Path, root: &Path) -> Result<(), String> {
+    if !path.starts_with(root) {
+        return Err(format!("CORE_PLUGIN_DESTINATION_ESCAPE: {}", path.display()));
+    }
+    let relative = path.strip_prefix(root).unwrap_or(Path::new("."));
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(format!(
+                    "CORE_PLUGIN_DESTINATION_PARENT_LINK: {}",
+                    current.display()
+                ));
+            }
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => return Err(format!("CORE_PLUGIN_DESTINATION_PARENT_INVALID: {}", current.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir(&current).map_err(|e| {
+                    format!("CORE_PLUGIN_DESTINATION_PARENT_CREATE_FAILED: {}: {e}", current.display())
+                })?;
+            }
+            Err(e) => return Err(format!("CORE_PLUGIN_DESTINATION_PARENT_STAT_FAILED: {}: {e}", current.display())),
+        }
+    }
+    Ok(())
+}
+
+fn remove_link_only(path: &Path) -> Result<(), String> {
+    #[cfg(windows)]
+    let result = std::fs::remove_dir(path).or_else(|_| std::fs::remove_file(path));
+    #[cfg(not(windows))]
+    let result = std::fs::remove_file(path);
+    result.map_err(|e| format!("CORE_PLUGIN_LINK_REMOVE_FAILED: {}: {e}", path.display()))
+}
+
+#[cfg(unix)]
+fn create_directory_link(source: &Path, destination: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(source, destination)
+}
+
+#[cfg(windows)]
+fn create_directory_link(source: &Path, destination: &Path) -> std::io::Result<()> {
+    // symlink_dir 会在启用 Developer Mode 或具备 SeCreateSymbolicLinkPrivilege 时工作；
+    // 失败必须显式返回，不能退化为危险的递归覆盖复制。
+    std::os::windows::fs::symlink_dir(source, destination)
+}
+
+fn is_safe_package_name(name: &str) -> bool {
+    let parts: Vec<_> = name.split('/').collect();
+    if parts.len() == 1 {
+        return valid_package_component(parts[0]);
+    }
+    parts.len() == 2 && parts[0].starts_with('@') && valid_package_component(parts[0]) && valid_package_component(parts[1])
+}
+
+fn valid_package_component(value: &str) -> bool {
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        // 单独的 `@` 不是合法 scope（`@scope` 中 scope 必须非空）。
+        && value != "@"
+        && value.bytes().all(|byte| byte.is_ascii_alphanumeric() || b"._-@".contains(&byte))
+}
+
+fn read_package_name(path: &Path) -> Result<Option<String>, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("CORE_PLUGIN_PACKAGE_MANIFEST_READ_FAILED: {}: {e}", path.display()))?;
+    let value = serde_json::from_str::<serde_json::Value>(&raw)
+        .map_err(|e| format!("CORE_PLUGIN_PACKAGE_MANIFEST_INVALID: {}: {e}", path.display()))?;
+    Ok(value.get("name").and_then(|value| value.as_str()).map(str::to_owned))
+}
+
+async fn detect_node_target(node: &Path, core_root: &Path) -> Result<NodeTarget, String> {
+    let node = node.to_path_buf();
+    let core_root = core_root.to_path_buf();
+    let output = tokio::task::spawn_blocking(move || run_command(&node, &["--input-type=module".into(), "-e".into(), NODE_PROBE_SCRIPT.into()], &core_root))
+        .await
+        .map_err(|e| format!("CORE_NODE_PLATFORM_PROBE_FAILED: {e}"))??;
+    if !output.status.success() {
+        return Err(format!(
+            "CORE_NODE_PLATFORM_PROBE_FAILED: {}",
+            command_output_tail(&output)
+        ));
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let Some((platform, arch)) = value.split_once(':') else {
+        return Err(format!("CORE_NODE_PLATFORM_UNSUPPORTED: {value}"));
+    };
+    let supported_platform = matches!(platform, "darwin" | "linux" | "win32");
+    let supported_arch = matches!(arch, "x64" | "arm64" | "ia32" | "arm" | "ppc64" | "riscv64" | "s390x" | "loong64");
+    if !supported_platform || !supported_arch {
+        return Err(format!("CORE_NODE_PLATFORM_UNSUPPORTED: {value}"));
+    }
+    Ok(NodeTarget { platform: platform.to_string(), arch: arch.to_string() })
+}
+
+async fn native_imports_ready(node: &Path, core_root: &Path) -> bool {
+    let node = node.to_path_buf();
+    let core_root = core_root.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        run_command(&node, &["--input-type=module".into(), "-e".into(), NATIVE_IMPORT_SCRIPT.into()], &core_root)
+            .is_ok_and(|output| output.status.success())
+    })
+    .await
+    .unwrap_or(false)
+}
+
+/// 决定需要补齐的原生依赖安装参数。
+///
+/// 优先从已安装的根包 `sharp`/`koffi` 的 `optionalDependencies` 取目标平台包的
+/// 精确版本并显式安装（轻量、不改核心依赖声明）。任一根包缺失时退化为安装根包
+/// 名（不带版本），由 npm 以核心 `package.json` + lockfile 解析正确版本 —— 这样
+/// 即使整个核心闭包被删也能恢复，且不硬编码版本号。
+fn native_package_plan(core_root: &Path, target: &NodeTarget) -> Vec<String> {
+    let node_modules = core_root.join("node_modules");
+    let sharp = node_modules.join("sharp");
+    let koffi = node_modules.join("koffi");
+    let sharp_optional = read_optional_dependencies(&sharp.join("package.json"));
+    let koffi_optional = read_optional_dependencies(&koffi.join("package.json"));
+
+    let mut packages = Vec::new();
+    let sharp_runtime = format!("@img/sharp-{}-{}", target.platform, target.arch);
+    let sharp_libvips = format!("@img/sharp-libvips-{}-{}", target.platform, target.arch);
+    let koffi_runtime = format!("@koromix/koffi-{}-{}", target.platform, target.arch);
+
+    for (name, optional) in [
+        (sharp_runtime.as_str(), &sharp_optional),
+        (sharp_libvips.as_str(), &sharp_optional),
+        (koffi_runtime.as_str(), &koffi_optional),
+    ] {
+        if let Some(version) = optional.get(name) {
+            packages.push(format!("{name}@{version}"));
+        }
+    }
+    // 根包本身缺失（核心闭包被删/损坏）时无法从清单取版本，退化为安装根包名，
+    // 由 npm 以核心 package.json + lockfile 解析正确版本（不硬编码版本号）。
+    if !sharp.is_dir() && !packages.iter().any(|p| p == "sharp") {
+        packages.push("sharp".to_string());
+    }
+    if !koffi.is_dir() && !packages.iter().any(|p| p == "koffi") {
+        packages.push("koffi".to_string());
+    }
+    packages
+}
+
+/// 读取 optionalDependencies；清单缺失/损坏时返回空（由调用方决定回退策略）。
+fn read_optional_dependencies(path: &Path) -> HashMap<String, String> {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return HashMap::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return HashMap::new();
+    };
+    value
+        .get("optionalDependencies")
+        .and_then(|value| value.as_object())
+        .map(|map| {
+            map.iter()
+                .filter_map(|(name, value)| {
+                    value
+                        .as_str()
+                        .map(|version| (name.clone(), version.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+async fn install_native_packages(core_root: &Path, target: &NodeTarget, packages: &[String]) -> Result<(), String> {
+    let core_root = core_root.to_path_buf();
+    let target = target.clone();
+    let packages = packages.to_vec();
+    let result = tokio::task::spawn_blocking(move || {
+        let program = if cfg!(windows) { OsString::from("npm.cmd") } else { OsString::from("npm") };
+        let mut args = vec![
+            OsString::from("install"),
+            OsString::from("--no-save"),
+            OsString::from("--package-lock=false"),
+            OsString::from("--include=optional"),
+            OsString::from(format!("--os={}", target.platform)),
+            OsString::from(format!("--cpu={}", target.arch)),
+        ];
+        args.extend(packages.into_iter().map(OsString::from));
+        run_process_with_timeout(&program, &args, &core_root, NATIVE_REPAIR_TIMEOUT)
+    })
+    .await
+    .map_err(|e| format!("CORE_NATIVE_DEPENDENCY_REPAIR_FAILED: {e}"))??;
+    if !result.status.success() {
+        return Err(format!(
+            "CORE_NATIVE_DEPENDENCY_REPAIR_FAILED: npm exited with {}: {}",
+            result.status,
+            command_output_tail(&result)
+        ));
+    }
+    Ok(())
+}
+
+fn run_command(program: &Path, args: &[OsString], cwd: &Path) -> Result<std::process::Output, String> {
+    let mut command = Command::new(program);
+    command.args(args).current_dir(cwd).stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x08000000);
+    }
+    command.output().map_err(|e| format!("CORE_RUNTIME_COMMAND_FAILED: {}: {e}", program.display()))
+}
+
+fn run_process_with_timeout(
+    program: &OsString,
+    args: &[OsString],
+    cwd: &Path,
+    timeout: Duration,
+) -> Result<std::process::Output, String> {
+    let mut command = Command::new(program);
+    command.args(args).current_dir(cwd).stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x08000000);
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("CORE_NATIVE_DEPENDENCY_REPAIR_SPAWN_FAILED: {e}"))?;
+    let stdout = child.stdout.take().expect("piped stdout");
+    let stderr = child.stderr.take().expect("piped stderr");
+    let stdout_thread = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = std::io::BufReader::new(stdout).read_to_end(&mut bytes);
+        bytes
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = std::io::BufReader::new(stderr).read_to_end(&mut bytes);
+        bytes
+    });
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().map_err(|e| format!("CORE_NATIVE_DEPENDENCY_REPAIR_WAIT_FAILED: {e}"))? {
+            let stdout = stdout_thread.join().unwrap_or_default();
+            let stderr = stderr_thread.join().unwrap_or_default();
+            return Ok(std::process::Output { status, stdout, stderr });
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let status = child.wait().map_err(|e| format!("CORE_NATIVE_DEPENDENCY_REPAIR_KILL_FAILED: {e}"))?;
+            // 排空管道，避免子进程因写满缓冲而挂起；输出在超时路径不作分析。
+            let _ = stdout_thread.join().unwrap_or_default();
+            let _ = stderr_thread.join().unwrap_or_default();
+            return Err(format!(
+                "CORE_NATIVE_DEPENDENCY_REPAIR_TIMEOUT: npm exceeded {} seconds (exit {status})",
+                timeout.as_secs()
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn command_output_tail(output: &std::process::Output) -> String {
+    let mut value = String::from_utf8_lossy(&output.stderr).to_string();
+    if value.trim().is_empty() {
+        value = String::from_utf8_lossy(&output.stdout).to_string();
+    }
+    value.trim().chars().rev().take(2000).collect::<String>().chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_names_allow_plain_and_scoped_names_only() {
+        assert!(is_safe_package_name("dshmarket"));
+        assert!(is_safe_package_name("@scope/plugin-name"));
+        assert!(!is_safe_package_name("../escape"));
+        assert!(!is_safe_package_name("@scope/../escape"));
+        assert!(!is_safe_package_name("C:\\escape"));
+        assert!(!is_safe_package_name("/absolute"));
+        assert!(!is_safe_package_name("@/missing"));
+    }
+
+    #[test]
+    fn native_plan_uses_manifest_versions_not_constants() {
+        let root = std::env::temp_dir().join(format!("dsh-native-plan-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("node_modules/sharp")).unwrap();
+        std::fs::create_dir_all(root.join("node_modules/koffi")).unwrap();
+        std::fs::write(
+            root.join("node_modules/sharp/package.json"),
+            r#"{"optionalDependencies":{"@img/sharp-darwin-arm64":"0.9.0","@img/sharp-libvips-darwin-arm64":"1.2.0"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("node_modules/koffi/package.json"),
+            r#"{"optionalDependencies":{"@koromix/koffi-darwin-arm64":"8.7.0"}}"#,
+        )
+        .unwrap();
+        let plan = native_package_plan(
+            &root,
+            &NodeTarget { platform: "darwin".into(), arch: "arm64".into() },
+        );
+        assert_eq!(plan, vec![
+            "@img/sharp-darwin-arm64@0.9.0",
+            "@img/sharp-libvips-darwin-arm64@1.2.0",
+            "@koromix/koffi-darwin-arm64@8.7.0",
+        ]);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src-tauri/src/service/plugin/mod.rs
+++ b/src-tauri/src/service/plugin/mod.rs
@@ -46,12 +46,15 @@ pub use cancel::cancel;
 pub(crate) use install::harness_prefer_bundled_pnpm;
 pub(crate) use install::uninstall_deprecated_plugins;
 pub use install::{install, remove, update};
-pub(crate) use installed::ensure_profile_npmrc;
+pub(crate) use installed::{ensure_profile_npmrc, installed_name, profile_dir};
 pub use installed::{list, PreinstallPlugin};
 pub(crate) use internal::cancel as cancel_internal_plugins;
 pub(crate) use internal::ensure as ensure_internal_plugins;
 pub use preset::repo_url_of;
-pub(crate) use preset::{current_preset_hash, preinstall_pending, remove_legacy_bundled_plugins};
+pub(crate) use preset::{
+    bundled_plugin_dir, current_preset_hash, load_presets, preinstall_pending,
+    remove_legacy_bundled_plugins,
+};
 pub use disable::{disable, enable};
 pub use recovery::{
     detect as detect_recovery, uninstall as uninstall_recovery, PluginRecoveryInfo,

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -421,6 +421,15 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     if let Err(e) = crate::service::plugin::ensure_preset_plugins(&app_handle).await {
         log::warn!("ensure preset plugins failed: {e}");
     }
+    // 预打包核心运行时自愈：把 app 内置插件与 profile 插件入口链接进活动核心的
+    // node_modules（dsh 的 loader 以核心根为裸包解析根），并核验/修复 sharp/koffi
+    // 原生可选依赖。只作用于 CoreSource::App，本地核心由用户自行管理。dsh 在缺失
+    // 这些入口或原生依赖时无法启动，因此失败直接阻断本次 launch（前端展示可恢复
+    // 错误），而不是带着必然失败的核心继续 spawn。
+    if let Err(e) = crate::service::core::prepare_active_runtime(&app_handle).await {
+        log::error!("prepare active core runtime failed: {e}");
+        return Err(e);
+    }
     let mut envs: HashMap<String, String> = HashMap::new();
     envs.insert(
         "DSH_HOME".to_string(),


### PR DESCRIPTION
## 背景 / Problem

从 Alpha 核心升级到 `0.1.2-rc.1` 后桌面端启动失败。根因是核心切换只移动 `dependencies/dsh` 目录，从不重建核心 `node_modules` 的插件入口，且下载的核心包只含**构建平台**的 native optional 依赖。

dsh 的 `cordis-plugin-loader` 以核心安装目录作为裸包解析根：
- app 内置插件（`dsh-tauri-*`）位于安装包资源目录；
- profile 插件位于 `$DSH_HOME/profiles/<profile>/node_modules`；
- `sharp`/`koffi` 平台原生包只匹配构建平台（实测本地等却下载/安装后只有 `sharp-win32-x64`、`koffi-win32-x64`）。

于是 loader 报一串 `Cannot find package 'dsh-tauri-ui'`（`ERR_MODULE_NOT_FOUND`）、`Could not load the "sharp" module using darwin-arm64 runtime`、`Cannot find the native Koffi module`，进程退出码 1。

## 改动 / Changes

新增 `prepare_active_runtime`（`src-tauri/src/service/core/runtime.rs`），在 `workflow::launch` 启动 dsh 前（`ensure_internal_plugins` / `ensure_preset_plugins` 之后）调用，**仅对 `CoreSource::App` 生效**，本地用户核心明确 no-op：

1. **插件入口链接**：从 `bundled_plugin_dir`（app 内置）与活动 profile manifest 的 `dependencies` + `dsh.profile.bundles` 收集包名，在核心 `node_modules` 建立安全目录链接。支持 scoped `@scope/name`；用 `symlink_metadata` 区分，真实目录/文件绝不覆盖，悬空/错误 link 只删链接本体再重建；scope 父目录拒绝链接逃逸。
2. **原生依赖自愈**：以实际启动 Node 的 `process.platform:process.arch` 探测（而非日志 os 字段 / Rust host，Rosetta 下更准确）；`import('sharp')` + `import('koffi')` smoke 预检，healthy 时零网络；失败时按 `sharp`/`koffi` 的 `optionalDependencies` 动态取版本执行 `npm install --no-save --package-lock=false --include=optional --os --cpu`，根包缺失时退化为安装根包名，120s 超时；失败返回 `CORE_NATIVE_*` 诊断并阻断 launch（不再带着必然失败的核心继续 spawn）。

顺便将 `load_presets` / `bundled_plugin_dir` / `installed_name` / `profile_dir` 在 `plugin` 模块 re-export 为 `pub(crate)` 以复用内部清单。

## 验证 / Verification

- `cargo check` 通过；
- `cargo test --lib`：438 passed / 0 failed（含新增 2 个 runtime 单测：包名/scope 校验、native plan 从 manifest 动态取版本而非硬编码）。

## 后续 / Follow-up

更根本的根治应在 `deepseek-harness-pkg` release 构建（每个 OS/CPU 打正确的 native 闭包并补齐插件可解析布局）；运行时自愈必须保留以兼容已下载的错误历史槽位与跨版本升级。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability for bundled runtimes by validating required components and repairing missing native dependencies automatically.
  * Bundled and profile plugins are now linked safely before launch.
  * Startup now stops with an actionable error when runtime preparation fails, preventing incomplete process launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->