### PR TITLE
fix(worktree): probe optional host process controller via ctx.get

### DIFF
--- a/packages/dsh-tauri-worktree/README.md
+++ b/packages/dsh-tauri-worktree/README.md
@@ -43,8 +43,11 @@ checkout_worktree({ worktree_hash_dirname: '[hash]/[dirname]', branch_name: 'dsh
 放弃/检出会移除工作树目录。Git for Windows 旧版本递归删除时会跟随 NTFS junction，
 误删 junction 目标内容，因此磁盘删除绝不交给 Git：
 
-1. （可选）宿主注册 `ctx.worktreeProcessController.stopSessionProcesses` 时，先终止仍以
-   工作树为 cwd 的进程；未注册时跳过（公共 DSH API 暂无按会话停止进程的能力）。
+1. （可选）先终止仍以工作树为 cwd 的进程：宿主把该能力注册为 ctx 服务后，插件经
+   `ctx.get('worktreeProcessController')` 探测并按「探测后调用」约定读取
+   `stopSessionProcesses`；未注册即跳过（公共 DSH API 暂无按会话停止进程的能力）。
+   注意宿主 ctx 是 cordis 代理，未注入的属性直接读取会抛
+   `cannot get property ... without inject`，因此探测失败或控制器异常都不会中断删除。
 2. 目录重命名到同卷 `<worktreesRoot>/.trash/[hash]/[dirname]` 后用
    `fs.rm({ recursive, force, maxRetries: 10, retryDelay: 100 })` 删除；重命名失败
    （跨卷/句柄占用）时退回直接 `fs.rm`，外层再重试 3 次（间隔 2s）。

--- a/packages/dsh-tauri-worktree/src/host/service/operation.test.ts
+++ b/packages/dsh-tauri-worktree/src/host/service/operation.test.ts
@@ -39,6 +39,26 @@ afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map(path => rm(path, { recursive: true, force: true })))
 })
 
+/**
+ * Mimic the cordis host ctx (see @deepseek-ai/cordis): reading a property that
+ * was never injected throws `cannot get property "X" without inject`, while
+ * optional host services are reachable through `ctx.get(name)`.
+ */
+function injectingCtx(services: Record<string, unknown> = {}): Record<string, unknown> {
+  const target: Record<string, unknown> = {
+    get(name: string): unknown {
+      return services[name]
+    },
+  }
+  return new Proxy(target, {
+    get(t, prop, receiver) {
+      if (prop in t)
+        return Reflect.get(t, prop, receiver)
+      throw new Error(`cannot get property "${String(prop)}" without inject`)
+    },
+  })
+}
+
 describe('ensureWorktree', () => {
   it('creates detached worktrees from refs/heads/main even when source HEAD differs', async () => {
     const repository = await createRepository('main')
@@ -135,5 +155,48 @@ describe('ensureWorktree', () => {
     expect(result.ok).toBe(false)
     expect(existsSync(worktreePath(worktreesRoot, computeHash(repository, 'missing-main-session'), projectDirname(repository))))
       .toBe(false)
+  })
+
+  it('stops worktree processes via ctx.get before discarding on a cordis-style ctx', async () => {
+    const repository = await createRepository('main')
+    const worktreesRoot = await mkdtemp(join(tmpdir(), 'dsh-worktrees-root-'))
+    temporaryDirectories.push(worktreesRoot)
+    const created = await ensureWorktree({}, worktreesRoot, repository, 'ctx-controller-session')
+    expect(created.ok).toBe(true)
+    if (!created.ok)
+      return
+
+    const stopped: string[] = []
+    const ctx = injectingCtx({
+      worktreeProcessController: {
+        stopSessionProcesses: (sessionId: string, worktreePath: string) => {
+          stopped.push(`${sessionId}:${worktreePath}`)
+          return Promise.resolve()
+        },
+      },
+    })
+
+    const result = await discardWorktree(ctx, worktreesRoot, { sessionId: 'ctx-controller-session' })
+
+    expect(result.ok).toBe(true)
+    expect(existsSync(created.binding.worktreePath)).toBe(false)
+    expect(stopped).toEqual([`ctx-controller-session:${created.binding.worktreePath}`])
+  })
+
+  it('discards even when the host ctx has no worktreeProcessController service (regression)', async () => {
+    const repository = await createRepository('main')
+    const worktreesRoot = await mkdtemp(join(tmpdir(), 'dsh-worktrees-root-'))
+    temporaryDirectories.push(worktreesRoot)
+    const created = await ensureWorktree({}, worktreesRoot, repository, 'ctx-probe-session')
+    expect(created.ok).toBe(true)
+    if (!created.ok)
+      return
+
+    // A cordis ctx whose uninjected property read throws used to make the
+    // controller probe fail and leave the worktree on disk forever.
+    const result = await discardWorktree(injectingCtx(), worktreesRoot, { sessionId: 'ctx-probe-session' })
+
+    expect(result.ok).toBe(true)
+    expect(existsSync(created.binding.worktreePath)).toBe(false)
   })
 })

--- a/packages/dsh-tauri-worktree/src/host/service/operation.ts
+++ b/packages/dsh-tauri-worktree/src/host/service/operation.ts
@@ -16,6 +16,7 @@ import type {
   HostContext,
   OperationResult,
   WorktreeParams,
+  WorktreeProcessController,
 } from '../types/index.js'
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
@@ -81,6 +82,30 @@ async function isRegisteredWorktree(root: string, path: string, signal?: AbortSi
   return { ok: true, registered }
 }
 
+/**
+ * Stop processes that still hold the worktree as their cwd (optional host
+ * capability). The host ctx is a cordis proxy: reading a property that was
+ * never injected throws `cannot get property "X" without inject`, so the
+ * capability must be probed via `ctx.get(name)` first; a plain-object ctx
+ * (tests, non-cordis hosts) falls back to a direct property read. A missing
+ * or broken controller must never block the removal, so the whole probe and
+ * call is guarded.
+ */
+async function stopWorktreeProcesses(ctx: HostContext, sessionId: string, path: string): Promise<void> {
+  try {
+    const get = (ctx as { get?: (name: string) => unknown } | undefined)?.get
+    const controller = typeof get === 'function'
+      ? get.call(ctx, 'worktreeProcessController')
+      : (ctx as { worktreeProcessController?: WorktreeProcessController } | undefined)?.worktreeProcessController
+    const stop = (controller as WorktreeProcessController | undefined)?.stopSessionProcesses
+    if (typeof stop === 'function')
+      await stop(sessionId, path)
+  }
+  catch {
+    // A missing or broken controller is optional: skip process termination.
+  }
+}
+
 async function removeWorktreeOnDisk(
   ctx: HostContext,
   sessionId: string,
@@ -91,10 +116,9 @@ async function removeWorktreeOnDisk(
   dirname: string,
   signal?: AbortSignal,
 ): Promise<OperationResult> {
+  await stopWorktreeProcesses(ctx, sessionId, path)
+
   try {
-    const stop = ctx?.worktreeProcessController?.stopSessionProcesses
-    if (stop)
-      await stop(sessionId, path)
     await removeDirectoryReliably(path, worktreeTrashPath(worktreesRoot, hash, dirname))
   }
   catch (error) {

--- a/src/components/toast-provider.tsx
+++ b/src/components/toast-provider.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Toast } from '@heroui/react'
-import { placements, activeQueues } from '@/utils/toast'
+import { activeQueues, placements } from '@/utils/toast'
 
 export function ToastProvider({ children }: { children?: ReactNode }) {
   return (

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -20,12 +20,12 @@ export const queues = Object.fromEntries(
 ) as Record<Placement, ToastQueue>
 
 const linuxQueues = Object.fromEntries(
-  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3 ,wrapUpdate: (fn) => fn() })]),
+  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3, wrapUpdate: fn => fn() })]),
 ) as Record<Placement, ToastQueue>
 
 export const activeQueues = navigator.platform.toLowerCase().includes('linux')
