### PR TITLE
fix(updater): show breaking-change confirm on update click, not detection

### DIFF
--- a/src/components/config-debug.tsx
+++ b/src/components/config-debug.tsx
@@ -97,11 +97,17 @@ export function ConfigDebug() {
     }
   }
 
-  /** 「存在新版本」：先按 rc.2 破坏性更改确认（高于 rc.2 则先拦截），再展示更新提示 */
-  async function handleShowNewVersion() {
-    if (updateInfo && !(await confirmCoreBreaking(updateInfo.tag)))
+  /** 「存在新版本」：直接展示更新提示；破坏性更改确认推迟到点击「立即更新」时 */
+  function handleShowNewVersion() {
+    store.harnessUpdater.showToast(() => handleUpdate())
+  }
+
+  /** 点击「立即更新」：目标版本高于 rc.2 时先弹破坏性更改确认，取消则中止更新 */
+  async function handleUpdate() {
+    const info = store.harnessUpdater.updateInfo
+    if (!info || !(await confirmCoreBreaking(info.tag)))
       return
-    store.harnessUpdater.showToast()
+    await store.harnessUpdater.handleUpdate()
   }
 
   const { mutate: onClearLogs } = useMutation({

--- a/src/layout/components/harness-updater.tsx
+++ b/src/layout/components/harness-updater.tsx
@@ -11,14 +11,16 @@ export function HarnessUpdater() {
   useWatch([updateInfo, updating], () => {
     if (!updateInfo || updating)
       return
-    // 高于 rc.2 时先弹破坏性更改确认，取消则不提示更新（不进入下载）
-    void showAfterConfirm(updateInfo.tag)
+    // 仅提示新版本，不打断用户；破坏性更改确认推迟到点击「立即更新」时（见 handleUpdate）
+    store.harnessUpdater.showToast(() => handleUpdate())
   }, { immediate: true })
 
-  async function showAfterConfirm(tag: string) {
-    if (!(await confirmCoreBreaking(tag)))
+  /** 点击「立即更新」：目标版本高于 rc.2 时先弹破坏性更改确认，取消则中止更新 */
+  async function handleUpdate() {
+    const info = store.harnessUpdater.updateInfo
+    if (!info || !(await confirmCoreBreaking(info.tag)))
       return
-    store.harnessUpdater.showToast()
+    await store.harnessUpdater.handleUpdate()
   }
 
   return holder

--- a/src/store/modules/harness-updater/store.ts
+++ b/src/store/modules/harness-updater/store.ts
@@ -79,7 +79,12 @@ export const harnessUpdater = defineStore({
       this.updateInfo = null
     },
 
-    showToast() {
+    /**
+     * 展示「发现新版本」提示条。
+     * onUpdate 由调用方（持有破坏性更改确认弹窗的组件）注入：点击「立即更新」时
+     * 先确认（高于 rc.2 则弹框），确认后才真正安装；未注入时回退为直接更新。
+     */
+    showToast(onUpdate?: () => void) {
       if (!this.updateInfo)
         return
       toast(t('update.available', { tag: this.updateInfo.tag }), {
@@ -87,7 +92,10 @@ export const harnessUpdater = defineStore({
           children: t('update.now'),
           onPress: () => {
             toast.clear()
-            void this.handleUpdate()
+            if (onUpdate)
+              void onUpdate()
+            else
+              void this.handleUpdate()
           },
           variant: 'tertiary',
         },


### PR DESCRIPTION
## 问题

打开软件检测到新版本（如 0.1.2.rc）时，会立即弹出「0.1.1-rc.2 以上的版本引入破坏性更改…」确认框，用户尚未选择更新就被打断。

需求：**确认框应在点击「立即更新」时弹出，而不是检测到更新时。**

## 修复

将破坏性更改确认从「检测到更新」推迟到「点击立即更新/下载」时：

- `src/layout/components/harness-updater.tsx`：检测到新版本只展示右下角提示条（不再弹确认框）；点击「立即更新」时先弹确认（高于 rc.2），取消则中止更新。
- `src/store/modules/harness-updater/store.ts`：`showToast` 增加可选 `onUpdate` 回调，点击「立即更新」时优先调用调用方注入的「确认后更新」逻辑，未注入时回退为直接更新。
- `src/components/config-debug.tsx`：debug 面板「存在新版本」链接同样只展示提示条，确认推迟到「立即更新」点击时，与核心面板下载入口行为统一。

现在三个入口（核心面板下载、右下角提示条、debug 链接）行为一致：**确认弹窗只出现在用户主动点击更新/下载时**。

## 验证

- `pnpm typecheck`（tsc --noEmit）通过
- `eslint` 三个改动文件无告警


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Update notifications now appear immediately when an update is available.
  - Core-breaking confirmation is shown when you choose to start the update, rather than before the notification appears.
  - Cancelling the confirmation leaves the current version unchanged.
  - Confirmed updates proceed using the selected target version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->