### PR TITLE
fix(toast): 修复linux下触发toast时程序无响应

### DIFF
--- a/src/components/toast-provider.tsx
+++ b/src/components/toast-provider.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Toast } from '@heroui/react'
-import { placements, queues } from '@/utils/toast'
+import { placements, activeQueues } from '@/utils/toast'
 
 export function ToastProvider({ children }: { children?: ReactNode }) {
   return (
@@ -9,7 +9,7 @@ export function ToastProvider({ children }: { children?: ReactNode }) {
         <Toast.Provider
           key={p}
           placement={p}
-          queue={queues[p]}
+          queue={activeQueues[p]}
         />
       ))}
       {children}

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -19,6 +19,14 @@ export const queues = Object.fromEntries(
   placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3 })]),
 ) as Record<Placement, ToastQueue>
 
+const linuxQueues = Object.fromEntries(
+  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3 ,wrapUpdate: (fn) => fn() })]),
+) as Record<Placement, ToastQueue>
+
+export const activeQueues = navigator.platform.toLowerCase().includes('linux')
+    ? linuxQueues
+    : queues
+
 const placementsKeys = new Map<string, Placement>()
 
 export function toast(
@@ -27,7 +35,7 @@ export function toast(
 ) {
   // 默认右下角；个别调用方需要其他位置时显式传 placement
   const { placement = 'bottom end', ...rest } = options || {}
-  const key = queues[placement].add({ title: message, ...rest })
+  const key = activeQueues[placement].add({ title: message, ...rest })
   placementsKeys.set(key, placement)
   return key
 }
@@ -36,12 +44,12 @@ function close(key: string) {
   const placement = placementsKeys.get(key)
   placementsKeys.delete(key)
   if (placement)
-    queues[placement].close(key)
+    activeQueues[placement].close(key)
 }
 
 function clear() {
   placementsKeys.clear()
-  placements.forEach(p => queues[p].clear())
+  placements.forEach(p => activeQueues[p].clear())
 }
 
 toast.close = close


### PR DESCRIPTION
# 问题
在linux版本下，只要触发toast就会无响应。

# 根因
wayland在处理heroui 的toast动画合成时出现了异常，导致整个程序页面卡死

# 修复
`const linuxQueues = Object.fromEntries(
  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3 ,wrapUpdate: (fn) => fn() })]),
) as Record<Placement, ToastQueue>`
使用`wrapUpdate: (fn) => fn() `去除动画过渡效果，此效果仅在linux下生效。不影响其他平台。

# 验证
fix前
<img width="1280" height="877" alt="err" src="https://github.com/user-attachments/assets/9c404ac9-24ab-4417-9b98-288e8eaa9d64" />
fix后
<img width="940" height="635" alt="ok" src="https://github.com/user-attachments/assets/921a5ff5-9a57-4119-9639-30bd2b833506" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toast notification handling on Linux for more consistent display and updates.
  * Ensured toast creation, dismissal, and clearing behave reliably across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->