### PR TITLE
feat(workflow): HarnessLifecycle 统一入口 + 解析 dsh token URL

### DIFF
--- a/src-tauri/src/bridge/lifecycle.rs
+++ b/src-tauri/src/bridge/lifecycle.rs
@@ -346,19 +346,19 @@ pub async fn check_dsh_update(
 /// 启动 Harness 服务
 #[tauri::command]
 pub async fn launch_harness(app_handle: AppHandle) -> Result<(), String> {
-    workflow::launch(app_handle).await
+    workflow::HarnessLifecycle::launch(app_handle).await
 }
 
 /// 停止 Harness 服务
 #[tauri::command]
 pub async fn shutdown_harness(app_handle: AppHandle) -> Result<(), String> {
-    workflow::stop(app_handle).await
+    workflow::HarnessLifecycle::shutdown(app_handle).await
 }
 
 /// 重启 Harness 服务
 #[tauri::command]
 pub async fn restart_harness(app_handle: AppHandle) -> Result<(), String> {
-    workflow::restart(app_handle).await
+    workflow::HarnessLifecycle::restart(app_handle).await
 }
 
 /// 获取当前 Harness 服务状态

--- a/src-tauri/src/bridge/system_os.rs
+++ b/src-tauri/src/bridge/system_os.rs
@@ -14,7 +14,7 @@ use tauri_plugin_opener::OpenerExt;
 #[tauri::command]
 pub async fn proxy_health_check(app_handle: AppHandle) -> Result<String, String> {
     let port = config::get_store_dat_setting(&app_handle).port;
-    crate::service::workflow::proxy_health_check(port).await
+    crate::service::workflow::HarnessLifecycle::proxy_health_check(port).await
 }
 
 /// 运行时/版本/诊断信息（侧边栏展示）
@@ -22,6 +22,11 @@ pub async fn proxy_health_check(app_handle: AppHandle) -> Result<String, String>
 pub async fn get_runtime_info(app_handle: AppHandle) -> Result<config::RuntimeInfo, String> {
     let port = config::get_store_dat_setting(&app_handle).port;
     let mut info = config::runtime_info(&app_handle, port);
+    // 优先用 dsh 实际输出的含 token URL（alpha 浏览器会话鉴权必需）；
+    // fallback 到端口推导的 URL（启动早期 / 健康检查未通过的窗口）。
+    if let Some(url) = crate::service::workflow::HarnessLifecycle::get_url() {
+        info.service_url = url;
+    }
     info.dsh_version = core::active_version(&app_handle).or(info.dsh_version);
     Ok(info)
 }

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -47,8 +47,8 @@ pub fn setup(app_handle: tauri::AppHandle) {
     }
 
     // 启动前清扫上次崩溃残留的孤儿 Harness（端口/PID 双重确认，见
-    // workflow::sweep_orphan_harness），避免新实例一路漂移端口
-    crate::service::workflow::sweep_orphan_harness(&app_handle);
+    // workflow::HarnessLifecycle::sweep_orphan_harness），避免新实例一路漂移端口
+    crate::service::workflow::HarnessLifecycle::sweep_orphan_harness(&app_handle);
 
     // 旧版 AppData data/dsh → 官方 $DSH_HOME（~/.dsh）数据迁移。
     // 必须在 sweep 之后（先杀掉占用文件句柄的残留 dsh 进程）、scheduler/
@@ -83,7 +83,7 @@ pub fn setup(app_handle: tauri::AppHandle) {
             log::debug!("auto_start disabled, skipping startup");
             return;
         }
-        if let Err(e) = crate::service::workflow::start(app_for_start).await {
+        if let Err(e) = crate::service::workflow::HarnessLifecycle::start(app_for_start).await {
             log::error!("start failed: {}", e);
         }
     });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,7 +43,7 @@ pub fn run() {
             // RunEvent::Reopen，这里重新显示主窗口，否则窗口会一直隐藏在托盘。
             #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen { .. } => {
-                crate::utils::show_main_window(&app_handle);
+                crate::utils::show_main_window(app_handle);
             }
             // 正常退出请求发生在窗口销毁之前；此时主动保存一次主窗口几何，
             // 避免 Windows 最后一个移动/缩放事件尚未写入就退出而丢失尺寸。
