### PR TITLE
feat(profile): bootstrap a dedicated Desktop profile on first install

### DIFF
--- a/src-tauri/src/config/setting.rs
+++ b/src-tauri/src/config/setting.rs
@@ -1,7 +1,7 @@
 use super::constants::*;
 use serde::{Deserialize, Serialize};
 use std::sync::{Mutex, OnceLock};
-use tauri::{AppHandle, Emitter, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tauri_plugin_store::StoreExt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,6 +36,11 @@ pub struct Setting {
     /// 桌面端启动服务与插件管理都以它为准（见 service::profile）。
     #[serde(default = "default_active_profile")]
     pub active_profile: String,
+    /// 首装档案引导是否已完成：桌面端首次安装时自动新建 Desktop 档案并切换为
+    /// 当前档案（见 service::profile::ensure_first_run_desktop_profile），成功后
+    /// 置位，之后启动不再重做（幂等标记，语义同 dsh_home_migrated）。
+    #[serde(default)]
+    pub desktop_profile_ready: bool,
     /// 活动核心的显式选择：`Some("local")` = 用户 CLI 安装的本地核心，
     /// `Some("app")` = 桌面端预打包核心；`None` = 自动（本地核心存在时优先）。
     #[serde(default)]
@@ -152,6 +157,7 @@ impl Default for Setting {
             preset_hash: None,
             dsh_home_migrated: false,
             active_profile: default_active_profile(),
+            desktop_profile_ready: false,
             active_core: None,
             manual_port: None,
             zoom_factor: default_zoom_factor(),
@@ -179,6 +185,32 @@ fn store_dat_file_name() -> &'static str {
 fn setting_write_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// 首装检测结果（进程内缓存）：`true` = 本次启动时 store 持久化文件尚不存在，
+/// 即桌面端首次安装/首次启动（无论是否装过 dsh CLI——后者正是需要隔离的
+/// 场景：CLI 侧的大量插件/补丁不应涌入桌面端档案）。
+static FIRST_INSTALL: OnceLock<bool> = OnceLock::new();
+
+/// 首装检测：store 持久化文件不存在 → 桌面端首次安装。
+///
+/// 必须在窗口创建与任何 store 写入之前调用一次（builder setup 最先）：窗口
+/// 几何恢复/退出保存都会写 store 并创建文件，判定晚于它们会把首装误判为升级。
+/// 判定结果进程内缓存，之后任何时点读取都拿到本次启动的同一结论。
+pub fn detect_first_install<R: Runtime>(app_handle: &AppHandle<R>) -> bool {
+    *FIRST_INSTALL.get_or_init(|| {
+        app_handle
+            .path()
+            .app_data_dir()
+            // 目录解析失败按老用户处理（保守：不做引导，回落 web 档案老行为）
+            .map(|dir| !dir.join(store_dat_file_name()).exists())
+            .unwrap_or(false)
+    })
+}
+
+/// 读取首装检测结果；尚未检测（或检测失败）时返回 `false`，保守按老用户处理。
+pub fn is_first_install() -> bool {
+    FIRST_INSTALL.get().copied().unwrap_or(false)
 }
 
 fn read_store_dat_setting<R: Runtime>(app_handle: &AppHandle<R>) -> Setting {

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -67,6 +67,11 @@ pub fn setup(app_handle: tauri::AppHandle) {
         log::warn!("pnpm modules metadata self-heal skipped: {e}");
     }
 
+    // 首装档案引导：桌面端首次安装时，在任何 dsh 启动/插件操作之前新建独立的
+    // Desktop 档案并切换（与 CLI 用户既有插件/补丁隔离，见 service::profile）。
+    // 必须先于 scheduler/auto_start：引导失败时它们回落 web 档案的老行为。
+    crate::service::profile::ensure_first_run_desktop_profile(&app_handle);
+
     // 启动进程监控（tick 检测 dsh 服务状态）
     crate::service::scheduler::start(&app_handle);
 
@@ -586,6 +591,10 @@ pub fn builder() -> tauri::Builder<tauri::Wry> {
     let builder = tauri::Builder::default()
         .setup(|app| {
             let app_handle = app.handle().clone();
+            // 首装检测必须最先执行：窗口几何恢复/退出保存等任何 store 写入都会
+            // 创建 store 文件，判定晚于它们会把首装误判为升级（见
+            // config::detect_first_install 的时序说明）。
+            crate::config::detect_first_install(&app_handle);
             build_main_window(&app_handle)?;
             #[cfg(target_os = "macos")]
             install_macos_menu(&app_handle)?;

--- a/src-tauri/src/service/profile/mod.rs
+++ b/src-tauri/src/service/profile/mod.rs
@@ -5,6 +5,11 @@
 //! 桌面端把「当前使用哪个档案」持久化在自己的 store 设置（`active_profile`，
 //! 默认 `web`），服务启动、插件安装/升级/卸载全部以它为准——不再写死 web。
 //!
+//! 首装防御：桌面端首次安装（本进程启动前 store 文件不存在）时，在任何 dsh
+//! 启动/插件操作之前自动新建独立的 Desktop 档案并切换过去（见
+//! `ensure_first_run_desktop_profile`）。此前装过 dsh CLI 并装了大量插件/补丁的
+//! 用户启用桌面端时，旧数据不再涌入桌面端所用档案，防御性规避加载异常。
+//!
 //! 新建档案时按官方 `dsh-app-boot` 的 `initProfile` 形态初始化目录：
 //! `package.json`（含 web 模板 bundles）+ `cordis.patch.yml` + `pnpm-workspace.yaml`，
 //! 与 CLI 侧产物完全一致，两边可互相操作。
@@ -20,6 +25,10 @@ use tauri::AppHandle;
 
 /// 桌面端默认档案（内置，不可删除）
 pub const DEFAULT_PROFILE: &str = "web";
+
+/// 首装引导档案：桌面端首次安装时自动新建并切换为当前档案（与 CLI 用户既有
+/// 档案隔离；用户新建同 id 档案被 `PROFILE_EXISTS` 拦截，此名仅由本引导占用）。
+pub const DESKTOP_PROFILE: &str = "desktop";
 
 /// 新建档案的初始 bundles：web 模板（`@deepseek-ai/dsh-base` +
 /// `@deepseek-ai/dsh-web-app`，与 dsh-app-boot `PROFILE_TEMPLATES.web` 一致）。
@@ -250,6 +259,49 @@ pub fn set_active(app_handle: &AppHandle, id: &str) -> Result<Profile, String> {
         .into_iter()
         .find(|p| p.id == id)
         .ok_or_else(|| "PROFILE_NOT_FOUND: profile disappeared after switch".to_string())
+}
+
+/// 确保首装引导档案目录存在（以 `profiles_root` 注入，便于单测）。
+///
+/// 幂等且绝不覆盖：目录已存在（含 CLI 侧手动创建的同名档案）时直接复用；
+/// 缺失时按官方 `initProfile` 形态初始化（web 模板 bundles，可正常渲染桌面
+/// 内嵌的 web UI）。
+fn ensure_desktop_profile_with_root(profiles_root: &Path) -> Result<(), String> {
+    let dir = profiles_root.join(DESKTOP_PROFILE);
+    if dir.is_dir() {
+        return Ok(());
+    }
+    init_profile_dir(&dir, DESKTOP_PROFILE)
+}
+
+/// 首装档案引导：桌面端首次安装时新建独立的 Desktop 档案并切换为当前档案。
+///
+/// 为什么：此前装过 dsh CLI 并装了大量插件/补丁的用户，启用桌面端时这些旧
+/// 数据会涌入桌面端所用档案导致加载异常；首装即隔离到干净档案可防御性规避。
+/// 老用户（store 已存在）绝不动其档案选择。幂等 + 最佳努力：已引导过
+/// （`desktop_profile_ready`）或任何一步失败时跳过并告警，回落 web 档案的
+/// 老行为，绝不阻断启动。调用时机：desktop::setup（前端可操作之前，让安装
+/// 向导/预装插件/内置插件全部落进 Desktop 档案）与 launch（spawn dsh 前重试）。
+pub fn ensure_first_run_desktop_profile(app_handle: &AppHandle) {
+    if !config::is_first_install() {
+        return;
+    }
+    if config::get_store_dat_setting(app_handle).desktop_profile_ready {
+        return;
+    }
+    let profiles_root = config::get_dsh_data_path(app_handle).join("profiles");
+    if let Err(e) = ensure_desktop_profile_with_root(&profiles_root) {
+        log::warn!("first-run Desktop profile init failed: {e}");
+        return;
+    }
+    if let Err(e) = set_active(app_handle, DESKTOP_PROFILE) {
+        log::warn!("first-run Desktop profile switch failed: {e}");
+        return;
+    }
+    config::update_store_dat_setting(app_handle, |setting| {
+        setting.desktop_profile_ready = true;
+    });
+    log::info!("First-run bootstrap: Desktop profile created and activated ({DESKTOP_PROFILE})");
 }
 
 /// 删除档案（默认档案与使用中的档案不可删除）。
@@ -646,6 +698,39 @@ mod tests {
         assert_eq!(npmrc, npmrc2);
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// 首装引导档案：初始化产物与官方 initProfile 形态一致，且已存在时绝不覆盖。
+    #[test]
+    fn desktop_bootstrap_creates_official_shape_once() {
+        let tmp = std::env::temp_dir().join(format!("dsh-profile-desktop-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let root = tmp.join("profiles");
+
+        ensure_desktop_profile_with_root(&root).unwrap();
+        let dir = root.join(DESKTOP_PROFILE);
+        let manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap())
+                .unwrap();
+        assert_eq!(manifest["name"], "dsh-profile-desktop");
+        assert_eq!(
+            manifest["dsh"]["profile"]["bundles"],
+            serde_json::json!(["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app"])
+        );
+        assert!(dir.join("cordis.patch.yml").is_file());
+        assert!(dir.join("pnpm-workspace.yaml").is_file());
+        let npmrc = std::fs::read_to_string(dir.join(".npmrc")).unwrap();
+        assert!(npmrc.contains("confirmModulesPurge=false"));
+
+        // 幂等：目录已存在时直接复用，绝不覆盖用户改动
+        std::fs::write(dir.join("cordis.patch.yml"), "# user edit\n[]\n").unwrap();
+        ensure_desktop_profile_with_root(&root).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("cordis.patch.yml")).unwrap(),
+            "# user edit\n[]\n"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     /// 路径穿越回归：`..`、`.`、绝对路径、含分隔符的 id 一律在 remove 前被拦截，

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -351,6 +351,11 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
     fs::create_dir_all(&dsh_home)
         .map_err(|e| format!("DSH_HOME_MKDIR_FAILED: create dsh home failed: {e}"))?;
 
+    // 首装档案引导重试：desktop::setup 的引导若失败（磁盘/权限抖动），在真正
+    // spawn dsh 前再补一次；幂等，已就绪时直接跳过。最佳努力：失败只告警，
+    // 不阻断启动（回落 web 档案的老行为）。
+    crate::service::profile::ensure_first_run_desktop_profile(&app_handle);
+
     // Linux 起步前探测 inotify 监视上限：harness 服务（dsh web）用 chokidar 递归
     // 监视 profile 目录，上限过低会在启动一瞬间抛 ENOSPC 直接退出（issue #116）。
     // 进程无法自我调高该参数，这里只做告警（启动日志 + 读取 run logs 中的环境信息），


### PR DESCRIPTION
## 需求背景

此前装过 dsh CLI 并装了大量插件/补丁的用户，启用桌面端时这些旧数据会涌入桌面端所用档案，导致加载异常。需要防御性规避：**新装桌面端**（首次安装本软件）时，在启动 dsh 之前自动新增一个独立的 Desktop 档案并切换过去。

## 实现逻辑

- **首装判定**：以「AppData 下 store 持久化文件（`.store.dat` / debug `.store.dev.dat`）在本进程启动前不存在」为准 —— 装过 dsh CLI 但首次装桌面端的用户（核心场景）与全新用户都命中；老用户升级（store 已存在）绝不动其档案选择。
- **引导动作**：新建 `$DSH_HOME/profiles/desktop`（与官方 `dsh-app-boot::initProfile` 产物一致：web 模板 bundles + `cordis.patch.yml` + `pnpm-workspace.yaml` + `.npmrc`），并写入 `active_profile = "desktop"`。此后服务启动（`--profile desktop`）、预装插件、内置插件、补丁全部落进该档案 —— 全部链路本就以 `active_profile` 为准，实现与 CLI 用户既有数据的防御性隔离。
- **时序安全**：首装检测放在 `.setup` 闭包第一行，先于 `build_main_window`（窗口几何恢复等任何 store 写入会创建 store 文件，判定晚于它们会把首装误判为升级）；判定结果进程内缓存。
- **档案必须先存在**：dsh CLI 对非模板档案在启动时直接抛 `profile does not exist`，故先 create 再切换；档案已存在（含 CLI 侧手动创建的同名档案）时直接复用、绝不覆盖。
- **幂等 + 最佳努力**：`Setting.desktop_profile_ready` 幂等标记；任一步失败仅 `log::warn`，`active_profile()` 自动回落 web，行为等同旧版，绝不阻断启动；`launch()` 内 spawn dsh 前再重试一次，覆盖 setup 阶段失败。

## 改动

| 文件 | 内容 |
| --- | --- |
| `src-tauri/src/config/setting.rs` | `detect_first_install` / `is_first_install`（`OnceLock` 进程内缓存）+ `Setting.desktop_profile_ready: bool` |
| `src-tauri/src/service/profile/mod.rs` | `DESKTOP_PROFILE` 常量、`ensure_first_run_desktop_profile` 引导、`ensure_desktop_profile_with_root`（可注入单测）+ 单测 |
| `src-tauri/src/desktop/builder.rs` | `.setup` 最先检测首装；`desktop::setup` 在 migrate 后、scheduler/auto_start 前调用引导 |
| `src-tauri/src/service/workflow/launch.rs` | `launch()` 内 spawn dsh 前引导重试 |

## 验证

- `cargo check` 通过（无新增告警；`profile::clone` 的 dead_code 告警为既有问题）
- `cargo test`：436 passed / 0 failed
- 新增单测 `desktop_bootstrap_creates_official_shape_once`：校验初始化产物形态与「已存在不覆盖」幂等语义

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic setup of a dedicated desktop profile during first-time installation.
  * Preserved existing profiles and user selections when upgrading or reopening the app.
  * Added a retry during launch to complete desktop profile setup if needed.

* **Bug Fixes**
  * Improved startup resilience by logging profile initialization issues without blocking app launch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->