### PR TITLE
fix(core): patch npm-installed core startup.js missing --skip-auth anchor

### DIFF
--- a/src-tauri/src/service/patch/alpha_auth.rs
+++ b/src-tauri/src/service/patch/alpha_auth.rs
@@ -12,6 +12,16 @@
 //!   browser-session 层（`authorizeIndex` 直接放行 index、`requestRejection` 不再
 //!   校验 cookie），Host/Origin 信任边界仍由 `isTrustedApiRequest` 保留。
 //!
+//! 锚点兼容两种核心布局（issue #358）：
+//! - pkg 打包核心（deepseek-harness-pkg）：`startup.js` 的 action 在
+//!   `const options = program.opts();` 之后有 `const allowLan =
+//!   process.env.DSH_PKG_ALLOW_LAN === "1";` 一行（pkg 构建注入的 0.0.0.0 护栏）；
+//! - npm 全局原版核心（`npm i -g @deepseek-ai/dsh`）：没有 allowLan 行，`opts()`
+//!   之后直接是 `--host`/`--port` 校验。
+//!
+//! 因此 action 锚点只匹配 `const options = program.opts();` 这一行，注入
+//! `--skip-auth` 处理并把 allowLan 等后续行原样保留；两种布局都能命中。
+//!
 //! 普通用户运行 `dsh web`（不带 `--skip-auth`）时鉴权行为与上游一致；旧核心无
 //! 上述锚点时 `patch_dsh` 安全跳过，不改变旧版行为。
 
@@ -24,9 +34,8 @@ const WEB_STARTUP_REL: &str = "node_modules/@deepseek-ai/dsh-web-app/lib/startup
 const STARTUP_OPTION_ANCHOR: &str =
     ".option(\"--no-open\", \"do not open the Web UI in the default browser\")";
 const STARTUP_OPTION_REPLACEMENT: &str = ".option(\"--no-open\", \"do not open the Web UI in the default browser\")\n\t\t.option(\"--skip-auth\", \"skip the browser-session token/cookie exchange; keeps the Host/Origin trust fence (for embedded UIs)\")";
-const STARTUP_ACTION_ANCHOR: &str =
-    "\t\tconst options = program.opts();\n\t\tconst allowLan = process.env.DSH_PKG_ALLOW_LAN === \"1\";";
-const STARTUP_ACTION_REPLACEMENT: &str = "\t\tconst options = program.opts();\n\t\t/* dsh-tauri-desktop: alpha embedded auth --skip-auth flag */\n\t\tif (options.skipAuth) process.env.DSH_SKIP_AUTH = \"1\";\n\t\tconst allowLan = process.env.DSH_PKG_ALLOW_LAN === \"1\";";
+const STARTUP_ACTION_ANCHOR: &str = "\t\tconst options = program.opts();";
+const STARTUP_ACTION_REPLACEMENT: &str = "\t\tconst options = program.opts();\n\t\t/* dsh-tauri-desktop: alpha embedded auth --skip-auth flag */\n\t\tif (options.skipAuth) process.env.DSH_SKIP_AUTH = \"1\";";
 
 // ── dsh-client-connection/lib/index.js ────────────────────────────────────────
 const CONNECTION_INDEX_JS: &str =
@@ -119,6 +128,17 @@ mod tests {
         source
     }
 