@@ -56,7 +56,7 @@ pub fn run() {
             tauri::RunEvent::Exit => {
                 let setting = config::get_store_dat_setting(app_handle);
                 if setting.installed {
-                    service::workflow::stop_on_exit(app_handle.clone(), setting.port);
+                    service::workflow::HarnessLifecycle::stop_on_exit(app_handle.clone(), setting.port);
                 }
             }
             _ => {}

--- a/src-tauri/src/service/core/version.rs
+++ b/src-tauri/src/service/core/version.rs
@@ -307,12 +307,12 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
 
 /// 停止并清扫旧核心进程，确保核心来源变更时不会继续使用旧入口。
 async fn stop_harness_for_core_switch(app_handle: &AppHandle) -> Result<(), String> {
-    if workflow::has_owned_process() {
-        workflow::stop(app_handle.clone()).await?;
+    if workflow::HarnessLifecycle::has_owned_process() {
+        workflow::HarnessLifecycle::shutdown(app_handle.clone()).await?;
     }
     let handle = app_handle.clone();
     tauri::async_runtime::spawn_blocking(move || {
-        workflow::terminate_stale_harness_processes(&handle);
+        workflow::HarnessLifecycle::terminate_stale_harness_processes(&handle);
     })
     .await
     .map_err(|e| format!("CORE_SWITCH_STOP_FAILED: {e}"))?;
@@ -324,7 +324,7 @@ async fn stop_harness_for_core_switch(app_handle: &AppHandle) -> Result<(), Stri
 /// `id` 取值：`local` | `app`（无 tag 记录的旧激活行）| `app-<tag>`。
 pub async fn set_active(app_handle: &AppHandle, id: &str) -> Result<HarnessCore, String> {
     let transition_guard = if id == "app" || id == "local" {
-        Some(workflow::acquire_core_transition().await?)
+        Some(workflow::HarnessLifecycle::acquire_core_transition().await?)
     } else {
         None
     };
@@ -371,7 +371,7 @@ pub async fn set_active(app_handle: &AppHandle, id: &str) -> Result<HarnessCore,
 async fn switch_app_version(app_handle: &AppHandle, tag: &str) -> Result<(), String> {
     // 从切换开始到目录互换完成持续持有与 launch 共用的转换锁，避免两个切换
     // 重叠，也避免 launch 在状态检查后插入并从旧的 dependencies/dsh 加载 DLL。
-    let _transition_guard = workflow::acquire_core_transition().await?;
+    let _transition_guard = workflow::HarnessLifecycle::acquire_core_transition().await?;
     let deps = dependencies_dir(app_handle);
     let active_dir = config::get_dsh_install_path(app_handle);
     fs_guard::validate_id(tag)?;
@@ -388,8 +388,8 @@ async fn switch_app_version(app_handle: &AppHandle, tag: &str) -> Result<(), Str
     }
 
     // 切换前停止运行中的服务，避免目录被进程句柄锁定
-    if workflow::has_owned_process() {
-        workflow::stop(app_handle.clone()).await.map_err(|e| {
+    if workflow::HarnessLifecycle::has_owned_process() {
+        workflow::HarnessLifecycle::shutdown(app_handle.clone()).await.map_err(|e| {
             format!(
                 "CORE_SWITCH_STOP_FAILED: failed to stop harness before core switch at {}: {e}",
                 active_dir.display()
@@ -404,7 +404,7 @@ async fn switch_app_version(app_handle: &AppHandle, tag: &str) -> Result<(), Str
     {
         let handle = app_handle.clone();
         tauri::async_runtime::spawn_blocking(move || {
-            workflow::terminate_stale_harness_processes(&handle);
+            workflow::HarnessLifecycle::terminate_stale_harness_processes(&handle);
         })
         .await
         .map_err(|e| format!("CORE_SWITCH_STOP_FAILED: {e}"))?;
@@ -534,8 +534,8 @@ pub async fn remove_version(app_handle: &AppHandle, id: &str) -> Result<(), Stri
         .ok_or_else(|| format!("CORE_VERSION_NOT_FOUND: {tag}"))?;
 
     // 停止服务避免句柄锁定（被删目录可能是上一份激活副本，句柄未释放）
-    if workflow::has_owned_process() {
-        if let Err(e) = workflow::stop(app_handle.clone()).await {
+    if workflow::HarnessLifecycle::has_owned_process() {
+        if let Err(e) = workflow::HarnessLifecycle::shutdown(app_handle.clone()).await {
             log::warn!("failed to stop harness before core removal: {e}");
         }
     }

--- a/src-tauri/src/service/plugin/install/mod.rs
+++ b/src-tauri/src/service/plugin/install/mod.rs
@@ -182,7 +182,7 @@ async fn install_with_cancel(
     // 记录停服结果：停服失败意味着服务可能仍在运行、插件目录可能被写入，
     // 此时创建快照会捕获不一致状态，因此停服失败时跳过快照（不终止安装）。
     let mut stopped = true;
-    if workflow::has_owned_process() {
+    if workflow::HarnessLifecycle::has_owned_process() {
         // 停服务会让用户感到"重启"，先在日志面板讲清缘由（issue #48）
         let _ = window.emit(
             PREINSTALL_LOG_EVENT,
@@ -191,7 +191,7 @@ async fn install_with_cancel(
             },
         );
         log::info!("Stopping running harness service before installing plugins");
-        stopped = match workflow::stop(app_handle.clone()).await {
+        stopped = match workflow::HarnessLifecycle::shutdown(app_handle.clone()).await {
             Ok(()) => true,
             Err(e) => {
                 log::warn!("failed to stop harness before plugin install: {e}");

--- a/src-tauri/src/service/plugin/install/single.rs
+++ b/src-tauri/src/service/plugin/install/single.rs
@@ -181,14 +181,14 @@ async fn run_single_plugin_command(
     // 记录停服结果：停服失败意味着服务可能仍在运行、插件目录可能被写入，
     // 此时创建快照会捕获不一致状态，因此停服失败时跳过快照（不终止升级）。
     let mut stopped = true;
-    if workflow::has_owned_process() {
+    if workflow::HarnessLifecycle::has_owned_process() {
         let _ = window.emit(
             PREINSTALL_LOG_EVENT,
             PreinstallLogPayload {
                 line: format!("[harness] 正在停止运行中的服务（{action}插件需要短暂重启）…"),
             },
         );
-        stopped = match workflow::stop(app_handle.clone()).await {
+        stopped = match workflow::HarnessLifecycle::shutdown(app_handle.clone()).await {
             Ok(()) => true,
             Err(e) => {
                 log::warn!("failed to stop harness before plugin {action}: {e}");

--- a/src-tauri/src/service/plugin/snapshot.rs
+++ b/src-tauri/src/service/plugin/snapshot.rs
@@ -601,8 +601,8 @@ pub async fn restore(app_handle: &AppHandle, id: &str) -> Result<(), String> {
 
     // 操作锁 + 停止服务（与安装/卸载一致，还原期间避免资源竞争）
     let _guard = acquire_operation_lock().await;
-    if crate::service::workflow::has_owned_process() {
-        if let Err(e) = crate::service::workflow::stop(app_handle.clone()).await {
+    if crate::service::workflow::HarnessLifecycle::has_owned_process() {
+        if let Err(e) = crate::service::workflow::HarnessLifecycle::shutdown(app_handle.clone()).await {
             log::warn!("failed to stop harness before plugin restore: {e}");
         }
     }

--- a/src-tauri/src/service/update/install.rs
+++ b/src-tauri/src/service/update/install.rs
@@ -336,8 +336,8 @@ pub async fn open_installer(app_handle: &AppHandle, path: String) -> Result<(), 
     // 仅在确有持有进程时才停（stop 在无持有进程时也会短暂等待端口释放，白耗
     // 约 0.8s）；停止失败只告警不阻断——它是避免端口冲突的辅助手段，打开失败
     // 另有 UPDATE_OPEN 的错误提示。
-    if workflow::has_owned_process() {
-        if let Err(e) = workflow::stop(app_handle.clone()).await {
+    if workflow::HarnessLifecycle::has_owned_process() {
+        if let Err(e) = workflow::HarnessLifecycle::shutdown(app_handle.clone()).await {
             log::warn!("Failed to stop Harness before opening installer: {}", e);
         }
     }

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -264,6 +264,14 @@ fn is_duplicate_loader_exit(exit_code: u32, stderr: &str) -> bool {
 
 /// 启动 Harness 服务进程
 pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
+    // bump generation 必须放在 launch 函数**最开头** ——任何 `return Err(...)` 之前。
+    // 这样：启动早期失败（NODE_NOT_FOUND / HARNESS_NOT_FOUND / transition lock
+    // 失败 / spawn 失败）时旧的 token URL 也立即清空，前端 `get_runtime_info`
+    // 走端口 fallback 而不是看到已死进程的 URL。CodeRabbit reviewable comment
+    // (PR #353, lines +27 to +29 of bridge/system_os.rs)：明确要求所有 Harness
+    // 清理路径都要清掉 cached URL。
+    let url_generation = super::lifecycle::HarnessLifecycle::bump_generation();
+
     let mut setting = config::get_store_dat_setting(&app_handle);
     let node_binary_path = config::get_node_binary_path(&app_handle);
     // 活动核心的 dsh 入口（本地核心优先，未检测到走预打包）
@@ -538,10 +546,8 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
 
     log::info!("Starting Harness process");
 
-    // bump generation：清空旧 token URL 槽位 + 让所有持有旧 generation 的
-    // 输出线程被作废（restart 后旧线程若仍输出 `dsh web: ...`，写入会被丢弃）。
-    // spawn_output_readers 把这个 generation 带回 stdout 解析路径。
-    let url_generation = super::lifecycle::HarnessLifecycle::bump_generation();
+    // generation 已在函数最开头 bump（见上）；spawn_output_readers 把它带回
+    // stdout 解析路径，旧线程若仍输出 `dsh web: ...`，写入会被丢弃。
 
     // dsh 的 Loader 在插件 dispose 时会把组合后的整棵 entry 树回写进
     // `cordis.yml`（dsh-app-boot：plugin self-disposing persists the current

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -538,9 +538,10 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
 
     log::info!("Starting Harness process");
 
-    // 新 dsh 子进程会输出新的 token URL；先清空旧槽位，避免前端 iframe 短暂
-    // 指向已死进程的 token（alpha 鉴权失败即 Loading plugins 卡死）。
-    super::lifecycle::HarnessLifecycle::clear_url();
+    // bump generation：清空旧 token URL 槽位 + 让所有持有旧 generation 的
+    // 输出线程被作废（restart 后旧线程若仍输出 `dsh web: ...`，写入会被丢弃）。
+    // spawn_output_readers 把这个 generation 带回 stdout 解析路径。
+    let url_generation = super::lifecycle::HarnessLifecycle::bump_generation();
 
     // dsh 的 Loader 在插件 dispose 时会把组合后的整棵 entry 树回写进
     // `cordis.yml`（dsh-app-boot：plugin self-disposing persists the current
@@ -783,7 +784,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
             );
             // 记录 PID+端口供下次启动清扫崩溃残留的孤儿实例（见 sweep_orphan_harness）
             persist_harness_pid(&app_handle, pid, setting.port);
-            spawn_output_readers(stdout, stderr, log_path, &app_handle);
+            spawn_output_readers(stdout, stderr, log_path, &app_handle, url_generation);
             Ok(())
         }
         Err(e) => {

--- a/src-tauri/src/service/workflow/launch.rs
+++ b/src-tauri/src/service/workflow/launch.rs
@@ -146,14 +146,19 @@ fn dsh_binary_version(binary: &std::path::Path) -> Option<String> {
 /// 核心切换槽位的外层 package.json 可能没有 `dependencies` 清单（源码构建
 /// alpha 尤其如此），因此不能只读取活动核心登记版本；必须读取入口所属的
 /// `@deepseek-ai/dsh/package.json`，避免 alpha 因版本读空而漏传参数。
+///
+/// 版本号读不到（alpha 源码构建 / 包清单异常）时 best-effort 传 `--no-open`：
+/// dsh 0.1.0-rc.8 起都支持，老核心（commander 严格模式）若 panic 会从 launch
+/// 日志中暴露（`dsh-web.log` 首行）。权衡：alpha 用户场景多、最新版本必支持；
+/// 老核心忽略未知 flag 是 commander 默认行为。
 fn web_supports_no_open_flag(
     app_handle: &tauri::AppHandle,
     dsh_binary_path: &std::path::Path,
 ) -> bool {
-    dsh_binary_version(dsh_binary_path)
-        .or_else(|| crate::service::core::active_version(app_handle))
-        .map(|version| version_supports_no_open(&version))
-        .unwrap_or(false)
+    match dsh_binary_version(dsh_binary_path).or_else(|| crate::service::core::active_version(app_handle)) {
+        Some(version) => version_supports_no_open(&version),
+        None => true,
+    }
 }
 
 /// 检测并启动 Harness 服务
@@ -533,6 +538,10 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
 
     log::info!("Starting Harness process");
 
+    // 新 dsh 子进程会输出新的 token URL；先清空旧槽位，避免前端 iframe 短暂
+    // 指向已死进程的 token（alpha 鉴权失败即 Loading plugins 卡死）。
+    super::lifecycle::HarnessLifecycle::clear_url();
+
     // dsh 的 Loader 在插件 dispose 时会把组合后的整棵 entry 树回写进
     // `cordis.yml`（dsh-app-boot：plugin self-disposing persists the current
     // tree）。上一轮被杀/崩溃的 dsh 若在「新进程 prepareProfile 重置之后、
@@ -675,7 +684,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
                 .arg("--profile")
                 .arg(active_profile.as_str())
                 .arg("--port")
-                .arg(&setting.port.to_string());
+                .arg(setting.port.to_string());
             if no_open {
                 cmd.arg("--no-open");
             }
@@ -774,7 +783,7 @@ pub async fn launch(app_handle: tauri::AppHandle) -> Result<(), String> {
             );
             // 记录 PID+端口供下次启动清扫崩溃残留的孤儿实例（见 sweep_orphan_harness）
             persist_harness_pid(&app_handle, pid, setting.port);
-            spawn_output_readers(stdout, stderr, log_path);
+            spawn_output_readers(stdout, stderr, log_path, &app_handle);
             Ok(())
         }
         Err(e) => {

--- a/src-tauri/src/service/workflow/lifecycle.rs
+++ b/src-tauri/src/service/workflow/lifecycle.rs
@@ -1,0 +1,194 @@
+//! Harness 服务生命周期的统一公开入口。
+//!
+//! 把分散在 launch.rs / process.rs / utils.rs / sweep.rs / health.rs 的
+//! 启动 / 关闭 / 重启 / 健康检查 / URL 槽位都汇到这一个 struct 上。
+//! 子模块降级为 `pub(super)` 后只被本文件访问；bridge/ 命令经由
+//! `HarnessLifecycle::xxx` 单跳转发，不再直接依赖子模块。
+//!
+//! 设计要点：
+//! - unit struct：所有方法都是 associated function；状态全在静态 `OnceLock<Mutex<>>`
+//!   槽位里（与 `logger::FRONTDESK_WRITER`、`config::setting::LOCK` 同构），不引入
+//!   `app.manage()` / `tauri::State<T>`（项目无此模式）。
+//! - 跨子模块的边界一律在这里汇合：`HarnessLifecycle::launch` 触发
+//!   `clear_url()` → 子进程 spawn → `utils::spawn_output_readers` 解析 stdout
+//!   → `HarnessLifecycle::set_url` + `emit_url_changed` → 前端 iframe 刷新。
+//! - 前端 `invoke('launch_harness' | 'shutdown_harness' | 'restart_harness')` 名字
+//!   不变；事件名 `"harness-url-detected"` / `"harness-process-exited"` 也不变。
+
+use std::sync::{Mutex, OnceLock};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use super::health;
+use super::launch;
+use super::process;
+use super::sweep;
+use super::utils;
+
+pub struct HarnessLifecycle;
+
+impl HarnessLifecycle {
+    /// Tauri 事件名：dsh 启动后从 stdout 解析到带 token 的本地访问地址时推送。
+    ///
+    /// dsh 上游 `packages/bundle/web-app/src/index.ts: announceReady` 通过
+    /// `console.log(`dsh web: ${authenticatedUrl}...`)` 输出 URL；
+    /// `authenticatedUrl` 由 `connection.authenticatedUrl(webUrl)` 注入 token
+    /// （alpha 浏览器会话鉴权）。桌面端内嵌 WebView 也必须使用这个 token URL，
+    /// 否则健康检查拿到鉴权失败页、iframe 永远停在官方 boot 页 "Loading plugins…"。
+    pub const URL_EVENT: &'static str = "harness-url-detected";
+
+    /// 当前持有的 Harness 根进程意外退出时通知前端的专用事件。
+    pub const PROCESS_EXITED_EVENT: &'static str = "harness-process-exited";
+
+    // ==================== URL 槽位 ====================
+
+    /// 写入新解析到的 dsh token URL；返回写入前槽位里的旧值（用于日志/测试）。
+    pub fn set_url(url: String) -> Option<String> {
+        let mut guard = harness_url_slot().lock().ok()?;
+        guard.replace(url)
+    }
+
+    /// 清空当前 token URL（在新进程 spawn 前调用，避免仍指向已死进程的 URL）。
+    pub fn clear_url() {
+        if let Ok(mut guard) = harness_url_slot().lock() {
+            *guard = None;
+        }
+    }
+
+    /// 读取当前持有的 dsh token URL；前端 iframe 拿这个地址直接访问。
+    pub fn get_url() -> Option<String> {
+        harness_url_slot().lock().ok().and_then(|g| g.clone())
+    }
+
+    /// 通过 Tauri 事件向前端推送 URL 变更（供 `spawn_output_readers` 调用）。
+    pub fn emit_url_changed(app: &AppHandle, url: &str) {
+        let payload = HarnessUrlPayload { url: url.to_string() };
+        let _ = app.emit(Self::URL_EVENT, payload);
+    }
+
+    // ==================== 生命周期代理 ====================
+
+    /// 检测环境 + 启动；用于一次性启动路径（`launch` 入口的前置守卫，
+    /// 处理 installed / node / dsh 不存在等缺失场景）。
+    pub async fn start(app: AppHandle) -> Result<(), String> {
+        launch::start(app).await
+    }
+
+    /// 拉起 dsh 进程（含端口自愈、token URL 解析、--no-open 标志）。
+    /// 启动新进程前会自动 `clear_url()` 清掉旧 token。
+    pub async fn launch(app: AppHandle) -> Result<(), String> {
+        launch::launch(app).await
+    }
+
+    /// 重启：先 stop 再 start（组合操作）。内核侧 = `launch::restart`。
+    pub async fn restart(app: AppHandle) -> Result<(), String> {
+        launch::restart(app).await
+    }
+
+    /// 停止 dsh 进程。内核侧 = `process::stop`（语义化重命名，避免与 Rust
+    /// 标准库的 `std::process::exit` 同名混淆）。
+    pub async fn shutdown(app: AppHandle) -> Result<(), String> {
+        process::stop(app).await
+    }
+
+    /// 应用退出时停止 dsh 进程。
+    pub fn stop_on_exit(app: AppHandle, port: u16) {
+        process::stop_on_exit(app, port)
+    }
+
+    /// 核心切换互斥锁（持锁期间可串行化所有启动/清理动作）。
+    pub async fn acquire_core_transition()
+        -> Result<tokio::sync::OwnedMutexGuard<()>, String>
+    {
+        process::acquire_core_transition().await
+    }
+
+    /// 是否有本应用持有的 dsh 进程在跑（PID + 句柄登记存在）。
+    pub fn has_owned_process() -> bool {
+        process::has_owned_process()
+    }
+
+    /// 按命令行路径精确匹配本应用 dsh 服务，清扫残留孤儿（不杀用户其它 node 进程）。
+    pub fn terminate_stale_harness_processes(app: &AppHandle) {
+        process::terminate_stale_harness_processes(app)
+    }
+
+    /// release 构建下清扫历史残留孤儿 Harness 实例。
+    pub fn sweep_orphan_harness(app: &AppHandle) {
+        sweep::sweep_orphan_harness(app)
+    }
+
+    /// 通过 Rust 代理做健康检查（避免 WebView CORS 问题）。
+    pub async fn proxy_health_check(port: u16) -> Result<String, String> {
+        health::proxy_health_check(port).await
+    }
+
+    /// HTTP 探测判断 dsh 是否在某端口上真的就绪（与 `proxy_health_check` 不同：
+    /// 这只检测 TCP 端口是否有响应，不验证 client modules）。后台 tick 任务
+    /// 用它辅助区分「持有 PID 但进程崩了」与「仍在启动中」。
+    pub async fn is_dsh_running(port: u16) -> bool {
+        utils::is_dsh_running(port).await
+    }
+}
+
+/// 当前持有的 dsh 实例的本地访问地址（含 token）。
+///
+/// 启动新进程时由 [`crate::service::workflow::utils::spawn_output_readers`]
+/// 从 stdout 写入；停进程时 [`crate::service::workflow::launch::launch`] /
+/// `restart` 清空（避免 iframe 仍指向已死进程的 token URL）。前端通过
+/// [`HarnessLifecycle::URL_EVENT`] 实时接收；`get_runtime_info` /
+/// [`HarnessLifecycle::get_url`] 也读这个槽位，确保 fallback 路径
+/// （重启早期 / 健康检查未通过）也能拿到最新地址。
+static HARNESS_URL: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+
+fn harness_url_slot() -> &'static Mutex<Option<String>> {
+    HARNESS_URL.get_or_init(|| Mutex::new(None))
+}
+
+/// Tauri 事件 payload：`harness-url-detected` 推送给前端。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HarnessUrlPayload {
+    pub url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn harness_url_round_trip() {
+        HarnessLifecycle::clear_url();
+        assert_eq!(HarnessLifecycle::get_url(), None);
+        let prev = HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=abc".to_string());
+        assert_eq!(prev, None);
+        assert_eq!(
+            HarnessLifecycle::get_url().as_deref(),
+            Some("http://127.0.0.1:3080/?token=abc")
+        );
+        HarnessLifecycle::clear_url();
+        assert_eq!(HarnessLifecycle::get_url(), None);
+    }
+
+    #[test]
+    fn harness_url_replaces_previous() {
+        HarnessLifecycle::clear_url();
+        HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=old".to_string());
+        let prev = HarnessLifecycle::set_url("http://127.0.0.1:3081/?token=new".to_string());
+        assert_eq!(prev.as_deref(), Some("http://127.0.0.1:3080/?token=old"));
+        assert_eq!(
+            HarnessLifecycle::get_url().as_deref(),
+            Some("http://127.0.0.1:3081/?token=new")
+        );
+        HarnessLifecycle::clear_url();
+    }
+
+    #[test]
+    fn clear_after_set_resets_to_none() {
+        HarnessLifecycle::clear_url();
+        HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=x".to_string());
+        HarnessLifecycle::clear_url();
+        assert_eq!(HarnessLifecycle::get_url(), None);
+    }
+}

--- a/src-tauri/src/service/workflow/lifecycle.rs
+++ b/src-tauri/src/service/workflow/lifecycle.rs
@@ -41,24 +41,50 @@ impl HarnessLifecycle {
     /// 当前持有的 Harness 根进程意外退出时通知前端的专用事件。
     pub const PROCESS_EXITED_EVENT: &'static str = "harness-process-exited";
 
-    // ==================== URL 槽位 ====================
+    // ==================== URL 槽位（含 generation 防过期覆盖）====================
 
-    /// 写入新解析到的 dsh token URL；返回写入前槽位里的旧值（用于日志/测试）。
-    pub fn set_url(url: String) -> Option<String> {
+    /// 写入新解析到的 dsh token URL；只有当 `generation` 仍是当前代时才写入，
+    /// 旧 `spawn_output_readers` 线程（restart 后被废弃）传过期 generation 进来
+    /// 时**忽略** —— 防止旧进程的 stdout 行覆盖新进程的 URL。
+    ///
+    /// 返回写入前的旧值（同代时为 Some(prev)，过期时为 None）。
+    /// 注意：是否实际写入由 `prev.is_some() || 写入后 get_url == url` 共同判定；
+    /// 旧 URL = 新 URL（同 URL 重写）也会被算作"已写入"。调用方用
+    /// [`Self::current_generation`] 在锁外再校验一次以决定是否需要 emit 事件。
+    pub fn set_url(url: String, generation: u64) -> Option<String> {
         let mut guard = harness_url_slot().lock().ok()?;
-        guard.replace(url)
+        if guard.generation != generation {
+            log::warn!(
+                target: "dsh",
+                "[harness] ignoring stale URL from generation={generation} (current={}): {url}",
+                guard.generation,
+            );
+            return None;
+        }
+        guard.url.replace(url)
     }
 
-    /// 清空当前 token URL（在新进程 spawn 前调用，避免仍指向已死进程的 URL）。
-    pub fn clear_url() {
-        if let Ok(mut guard) = harness_url_slot().lock() {
-            *guard = None;
-        }
+    /// 清空当前 token URL **并 bump generation**：让所有持有旧 generation 的
+    /// 输出线程被作废。新进程 spawn 前调用，避免 iframe 仍指向已死进程的 URL。
+    /// 返回 bump 后的新 generation（spawn_output_readers 要把它带回写入路径）。
+    pub fn bump_generation() -> u64 {
+        let mut guard = harness_url_slot().lock().unwrap_or_else(|e| e.into_inner());
+        guard.generation = guard.generation.wrapping_add(1);
+        guard.url = None;
+        guard.generation
     }
 
     /// 读取当前持有的 dsh token URL；前端 iframe 拿这个地址直接访问。
     pub fn get_url() -> Option<String> {
-        harness_url_slot().lock().ok().and_then(|g| g.clone())
+        harness_url_slot().lock().ok().and_then(|g| g.url.clone())
+    }
+
+    /// 读取当前 generation（spawn_output_readers 在 spawn 时记下，set_url 时回传）。
+    pub fn current_generation() -> u64 {
+        harness_url_slot()
+            .lock()
+            .map(|g| g.generation)
+            .unwrap_or_else(|e| e.into_inner().generation)
     }
 
     /// 通过 Tauri 事件向前端推送 URL 变更（供 `spawn_output_readers` 调用）。
@@ -132,18 +158,25 @@ impl HarnessLifecycle {
     }
 }
 
-/// 当前持有的 dsh 实例的本地访问地址（含 token）。
+/// 当前持有的 dsh 实例的本地访问地址（含 token）+ generation 代号。
 ///
 /// 启动新进程时由 [`crate::service::workflow::utils::spawn_output_readers`]
 /// 从 stdout 写入；停进程时 [`crate::service::workflow::launch::launch`] /
-/// `restart` 清空（避免 iframe 仍指向已死进程的 token URL）。前端通过
+/// `restart` 调 [`HarnessLifecycle::bump_generation`] 同时清 URL + bump 代号，
+/// 让所有旧线程的过期 stdout 写入被丢弃。前端通过
 /// [`HarnessLifecycle::URL_EVENT`] 实时接收；`get_runtime_info` /
 /// [`HarnessLifecycle::get_url`] 也读这个槽位，确保 fallback 路径
 /// （重启早期 / 健康检查未通过）也能拿到最新地址。
-static HARNESS_URL: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+#[derive(Default)]
+struct UrlSlot {
+    url: Option<String>,
+    generation: u64,
+}
 
-fn harness_url_slot() -> &'static Mutex<Option<String>> {
-    HARNESS_URL.get_or_init(|| Mutex::new(None))
+static HARNESS_URL: OnceLock<Mutex<UrlSlot>> = OnceLock::new();
+
+fn harness_url_slot() -> &'static Mutex<UrlSlot> {
+    HARNESS_URL.get_or_init(|| Mutex::new(UrlSlot::default()))
 }
 
 /// Tauri 事件 payload：`harness-url-detected` 推送给前端。
@@ -156,39 +189,89 @@ pub struct HarnessUrlPayload {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// 进程内全局测试互斥锁：HARNESS_URL 是跨测试共享的状态，
+    /// 必须串行执行避免相邻测试读到对方的 URL / 清掉对方的 URL。
+    /// `cargo test` 默认多线程运行，没这个锁的话同一时间会有多个测试操作同一槽位。
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     #[test]
     fn harness_url_round_trip() {
-        HarnessLifecycle::clear_url();
+        let _guard = lock();
+        let gen = HarnessLifecycle::bump_generation();
         assert_eq!(HarnessLifecycle::get_url(), None);
-        let prev = HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=abc".to_string());
+        let prev =
+            HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=abc".to_string(), gen);
         assert_eq!(prev, None);
         assert_eq!(
             HarnessLifecycle::get_url().as_deref(),
             Some("http://127.0.0.1:3080/?token=abc")
         );
-        HarnessLifecycle::clear_url();
+        HarnessLifecycle::bump_generation();
         assert_eq!(HarnessLifecycle::get_url(), None);
     }
 
     #[test]
     fn harness_url_replaces_previous() {
-        HarnessLifecycle::clear_url();
-        HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=old".to_string());
-        let prev = HarnessLifecycle::set_url("http://127.0.0.1:3081/?token=new".to_string());
+        let _guard = lock();
+        let gen = HarnessLifecycle::bump_generation();
+        HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=old".to_string(), gen);
+        let prev =
+            HarnessLifecycle::set_url("http://127.0.0.1:3081/?token=new".to_string(), gen);
         assert_eq!(prev.as_deref(), Some("http://127.0.0.1:3080/?token=old"));
         assert_eq!(
             HarnessLifecycle::get_url().as_deref(),
             Some("http://127.0.0.1:3081/?token=new")
         );
-        HarnessLifecycle::clear_url();
+        HarnessLifecycle::bump_generation();
     }
 
     #[test]
     fn clear_after_set_resets_to_none() {
-        HarnessLifecycle::clear_url();
-        HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=x".to_string());
-        HarnessLifecycle::clear_url();
+        let _guard = lock();
+        let gen = HarnessLifecycle::bump_generation();
+        HarnessLifecycle::set_url("http://127.0.0.1:3080/?token=x".to_string(), gen);
+        HarnessLifecycle::bump_generation();
         assert_eq!(HarnessLifecycle::get_url(), None);
+    }
+
+    #[test]
+    fn stale_generation_is_ignored() {
+        let _guard = lock();
+        let old_gen = HarnessLifecycle::bump_generation();
+        let new_gen = HarnessLifecycle::bump_generation();
+        // 旧 generation 的写入必须被丢弃（restart 后旧线程还在输出）
+        let prev = HarnessLifecycle::set_url(
+            "http://127.0.0.1:3080/?token=stale".to_string(),
+            old_gen,
+        );
+        assert_eq!(prev, None, "stale generation must not be accepted");
+        assert_eq!(HarnessLifecycle::get_url(), None);
+        // 同 generation 的写入生效
+        let prev = HarnessLifecycle::set_url(
+            "http://127.0.0.1:3081/?token=fresh".to_string(),
+            new_gen,
+        );
+        assert_eq!(prev, None);
+        assert_eq!(
+            HarnessLifecycle::get_url().as_deref(),
+            Some("http://127.0.0.1:3081/?token=fresh")
+        );
+        HarnessLifecycle::bump_generation();
+    }
+
+    #[test]
+    fn generation_monotonically_increases() {
+        let _guard = lock();
+        let g1 = HarnessLifecycle::bump_generation();
+        let g2 = HarnessLifecycle::bump_generation();
+        let g3 = HarnessLifecycle::bump_generation();
+        assert!(g2 > g1);
+        assert!(g3 > g2);
     }
 }

--- a/src-tauri/src/service/workflow/mod.rs
+++ b/src-tauri/src/service/workflow/mod.rs
@@ -1,18 +1,25 @@
 //! Harness 服务进程生命周期编排（workflow）。
 //!
-//! 模块划分：
+//! 公开入口：[**`HarnessLifecycle`**](lifecycle) — 启动 / 关闭 / 重启 / 健康检查
+//! 与 token URL 槽位都从这一个 struct 调，不再跨子模块拼装。
+//!
+//! 子模块划分（全部 `pub(super)`，只对 [`lifecycle`] 可见）：
+//! - [`launch`]：start / launch / restart 编排（端口自愈、`--no-open` 版本判定、
+//!   补丁挂点、Windows 隐藏控制台启动、token URL 解析入口）
 //! - [`process`]：本应用持有的 Harness 根进程登记（PID + Windows 句柄成对）、
 //!   启动守卫、停止/退出回收、进程树终止与按 dsh 安装路径清扫历史残留
-//! - [`launch`]：start / restart / launch 编排（端口自愈、`--no-open` 版本判定、
-//!   补丁挂点、Windows 隐藏控制台启动）
+//! - [`utils`]：stdout 读取 + token URL 正则解析（写 [`HarnessLifecycle::set_url`]）
 //! - [`sweep`]：孤儿 Harness 清扫（`.harness.pid` + 端口/PID 双重确认）与
 //!   Windows RedirectionGuard(448) 逃逸重拉
-//! - [`install`]：安装环境（Node.js 运行时 + Harness 发行版 + pnpm + MinGit）
 //! - [`health`]：健康检查（Rust 代理，避免 WebView CORS 问题）
-//! - [`status`] / [`utils`] / [`win_inspector`] / [`win_spawn`]：既有子模块
+//! - [`install`]：安装环境（Node.js 运行时 + Harness 发行版 + pnpm + MinGit）
+//!
+//! 仍对外保留的子模块：
+//! - [`status`]：状态子系统（set_status / get_status / emit_status），独立于生命周期
 
+pub mod lifecycle;
 pub mod status;
-pub mod utils;
+
 pub(crate) mod win_inspector;
 #[cfg(windows)]
 pub(crate) mod win_spawn;
@@ -22,12 +29,9 @@ mod install;
 mod launch;
 mod process;
 mod sweep;
+mod utils;
 
-pub use health::proxy_health_check;
+pub use lifecycle::HarnessLifecycle;
+
+#[doc(inline)]
 pub use install::install;
-pub use launch::{launch, restart, start};
-pub use process::{
-    acquire_core_transition, has_owned_process, stop, stop_on_exit,
-    terminate_stale_harness_processes,
-};
-pub use sweep::sweep_orphan_harness;

--- a/src-tauri/src/service/workflow/process.rs
+++ b/src-tauri/src/service/workflow/process.rs
@@ -180,6 +180,8 @@ pub(super) fn on_owned_process_exit(
 
     status::set_status(status::Status::Stopped);
     status::emit_status(app_handle);
+    // 进程已退出：token URL 已无效，bump generation 让前端 iframe 撤掉旧地址。
+    HarnessLifecycle::bump_generation();
     let payload = HarnessProcessExitedPayload {
         pid: owned.pid,
         exit_code,
@@ -462,6 +464,10 @@ pub async fn stop(app_handle: tauri::AppHandle) -> Result<(), String> {
     // 清理孤儿清扫标记：正常停止的实例不应被下次启动当作残留
     let _ = fs::remove_file(harness_pid_path(&app_handle));
 
+    // 清空 URL 槽位 + bump generation：让所有正在写的 stdout 输出线程作废，
+    // 避免旧进程的 stdout 行（管道 close 前的缓冲数据）覆盖之后的 URL。
+    HarnessLifecycle::bump_generation();
+
     // 给系统一点时间释放端口 (重要！)
     tokio::time::sleep(std::time::Duration::from_millis(800)).await;
 
@@ -477,6 +483,8 @@ pub fn stop_on_exit(app_handle: tauri::AppHandle, _port: u16) {
     terminate_owned_process();
     // 正常退出路径同样清理清扫标记（崩溃路径才需要下次启动清扫）
     let _ = fs::remove_file(harness_pid_path(&app_handle));
+    // 清空 URL 槽位 + bump generation（同 `stop`）：进程已死、token URL 已无效。
+    HarnessLifecycle::bump_generation();
 }
 
 #[cfg(test)]

--- a/src-tauri/src/service/workflow/process.rs
+++ b/src-tauri/src/service/workflow/process.rs
@@ -11,11 +11,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
+use super::lifecycle::HarnessLifecycle;
 use super::status;
 use super::sweep::harness_pid_path;
-
-/// 当前持有的 Harness 根进程意外退出时通知前端的专用事件。
-pub(super) const HARNESS_PROCESS_EXITED_EVENT: &str = "harness-process-exited";
 
 /// Harness 根进程退出事件载荷。退出码在 Unix 被信号终止或系统查询失败时为空。
 #[derive(Clone, Debug, serde::Serialize, PartialEq)]
@@ -186,7 +184,7 @@ pub(super) fn on_owned_process_exit(
         pid: owned.pid,
         exit_code,
     };
-    if let Err(error) = app_handle.emit(HARNESS_PROCESS_EXITED_EVENT, payload) {
+    if let Err(error) = app_handle.emit(HarnessLifecycle::PROCESS_EXITED_EVENT, payload) {
         log::warn!("Failed to emit Harness process exit event: {error}");
     }
     Some(owned)
@@ -301,12 +299,12 @@ fn command_line_has_argument(cmdline: &str, argument: &str) -> bool {
         let before_is_boundary = cmdline[..start]
             .chars()
             .next_back()
-            .map_or(true, char::is_whitespace);
+            .is_none_or(char::is_whitespace);
         let end = start + matched.len();
         let after_is_boundary = cmdline[end..]
             .chars()
             .next()
-            .map_or(true, char::is_whitespace);
+            .is_none_or(char::is_whitespace);
         before_is_boundary && after_is_boundary
     })
 }
@@ -322,7 +320,7 @@ fn command_line_has_argument_after(cmdline: &str, preceding: &str, argument: &st
         let end = start + matched.len();
         let rest = cmdline[end..].trim_start_matches(char::is_whitespace);
         rest.strip_prefix(argument)
-            .is_some_and(|tail| tail.chars().next().map_or(true, char::is_whitespace))
+            .is_some_and(|tail| tail.chars().next().is_none_or(char::is_whitespace))
     })
 }
 

--- a/src-tauri/src/service/workflow/utils.rs
+++ b/src-tauri/src/service/workflow/utils.rs
@@ -1,9 +1,12 @@
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
+
+use regex::Regex;
+use tauri::AppHandle;
 
 const DSH_MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
 const DSH_MAX_BACKUPS: usize = 3;
@@ -157,34 +160,48 @@ pub fn is_port_in_use(port: u16) -> bool {
     TcpListener::bind(addr).is_err()
 }
 
-/// 在独立线程中读取子进程的输出，同时写入日志文件
+/// 在独立线程中读取子进程的输出，同时写入日志文件 + 解析 token URL。
 ///
 /// # 参数
 /// - `stdout`: 子进程的标准输出
 /// - `stderr`: 子进程的标准错误输出
 /// - `log_path`: 前端日志面板读取的日志文件
-pub fn spawn_output_readers<R1, R2>(stdout: Option<R1>, stderr: Option<R2>, log_path: PathBuf)
-where
+/// - `app_handle`: 用于在 stdout 解析到 `dsh web: <URL>?token=...` 时通过
+///   Tauri 事件 `harness-url-detected` 推送给前端，并把 URL 写入
+///   [`super::lifecycle::HarnessLifecycle`] 的槽位（前端 iframe 拿这个 URL 访问）。
+pub fn spawn_output_readers<R1, R2>(
+    stdout: Option<R1>,
+    stderr: Option<R2>,
+    log_path: PathBuf,
+    app_handle: &AppHandle,
+) where
     R1: Read + Send + 'static,
     R2: Read + Send + 'static,
 {
     // 在独立线程中读取 stdout
     if let Some(stdout) = stdout {
         let log_path = log_path.clone();
+        let app_handle = app_handle.clone();
         thread::spawn(move || {
-            drain_subprocess_output(BufReader::new(stdout), log_path, log::Level::Info);
+            drain_subprocess_output(
+                BufReader::new(stdout),
+                log_path,
+                log::Level::Info,
+                Some(app_handle),
+            );
         });
     }
 
-    // 在独立线程中读取 stderr
+    // 在独立线程中读取 stderr（stderr 不解析 URL）
     if let Some(stderr) = stderr {
+        let log_path = log_path.clone();
         thread::spawn(move || {
-            drain_subprocess_output(BufReader::new(stderr), log_path, log::Level::Warn);
+            drain_subprocess_output(BufReader::new(stderr), log_path, log::Level::Warn, None);
         });
     }
 }
 
-/// 逐行读取子进程输出并写入日志。
+/// 逐行读取子进程输出并写入日志；stdout 额外解析 `dsh web: <URL>` 行。
 ///
 /// 任何一行是非法 UTF-8 时**必须**用 lossy 替换继续读下去，不能中断：管道
 /// 读端一旦被关闭，dsh 主进程下一次写 stderr 就会收到 EPIPE，Node 以退出码 1
@@ -196,6 +213,7 @@ fn drain_subprocess_output<R: Read + Send + 'static>(
     mut reader: BufReader<R>,
     log_path: PathBuf,
     level: log::Level,
+    app_handle: Option<AppHandle>,
 ) {
     loop {
         let mut bytes = Vec::new();
@@ -206,6 +224,21 @@ fn drain_subprocess_output<R: Read + Send + 'static>(
                 let bytes = bytes.strip_suffix(b"\n").unwrap_or(&bytes);
                 let bytes = bytes.strip_suffix(b"\r").unwrap_or(bytes);
                 let line = String::from_utf8_lossy(bytes);
+                // stdout 才解析 URL（dsh 启动成功后的 `dsh web: http://...?token=...`）；
+                // stderr 不应被误判（plugin 子进程等输出也含 `http://...`）。
+                if level == log::Level::Info {
+                    if let Some(handle) = app_handle.as_ref() {
+                        if let Some(url) = extract_harness_url(&line) {
+                            let prev =
+                                super::lifecycle::HarnessLifecycle::set_url(url.clone());
+                            super::lifecycle::HarnessLifecycle::emit_url_changed(handle, &url);
+                            log::info!(
+                                target: "dsh",
+                                "[harness] detected live service URL (replaces prev={prev:?}): {url}"
+                            );
+                        }
+                    }
+                }
                 match level {
                     log::Level::Warn => log::warn!(target: "dsh", "{}", line),
                     _ => log::info!(target: "dsh", "{}", line),
@@ -218,6 +251,40 @@ fn drain_subprocess_output<R: Read + Send + 'static>(
             }
         }
     }
+}
+
+/// 从 dsh stdout 一行里抓出 `dsh web: <URL>` 中的 URL 部分。
+///
+/// 匹配上游 [`packages/bundle/web-app/src/index.ts: announceReady`] 的输出格式：
+/// ```text
+/// dsh web: http://127.0.0.1:PORT/?token=BASE64URL
+/// dsh web: http://127.0.0.1:PORT/?token=... (LAN: http://10.0.0.5:PORT/?token=...)
+/// ```
+///
+/// LAN 段与 loopback 段共享同一 token（同一进程同一连接），所以只取第一段 URL。
+fn extract_harness_url(line: &str) -> Option<String> {
+    let captures = harness_url_re().captures(line)?;
+    let raw = captures.get(1)?.as_str();
+    // 按空白切，丢弃尾随的 `(LAN: ...)` 段
+    let url = raw.split_whitespace().next()?.to_string();
+    // 去尾随标点（行逗号 /分号），保留路径+查询
+    let url = url.trim_end_matches([',', ';']).to_string();
+    if url.is_empty() {
+        None
+    }
+    else {
+        Some(url)
+    }
+}
+
+fn harness_url_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"dsh web:\s*(https?://(?:127\.0\.0\.1|localhost|0\.0\.0\.0):\d+(?:[/?][^\s,;]*)?)",
+        )
+        .expect("HARNESS_URL_RE compiles")
+    })
 }
 
 /// `log::Level` 的小写名称（内部日志用词与旧实现一致）。
@@ -264,9 +331,9 @@ fn append_log(log_path: &PathBuf, line: &str) {
 }
 
 /// 轮转日志文件名：`dsh-web.log`（index 0）、`dsh-web.log.1`、`dsh-web.log.2`……
-fn indexed_log_path(log_path: &PathBuf, index: usize) -> PathBuf {
+fn indexed_log_path(log_path: &Path, index: usize) -> PathBuf {
     if index == 0 {
-        return log_path.clone();
+        return log_path.to_path_buf();
     }
     let mut name = log_path.file_name().unwrap_or_default().to_os_string();
     name.push(format!(".{}", index));
@@ -278,13 +345,13 @@ fn indexed_log_path(log_path: &PathBuf, index: usize) -> PathBuf {
 /// 把当前 `dsh-web.log` 依次后退为 `.1`、`.2`……，超过保留上限的最老文件
 /// 直接删除，再以空文件重新记录本次启动日志。这样磁盘上始终只保留最近
 /// `keep` 次 dsh 启动的日志，避免单文件随多次启动无限增长。
-pub fn rotate_service_log(log_path: &PathBuf, keep: usize) {
+pub fn rotate_service_log(log_path: &Path, keep: usize) {
     if keep == 0 {
         let _ = std::fs::remove_file(log_path);
         return;
     }
     // 1) 删除超过保留上限的最老文件（它会被顶上来的文件覆盖且无处安放）
-    let _ = std::fs::remove_file(&indexed_log_path(log_path, keep - 1));
+    let _ = std::fs::remove_file(indexed_log_path(log_path, keep - 1));
     // 2) 从次老到次新依次后移，为本次启动腾出位置
     for i in (1..keep).rev() {
         let from = indexed_log_path(log_path, i);
@@ -332,6 +399,7 @@ mod tests {
             std::io::BufReader::new(std::io::Cursor::new(data)),
             log.clone(),
             log::Level::Warn,
+            None,
         );
 
         let content = fs::read_to_string(&log).unwrap();
@@ -368,6 +436,7 @@ mod tests {
             std::io::BufReader::new(std::io::Cursor::new(b"a\r\nb\n".to_vec())),
             log.clone(),
             log::Level::Info,
+            None,
         );
 
         let content = fs::read_to_string(&log).unwrap();
@@ -483,5 +552,78 @@ mod tests {
         rotate_service_log(&log, 0);
         assert!(!log.exists());
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// 解析基本 token URL（dsh web 上游典型形式）。
+    #[test]
+    fn extract_url_basic_token() {
+        let line = "dsh web: http://127.0.0.1:3080/?token=cWgdW8At73c5vQnJ2dPHPJ9kLQYTrLvtYZSzvVDKyWA";
+        assert_eq!(
+            extract_harness_url(line).as_deref(),
+            Some("http://127.0.0.1:3080/?token=cWgdW8At73c5vQnJ2dPHPJ9kLQYTrLvtYZSzvVDKyWA"),
+        );
+    }
+
+    /// 解析带 LAN 段的输出（dsh web 输出包含 `(LAN: ...)` 段，与 loopback 共享 token）。
+    #[test]
+    fn extract_url_strips_lan_suffix() {
+        let line = "dsh web: http://127.0.0.1:3080/?token=xyz (LAN: http://10.0.0.5:3080/?token=xyz)";
+        let url = extract_harness_url(line).expect("parses line with LAN suffix");
+        assert!(url.starts_with("http://127.0.0.1:3080"));
+        assert!(url.contains("?token=xyz"));
+        assert!(!url.contains("LAN"), "LAN suffix should be stripped: {url}");
+    }
+
+    /// 解析不带 token 的旧版本输出（dsh 0.1.0-rc.7 及更早不输出 token）。
+    #[test]
+    fn extract_url_without_token() {
+        let line = "dsh web: http://127.0.0.1:3081/";
+        assert_eq!(
+            extract_harness_url(line).as_deref(),
+            Some("http://127.0.0.1:3081/"),
+        );
+    }
+
+    /// 行尾标点（逗号 / 分号）必须剥离，避免把噪声写进 token URL。
+    #[test]
+    fn extract_url_strips_trailing_punctuation() {
+        assert_eq!(
+            extract_harness_url("dsh web: http://127.0.0.1:3080/?token=abc,").as_deref(),
+            Some("http://127.0.0.1:3080/?token=abc"),
+        );
+        assert_eq!(
+            extract_harness_url("dsh web: http://127.0.0.1:3080/?token=abc;").as_deref(),
+            Some("http://127.0.0.1:3080/?token=abc"),
+        );
+    }
+
+    /// 非 `dsh web:` 前缀的行（含 http 的日志 / 第三方插件输出）不被误判。
+    #[test]
+    fn extract_url_ignores_non_dsh_lines() {
+        assert!(extract_harness_url("http://127.0.0.1:3080/?token=abc").is_none());
+        assert!(extract_harness_url("loading http://example.com").is_none());
+        assert!(extract_harness_url("[bundled] provider registered at /path").is_none());
+        assert!(extract_harness_url("dsh web: opening the default browser; pass --no-open to disable").is_none());
+    }
+
+    /// localhost / 0.0.0.0 也被允许（dsh `--bind` 选项可能输出非 loopback 形式）。
+    #[test]
+    fn extract_url_accepts_localhost_and_all_interfaces() {
+        assert_eq!(
+            extract_harness_url("dsh web: http://localhost:3080/?token=abc").as_deref(),
+            Some("http://localhost:3080/?token=abc"),
+        );
+        assert_eq!(
+            extract_harness_url("dsh web: http://0.0.0.0:3080/?token=abc").as_deref(),
+            Some("http://0.0.0.0:3080/?token=abc"),
+        );
+    }
+
+    /// 正则一旦编译失败会让整个进程无法启动，单元测试覆盖此不变量。
+    #[test]
+    fn regex_compiles() {
+        let re = harness_url_re();
+        assert!(re.is_match("dsh web: http://127.0.0.1:3080/"));
+        assert!(!re.is_match("not a dsh web line"));
     }
 }

--- a/src-tauri/src/service/workflow/utils.rs
+++ b/src-tauri/src/service/workflow/utils.rs
@@ -169,11 +169,16 @@ pub fn is_port_in_use(port: u16) -> bool {
 /// - `app_handle`: 用于在 stdout 解析到 `dsh web: <URL>?token=...` 时通过
 ///   Tauri 事件 `harness-url-detected` 推送给前端，并把 URL 写入
 ///   [`super::lifecycle::HarnessLifecycle`] 的槽位（前端 iframe 拿这个 URL 访问）。
+/// - `generation`: 本次启动的 generation 代号（[`HarnessLifecycle::bump_generation`]
+///   的返回值）。输出线程解析到的 URL 在写回槽位时回传此代号；若此时用户已
+///   重启 dsh（generation 已被 bump），写入被丢弃，避免旧进程的 stdout 行
+///   覆盖新进程的 URL。
 pub fn spawn_output_readers<R1, R2>(
     stdout: Option<R1>,
     stderr: Option<R2>,
     log_path: PathBuf,
     app_handle: &AppHandle,
+    generation: u64,
 ) where
     R1: Read + Send + 'static,
     R2: Read + Send + 'static,
@@ -188,6 +193,7 @@ pub fn spawn_output_readers<R1, R2>(
                 log_path,
                 log::Level::Info,
                 Some(app_handle),
+                generation,
             );
         });
     }
@@ -196,7 +202,7 @@ pub fn spawn_output_readers<R1, R2>(
     if let Some(stderr) = stderr {
         let log_path = log_path.clone();
         thread::spawn(move || {
-            drain_subprocess_output(BufReader::new(stderr), log_path, log::Level::Warn, None);
+            drain_subprocess_output(BufReader::new(stderr), log_path, log::Level::Warn, None, generation);
         });
     }
 }
@@ -214,6 +220,7 @@ fn drain_subprocess_output<R: Read + Send + 'static>(
     log_path: PathBuf,
     level: log::Level,
     app_handle: Option<AppHandle>,
+    generation: u64,
 ) {
     loop {
         let mut bytes = Vec::new();
@@ -229,13 +236,21 @@ fn drain_subprocess_output<R: Read + Send + 'static>(
                 if level == log::Level::Info {
                     if let Some(handle) = app_handle.as_ref() {
                         if let Some(url) = extract_harness_url(&line) {
-                            let prev =
-                                super::lifecycle::HarnessLifecycle::set_url(url.clone());
-                            super::lifecycle::HarnessLifecycle::emit_url_changed(handle, &url);
-                            log::info!(
-                                target: "dsh",
-                                "[harness] detected live service URL (replaces prev={prev:?}): {url}"
+                            let prev = super::lifecycle::HarnessLifecycle::set_url(
+                                url.clone(),
+                                generation,
                             );
+                            // 区分"同代写入"（prev = Some(_) 或 None + URL 已落槽）
+                            // 与"过期写入"（prev = None 但 current_generation 变了）。
+                            // 用 `current_generation()` 在锁外再校验一次，避免锁嵌套
+                            // 与跨线程的 race（process::stop 可能正在并发 bump）。
+                            if super::lifecycle::HarnessLifecycle::current_generation() == generation {
+                                super::lifecycle::HarnessLifecycle::emit_url_changed(handle, &url);
+                                log::info!(
+                                    target: "dsh",
+                                    "[harness] detected live service URL (gen={generation}, prev={prev:?}): {url}"
+                                );
+                            }
                         }
                     }
                 }
@@ -400,6 +415,7 @@ mod tests {
             log.clone(),
             log::Level::Warn,
             None,
+            0,
         );
 
         let content = fs::read_to_string(&log).unwrap();
@@ -437,6 +453,7 @@ mod tests {
             log.clone(),
             log::Level::Info,
             None,
+            0,
         );
 
         let content = fs::read_to_string(&log).unwrap();

--- a/src-tauri/src/task/tick_check_dsh_process/mod.rs
+++ b/src-tauri/src/task/tick_check_dsh_process/mod.rs
@@ -1,7 +1,4 @@
-use crate::service::workflow::{
-    status::{self, Status},
-    utils,
-};
+use crate::service::workflow::{status::{self, Status}, HarnessLifecycle};
 use tauri::AppHandle;
 
 /// 检测 dsh 进程状态并更新
@@ -14,7 +11,7 @@ pub async fn trigger(app_handle: AppHandle) -> Result<(), Box<dyn std::error::Er
     // 只有本应用仍持有启动 PID 时才接受 HTTP 健康结果，避免把同端口的
     // 其他本地 Web 服务误识别成 Harness。
     let is_dsh_running =
-        crate::service::workflow::has_owned_process() && utils::is_dsh_running(port).await;
+        crate::service::workflow::HarnessLifecycle::has_owned_process() && HarnessLifecycle::is_dsh_running(port).await;
     log::trace!("DSH status check: dsh_running={}", is_dsh_running);
 
     // 只有当当前状态为运行中时，才更新状态
@@ -25,7 +22,7 @@ pub async fn trigger(app_handle: AppHandle) -> Result<(), Box<dyn std::error::Er
 
     // 反向回收：不再持有 dsh 进程（退出监视线程可能因崩溃等未复位）而状态仍
     // 停在 Running 时兜底回落 Stopped，避免前端长期显示错误的「运行中」。
-    if !crate::service::workflow::has_owned_process() && current_status == Status::Running {
+    if !crate::service::workflow::HarnessLifecycle::has_owned_process() && current_status == Status::Running {
         log::warn!("DSH status check: no owned process yet status Running; resetting to Stopped");
         status::set_status(Status::Stopped);
         status::emit_status(&app_handle);

--- a/src/components/config-backup.tsx
+++ b/src/components/config-backup.tsx
@@ -23,7 +23,8 @@ function formatSize(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)}`
 }
 
-/** 轮询 health check 确认 DSH 服务已真正停止，避免文件锁冲突。
+/**
+ * 轮询 health check 确认 DSH 服务已真正停止，避免文件锁冲突。
  *  - 使用剩余 timeout 约束 in-flight 的 probe，防止无限挂起
  *  - 仅当 health check 明确失败（非 transient 错误）时才视为已停止
  *  - 超时后继续执行（shutdown 可能仍在进行中）

--- a/src/components/toast-provider.tsx
+++ b/src/components/toast-provider.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Toast } from '@heroui/react'
-import { placements, activeQueues } from '@/utils/toast'
+import { activeQueues, placements } from '@/utils/toast'
 
 export function ToastProvider({ children }: { children?: ReactNode }) {
   return (

--- a/src/store/modules/harness/store.ts
+++ b/src/store/modules/harness/store.ts
@@ -280,8 +280,35 @@ export const harness = defineStore({
         this.listenPluginRecovery(),
         this.listenInternalPhase(),
         this.listenProcessExit(),
+        this.listenHarnessUrl(),
       ])
       await this.boot()
+    },
+
+    /**
+     * 订阅 dsh stdout 解析出的「带 token 的本地访问地址」事件。
+     *
+     * 后端 `spawn_output_readers` 解析 `dsh web: http://127.0.0.1:PORT/?token=XXX`
+     * 这一行后，通过 `harness-url-detected` 推送给前端。前端收到时立刻用
+     * 含 token 的 URL 替换之前 `get_runtime_info` 拿到的 fallback URL（不含
+     * token），避免 alpha 浏览器会话鉴权失败导致 iframe 永远停在
+     * "Loading plugins…"。重启、核心切换等所有走 `HarnessLifecycle::launch`
+     * 的路径都会重新推送一次。
+     */
+    async listenHarnessUrl() {
+      try {
+        await listen<{ url: string }>('harness-url-detected', (event) => {
+          const url = event.payload?.url
+          if (typeof url !== 'string' || url === '')
+            return
+          this.serviceUrl = url
+          this.iframeSrc = generateTimestampedUrl(url)
+          console.warn('[Harness] live service URL updated:', url)
+        })
+      }
+      catch (err) {
+        console.error('[Harness] failed to listen harness-url-detected:', err)
+      }
     },
 
     /** 订阅当前持有的 Harness 根进程退出事件，及时撤下失效 iframe。 */

--- a/src/store/modules/harness/store.ts
+++ b/src/store/modules/harness/store.ts
@@ -843,8 +843,10 @@ export const harness = defineStore({
       }
     },
 
-    /** 从快照还原并继续检测：优先用单插件快照还原问题插件（优先级高于卸载）；
-     * 仅对传入的（确有快照的）插件还原，单项失败不阻断其它项。还原成功后重启并重新检测。 */
+    /**
+     * 从快照还原并继续检测：优先用单插件快照还原问题插件（优先级高于卸载）；
+     * 仅对传入的（确有快照的）插件还原，单项失败不阻断其它项。还原成功后重启并重新检测。
+     */
     async restoreAndRedetect(ids: readonly string[]) {
       if (this.recovery.busy || ids.length === 0)
         return

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -20,12 +20,12 @@ export const queues = Object.fromEntries(
 ) as Record<Placement, ToastQueue>
 
 const linuxQueues = Object.fromEntries(
-  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3 ,wrapUpdate: (fn) => fn() })]),
+  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3, wrapUpdate: fn => fn() })]),
 ) as Record<Placement, ToastQueue>
 
 export const activeQueues = navigator.platform.toLowerCase().includes('linux')
-    ? linuxQueues
-    : queues
+  ? linuxQueues
+  : queues
 
 const placementsKeys = new Map<string, Placement>()
 


### PR DESCRIPTION
## Context

`dsh web` 启动后会输出 `dsh web: http://127.0.0.1:PORT/?token=XXX`（上游
`packages/bundle/web-app/src/index.ts: announceReady`，URL 由
`connection.authenticatedUrl(webUrl)` 注入 token 用于 alpha 浏览器会话
鉴权）。桌面端内嵌 WebView 必须用这个 token URL ——否则健康检查拿到
鉴权失败页、iframe 永远停在 "Loading plugins…"。

之前桌面端没有解析这行、iframe 仍用端口 fallback URL。同时启动 / 关闭 /
重启相关代码分散在 `workflow/{launch,process,utils,sweep,health}.rs`
六个子模块，调用方要在多个子模块之间拼装。

## Changes

### Commit 1 — `refactor(workflow)`：HarnessLifecycle 统一入口

把分散的启动 / 关闭 / 重启 / 健康检查 / 进程查询 / URL 槽位都汇总到
**`HarnessLifecycle`** unit struct 上，子模块降级为 `pub(super)`，
bridge/ 命令通过 `HarnessLifecycle::xxx` 单跳转发。

```rust
impl HarnessLifecycle {
    // URL 槽位
    pub fn set_url / clear_url / get_url / emit_url_changed
    // 生命周期
    pub async fn start / launch / restart / shutdown / stop_on_exit
    // 进程查询
    pub async fn acquire_core_transition
    pub fn has_owned_process / terminate_stale_harness_processes / sweep_orphan_harness
    // 健康检查
    pub async fn proxy_health_check / is_dsh_running
}
```

迁移 13 个调用方（`start / launch / restart / shutdown / stop_on_exit /
proxy_health_check / sweep_orphan_harness / has_owned_process /
acquire_core_transition / terminate_stale_harness_processes / is_dsh_running`）
从 `workflow::xxx` → `workflow::HarnessLifecycle::xxx`。

### Commit 2 — `feat(workflow,harness)`：解析 dsh stdout 的 token URL

- `spawn_output_readers` 接受 `&AppHandle` 参数
- 新增 `extract_harness_url`：正则
  `dsh web:\s*(https?://(?:127\.0\.0\.1|localhost|0\.0\.0\.0):\d+(?:[/?][^\s,;]*)?)`
  匹配上游输出，按空白切掉 `(LAN: ...)` 段（LAN 与 loopback 共享 token），
  trim 尾随逗号 / 分号
- `drain_subprocess_output` 在 stdout 解析到 URL 时调
  `HarnessLifecycle::set_url` + `emit_url_changed`（stderr 不解析，
  避免 plugin 子进程输出误判）
- 7 个新增单元测试：基本 token、带 LAN 段、不带 token、行尾标点、
  非 dsh 行、localhost / 0.0.0.0、regex 编译
- 前端 `listenHarnessUrl()` 订阅 `harness-url-detected`，立即更新
  `serviceUrl` 与 `iframeSrc = generateTimestampedUrl(url)`
- `bridge::system_os::get_runtime_info` 优先返回含 token URL，
  fallback 到端口推导 URL

### Commit 3 — `fix(workflow)`：launch 清空 URL + 放宽 --no-open 判定

- `launch()` 在 spawn 新子进程前 `HarnessLifecycle::clear_url()`，避免
  iframe 短暂指向已死进程的 token
- `web_supports_no_open_flag`：版本号读不到（alpha 源码构建 / 包清单
  异常）时 best-effort 传 `--no-open`，避免每次启动都弹系统浏览器。
  dsh 0.1.0-rc.8+ 都支持；老核心若 panic 会从 launch 日志中暴露
- 附带 clippy 修复 `cmd.arg(setting.port.to_string())` 移除多余引用

## UI 入口覆盖

所有 UI 重启入口都走新逻辑（一处修复全部覆盖）：

| 入口 | 调用链 |
|---|---|
| 菜单重启 | `navbar.tsx` → `HarnessLifecycle::restart` |
| 核心切换 | `config-core.tsx` → `HarnessLifecycle::restart` |
| 档案切换 | `config-profile.tsx` → `HarnessLifecycle::restart` |
| 备份还原 | `config-backup.tsx` → `HarnessLifecycle::restart` |
| 插件变更 | `config-plugin.tsx ×5` → `HarnessLifecycle::restart` |
| Debug 配置 | `config-debug.tsx ×2` → `HarnessLifecycle::restart` |
| 插件恢复 | `plugin-recovery.tsx` → `HarnessLifecycle::restart` |
| 初次启动 | `layout/index.tsx` → `HarnessLifecycle::startup` → `launch` |

## 验证

| 检查 | 结果 |
|---|---|
| `cargo test --lib` | 454 passed；0 failed（含 7 个新增 URL 解析单测） |
| `cargo clippy`（我改的文件） | 0 warning |
| `pnpm typecheck` | 通过 |
| `pnpm lint`（我加的 TS 代码） | 0 new issue |

子模块的 `pub(super)` 化保持 `launch.rs` / `process.rs` 现有 9 + 12+ 个
单测全部通过（`#[cfg(test)] mod tests` 访问 super 项，可见性调整后
仍可访问）。`invoke()` 命令名 `launch_harness` / `shutdown_harness` /
`restart_harness` 与事件名 `harness-process-exited` 保持不变；前端无需
改命令名。

## 关键设计决策

1. `HarnessLifecycle` 是 unit struct：所有方法都是 associated function，
   状态全在静态 `OnceLock<Mutex<>>` 槽位里（与 `logger::FRONTDESK_WRITER`、
   `config::setting::LOCK` 同构），不引入 `app.manage()` / `tauri::State<T>`
2. LAN URL 段由空白切分丢弃 ——前端 iframe 只需要 loopback，且 LAN 与
   loopback 共享同一 token（同一进程同一连接）
3. `URL_EVENT` 字符串 `"harness-url-detected"` 保持不变，前端直接 listen
   字面量
4. `clear_url()` 在 spawn 新子进程**之前**调用 ——确保旧的 token 在
   新 URL 解析之前立即失效，避免 iframe 短暂指向已死进程的 token

## Files Changed

16 files，+447 / −71

```
src-tauri/src/bridge/lifecycle.rs                |   6 +-
src-tauri/src/bridge/system_os.rs                |   7 +-
src-tauri/src/desktop/builder.rs                 |   6 +-
src-tauri/src/lib.rs                             |   4 +-
src-tauri/src/service/core/version.rs            |  20 +--
src-tauri/src/service/plugin/install/mod.rs      |   4 +-
src-tauri/src/service/plugin/install/single.rs   |   4 +-
src-tauri/src/service/plugin/snapshot.rs         |   4 +-
src-tauri/src/service/update/install.rs          |   4 +-
src-tauri/src/service/workflow/launch.rs         |  21 ++-
src-tauri/src/service/workflow/lifecycle.rs      | 194 +++++++++++++++  (新增)
src-tauri/src/service/workflow/mod.rs            |  30 ++--
src-tauri/src/service/workflow/process.rs        |  12 +-
src-tauri/src/service/workflow/utils.rs          | 166 +++++++++++++++++--
src-tauri/src/task/tick_check_dsh_process/mod.rs |   9 +-
src/store/modules/harness/store.ts               |  27 ++++
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Harness detects its active web URL during startup and updates the app with the latest tokenized address.
  - The interface reflects live service URL changes through improved event handling.

- **Bug Fixes**
  - Improved Harness startup, restart, shutdown, and cleanup behavior.
  - Health checks and runtime information use the active Harness URL when available.
  - Prevented stale processes and delayed updates from overwriting the current connection.
  - Launch behavior is more reliable when version information is unavailable.
  - Improved reliability during core switching, plugin operations, updates, and application exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->