### PR TITLE
chore: release v0.10.4-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.3",
+  "version": "0.10.4-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.3"
+version = "0.10.4-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.3"
+version = "0.10.4-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.3",
+  "version": "0.10.4-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.4-beta.1` (`0.10.3` → `0.10.4-beta.1`).

### Features

- **profile**: bootstrap a dedicated Desktop profile on first install (3b29d0c)

### Bug Fixes

- **core**: self-heal packaged core runtime plugins & native deps (a1f3a96)
- **clipboard**: use per-op native clipboard to stop Wayland crash on copy logs (ff63854)

### Documentation

- **plugins**: optimization Plan Document for Adding Plugin Type Definitions and Unified Closure (a2ee7d2)
- list scheduler built-in plugin (8312c55)

### Other Changes

- Merge pull request #349 from dsh-tauri-desk/feat/first-run-desktop-profile (f85897c)
- Merge pull request #345 from dsh-tauri-desk/fix/issue-343-core-runtime-self-heal (109ecef)
- Merge pull request #343 from dsh-tauri-desk/fix/clipboard-wayland-crash (5e1af10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to **0.10.4-beta.1** across its release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->