+    /// pkg 打包核心（deepseek-harness-pkg）布局：`opts()` 之后紧跟 pkg 注入的
+    /// allowLan 护栏行（issue #358 中 dev 核心正是此布局，补丁必须保留该行）。
+    fn startup_fixture_pkg_layout() -> String {
+        let mut source = startup_fixture();
+        source = source.replace(
+            STARTUP_ACTION_ANCHOR,
+            "\t\tconst options = program.opts();\n\t\tconst allowLan = process.env.DSH_PKG_ALLOW_LAN === \"1\";",
+        );
+        source
+    }
+
     #[test]
     fn connection_patch_keeps_trust_fence_and_gates_browser_session() {
         let PatchOutcome::Patched(patched) = patch_connection(&connection_fixture()) else {
@@ -149,6 +169,40 @@ mod tests {
             .contains("\t\tif (options.skipAuth) process.env.DSH_SKIP_AUTH = \"1\";"));
     }
 
+    /// 回归（issue #358）：npm 全局原版核心的 startup.js 在 `opts()` 之后**没有**
+    /// allowLan 行，旧锚点（要求两行紧邻）导致 AnchorMissing、`--skip-auth` 未注入，
+    /// boot page 返回 401。现在锚点只匹配 `opts()` 单行，npm 布局必须可打补丁。
+    #[test]
+    fn startup_patch_applies_to_npm_original_layout_without_allow_lan() {
+        let fixture = startup_fixture();
+        // npm 原版无 allowLan 行
+        assert!(!fixture.contains("DSH_PKG_ALLOW_LAN"));
+
+        let PatchOutcome::Patched(patched) = patch_startup(&fixture) else {
+            panic!("expected startup patch on npm original layout");
+        };
+        assert!(patched.contains(PATCH_MARKER));
+        assert!(patched
+            .contains("\t\tif (options.skipAuth) process.env.DSH_SKIP_AUTH = \"1\";"));
+    }
+
+    /// 回归（issue #358）：pkg 打包核心的 allowLan 行必须在打补丁后原样保留，
+    /// 不能因锚点放宽而被吞掉。
+    #[test]
+    fn startup_patch_preserves_pkg_allow_lan_line() {
+        let fixture = startup_fixture_pkg_layout();
+        assert!(fixture.contains("DSH_PKG_ALLOW_LAN"));
+
+        let PatchOutcome::Patched(patched) = patch_startup(&fixture) else {
+            panic!("expected startup patch on pkg layout");
+        };
+        assert!(patched.contains(PATCH_MARKER));
+        assert!(patched
+            .contains("\t\tconst allowLan = process.env.DSH_PKG_ALLOW_LAN === \"1\";"));
+        assert!(patched
+            .contains("\t\tif (options.skipAuth) process.env.DSH_SKIP_AUTH = \"1\";"));
+    }
+
     #[test]
     fn patches_are_idempotent() {
         let PatchOutcome::Patched(startup) = patch_startup(&startup_fixture()) else {
@@ -170,9 +224,10 @@ mod tests {
         );
         assert_eq!(patch_startup("no web command here"), PatchOutcome::AnchorMissing);
 
+        // `opts()` 行本身不存在（旧核心/上游布局彻底变化）→ 跳过
         let partial = startup_fixture().replace(
             STARTUP_ACTION_ANCHOR,
-            "\t\tconst options = program.opts();\n\t\tconst allowLan = 0;",
+            "\t\tconst options = program.parse();",
         );
         assert_eq!(patch_startup(&partial), PatchOutcome::AnchorMissing);
 


### PR DESCRIPTION
## 背景

issue #358：app 0.10.4-beta.1 + **npm 全局安装**的 `@deepseek-ai/dsh@0.1.2-rc.1`（`D:\Programs\nvm4w\nodejs\node_modules\@deepseek-ai\dsh`）启动卡在 Starting Harness…，健康检查报 `HARNESS_NOT_READY: boot page returned 401 Unauthorized`。

## 根因

桌面端按 `CoreSource::Local` 把 alpha_auth 补丁打到 npm 全局核心。`alpha_auth.rs` 的 `STARTUP_ACTION_ANCHOR` 要求 `startup.js` 的 action 里

```js
const options = program.opts();
const allowLan = process.env.DSH_PKG_ALLOW_LAN === "1";
```

两行**紧邻**。但 `allowLan` 行是 deepseek-harness-pkg 打包时注入的（0.0.0.0 护栏），npm 全局原版核心没有该行 → `patch_startup` 返回 `AnchorMissing` → `--skip-auth` 选项未注入 → `web_startup_supports_skip_auth()` 为 false → launch 不追加 `--skip-auth`（launch.rs）→ 沙箱跨源 iframe 无法完成 token/cookie 交换 → boot page 401。

报告者日志与之一致：

```
WARN main::utils: dsh patch anchor missing, skip: ...\node_modules/@deepseek-ai/dsh-web-app/lib/startup.js
INFO main::utils: dsh patch already applied: ...\dsh-client-connection/lib/index.js
```

## 改动（`src-tauri/src/service/patch/alpha_auth.rs`）

- `STARTUP_ACTION_ANCHOR` 从"两行紧邻（含 allowLan 行）"放宽为**只匹配 `const options = program.opts();` 单行**——pkg 打包版与 npm 原版都有该行。
- `STARTUP_ACTION_REPLACEMENT` 只注入 `--skip-auth` 处理逻辑，不再硬塞 allowLan 行：pkg 版原有 allowLan 行原样保留在后续，npm 原版直接续接 `--host`/`--port` 校验。
- 头部注释补充两种布局说明。
- 测试：新增 npm 原版布局可打补丁回归用例 + pkg allowLan 行保留用例；legacy 用例改为破坏 `opts()` 行本身验证 AnchorMissing 兜底。

## 验证

- `cargo test --lib -- service::patch::alpha_auth`：6/6 通过
- `cargo test --lib -- plugin_boot extract recovery profile`：40/40 通过（无回归）
- 实际安装 `npm i -g @deepseek-ai/dsh@0.1.2-rc.1` 比对确认：npm 原版缺 allowLan 行、pkg 版有；修复后两种布局均可命中锚点
- 未改动核心来源切换逻辑（`service/core/*`），release 版行为不变

## 验证补丁后 npm 原版 startup.js 效果

```js
const options = program.opts();
/* dsh-tauri-desktop: alpha embedded auth --skip-auth flag */
if (options.skipAuth) process.env.DSH_SKIP_AUTH = "1";
if (options.host === "0.0.0.0") program.error(...); // 原行保留
```

> issue #358 此前以 COMPLETED 关闭并关联到 #348（切换核心文件锁问题，症状不同且仍 OPEN）；本 PR 修复的是 npm 全局核心未打补丁导致 401 的直接根因。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup compatibility across npm and packaged application layouts.
  - Preserved existing LAN access configuration during startup updates.
  - Added safer handling for unexpected or changed startup layouts, preventing unsupported modifications.
  - Added regression coverage to verify consistent patching behavior across supported installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->