-    ? linuxQueues
-    : queues
+  ? linuxQueues
+  : queues
 
 const placementsKeys = new Map<string, Placement>()
 


### PR DESCRIPTION
## 问题

删除工作树（放弃/检出）失败，工作树目录与 Git 注册永久残留，用户只看到晦涩的 DI 错误：

```
Removed worktree C:/Users/.../.dsh/worktrees/... {
  ok: false,
  error: 'cannot get property "worktreeProcessController" without inject'
}
```

## 根因

插件宿主 ctx 是 cordis 代理：读取**未注入**的属性会抛 `cannot get property "X" without inject`
（见 `@deepseek-ai/cordis` 的 ReflectService handler / `ctx.get` 契约）。
`removeWorktreeOnDisk` 直接读了 `ctx.worktreeProcessController`（PR #346 引入），
在生产 ctx 上必然抛错 → 被 `try/catch` 捕获后返回 `ok:false` → 删除在触碰磁盘前就中断，
绑定保留、目录和 Git 管理记录都留在原地，且用户无法从错误信息判断磁盘占用。

## 修复

- 按插件宿主契约先经 `ctx.get('worktreeProcessController')` 探测可选能力（与
  `handoff.ts` 的 `agentPresets`、panel-scheduler 的 `permissionPresets` 同一模式）；
  普通对象 ctx（测试）回退到直接属性读取。
- 探测/调用全程防护：可选控制器缺失或异常**绝不阻塞删除**。
- 移除临时 debug console.log。
- README 同步探测契约说明。

## 测试

新增 2 个回归用例（cordis 风格 ctx 代理：有/无 controller 注册）：
- 有 controller：删除前调用 `stopSessionProcesses`，目录移除成功；
- 无 controller（复现本 bug）：`discardWorktree` 成功且目录消失。

本地验证：`vitest` 19/19 通过、`tsc` typecheck 通过、`eslint` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Worktree removal now attempts to stop associated session processes before deleting files.
  - Cleanup continues successfully when process-control services are unavailable or encounter errors.
  - Improved handling of process detection and termination failures to prevent interrupted worktree deletion.

- **Style**
  - Updated toast notification formatting without changing visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->