### PR TITLE
fix: 预装插件引导页无变更时避免出现两个「跳过」按钮 (#371)

### DIFF
--- a/src/layout/components/preinstall-setup.tsx
+++ b/src/layout/components/preinstall-setup.tsx
@@ -288,11 +288,13 @@ export function PreinstallSetup() {
                     <p className="text-center text-xs text-muted">{t('preinstall.can_uncheck_hint')}</p>
                   </If>
 
-                  {/* 操作区：跳过 / 确定（无变更时主按钮蜕变为「跳过」） */}
+                  {/* 操作区：有变更 → 弱「跳过」+ 主「确认」；无变更 → 主按钮独占「跳过」，避免重复入口 */}
                   <div className="flex items-center justify-end gap-2">
-                    <Button className="h-8 rounded-md" size="sm" variant="tertiary" onPress={handleSkip} isDisabled={installing}>
-                      {t('preinstall.skip')}
-                    </Button>
+                    <If cond={hasChanges}>
+                      <Button className="h-8 rounded-md" size="sm" variant="tertiary" onPress={handleSkip} isDisabled={installing}>
+                        {t('preinstall.skip')}
+                      </Button>
+                    </If>
                     <If cond={!hasChanges}>
                       <Then>
                         <Button


### PR DESCRIPTION
## 背景

issue #371：预装插件引导页（安装推荐插件界面）在「无任何勾选变更」时，底部操作区会**同时出现两个「跳过」按钮**（左侧弱样式一个 + 右侧主按钮降级成一个），入口重复、容易造成困惑。

## 复现

1. 进入预装插件引导页（首次安装后自动进入，或从侧边栏手动打开）；
2. 使页面处于「无变更」状态，例如：所有推荐插件均已安装（升级后再次进入引导），或未勾选任何插件的安装/卸载变更；
3. 观察底部操作区，可见两个「跳过」按钮并存。

## 改动

`src/layout/components/preinstall-setup.tsx`：

- 左侧弱样式「跳过」按钮（`variant="tertiary"`）仅在 `hasChanges=true` 时渲染，与右侧「确认」成对出现；
- `hasChanges=false` 时由右侧主按钮独占「跳过」，避免入口重复。

修复后按钮组合：

| 状态 | 按钮组合 |
| --- | --- |
| 有变更（有插件要装/卸） | `[跳过] [确认]` |
| 无变更 | 仅一个主按钮「跳过」 |

纯 UI 交互问题，不影响安装/跳过逻辑本身（两个按钮行为一致）。

## 验证

- `pnpm typecheck` 通过
- `pnpm lint` 通过（0 errors，改动文件无新增 warning）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the pre-install setup actions so the tertiary “Skip” option appears only when plugin changes are present.
  * When no plugin changes exist, the primary “Skip” action remains the only skip option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->