### PR TITLE
chore: release v0.10.4-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.4-beta.2",
+  "version": "0.10.4-beta.3",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.4-beta.2"
+version = "0.10.4-beta.3"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.4-beta.2"
+version = "0.10.4-beta.3"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.4-beta.2",
+  "version": "0.10.4-beta.3",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.4-beta.3` (`0.10.4-beta.2` → `0.10.4-beta.3`).

### Bug Fixes

- **core**: only fall back to junction on privilege errors, clean up on open failure (6eaf809)
- **core**: fall back to junction when symlink creation lacks privileges (00ea808)
- **core**: patch npm-installed core startup.js missing --skip-auth anchor (b54c624)

### Chores

- **core**: bump recommended dsh version to 0.1.2-rc.1 (adeb842)

### Other Changes

- Merge pull request #366 from hairyf/chore/bump-recommended-version (a8ffed1)
- Merge pull request #365 from hairyf/fix/win-junction-link-without-admin (b68ef7a)
- Merge pull request #364 from hairyf/fix/alpha-auth-npm-core-anchor (df390c0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application version to **0.10.4-beta.3** across supported package and application metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->