### PR TITLE
chore: release v0.10.4-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.4-beta.1",
+  "version": "0.10.4-beta.2",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.4-beta.1"
+version = "0.10.4-beta.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.4-beta.1"
+version = "0.10.4-beta.2"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.4-beta.1",
+  "version": "0.10.4-beta.2",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.4-beta.2` (`0.10.4-beta.1` → `0.10.4-beta.2`).

### Features

- **session**: open archived session data directory from group title (2730674)
- **desktop**: restart in safe mode from the error screen (9585129)
- add the directory of empty containers left after cleaning and discarding the work tree (c0deb05)
- **pet**: checkpoint desktop pet overhaul (27f9346)
- **worktree**: reliable junction-safe deletion, async discard, and main baseline (245991f)
- **pet**: mockup-shaped settings tabs, live percent resize, robust sidebar row (f7ac21f)
- **pet**: redesign per feedback — sidebar icon + standalone settings page + draggable pet window with sprite (443cc4f)
- **pet**: external transparent pet window bridged via tauri invoke (#308) (6a13a70)

### Bug Fixes

- **session**: open session dir from row title, prune empty dirs on delete (4c2efc4)
- **desktop**: capture official boot failure page and pending-service plugin refs (42a3067)
- **rightclick**: open directories via plugin-owned host route (bbf8b76)
- **ui**: keep turn navigation visible in narrow sidebar (5edf495)
- **lint**: satisfy eslint in toast.ts and toast-provider.tsx (0695ebb)
- **worktree**: probe optional host process controller via ctx.get (1846263)
- **lint**: put @/utils/core-version before @/utils/silence (ef43c4e)
- **toast**: prevent webview freeze on Linux (dbe4a7c)
- set delete-snapshot busy state before mutation (b7d2e2c)
- address CodeRabbit review comments (b214973)
- **pet**: keep sidebar entry on the settings trigger row (8cfa535)
- **pet**: rework sidebar entry, settings section and pet window per feedback (2d3b817)
- **pet**: address CodeRabbit merge-risk notes — live pet label + visible settings errors (49e50e3)
- **pet**: address CodeRabbit review — cmd allowlist, focus/geometry hardening, settings a11y + rejection handling (0bb1bd7)

### Refactors

- introduce shared silence() utility for intentional error swallowing (434c360)

### Documentation

- **pet**: clarify asset and toast lifecycle (7912187)
- **pet-plugin**: Added pet plugin to-do list and layout specification document (5018747)

### Chores

- re-trigger CI (runner infra hang on node setup) (0c36440)
- update docs (d8b7603)

### Other Changes

- Merge pull request #361 from hairyf/feat/session-open-directory (ac77ec8)
- Merge pull request #360 from hairyf/fix/capture-boot-failure-safe-mode (8fcc110)
- Merge pull request #357 from dsh-tauri-desk/fix/worktree-remove-ctx-inject (d316cdc)
- Merge pull request #346 from dsh-tauri-desk/dsh/worktree-reliable-delete (1960542)
- Merge pull request #355 from dsh-tauri-desk/revert/pr-319-pet (ba75694)
- Revert "Merge pull request #319 from dsh-tauri-desk/dsh/issue-308-pet" (b9afdf0)
- Merge pull request #319 from dsh-tauri-desk/dsh/issue-308-pet (03881b6)
- Merge pull request #328 from coderstory/fix/shared-silence-utility (d13f1cd)
- Merge pull request #351 from r3fuse/fix/linux-toast-webview-freeze (9ba3521)
- Merge branch 'main' into dsh/issue-308-pet (2d9d15c)
- Merge branch 'main' into fix/shared-silence-utility (e3bc5fb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.10.4-beta.2** across the release packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->