### PR TITLE
fix(plugin): git-hosted preset install fails on Linux without system git (#369)

### DIFF
--- a/src-tauri/resources/preset-plugins.json
+++ b/src-tauri/resources/preset-plugins.json
@@ -20,7 +20,7 @@
   },
   {
     "id": "dsh-better-sidebar",
-    "spec": "github:omdsh-dev/DSH-better-sidebar",
+    "spec": "dsh-better-sidebar",
     "name": "DSH Better Sidebar",
     "description": "A VSCode-like right sidebar (explorer / editor / terminal / git / browser), isolated per conversation session. Exposes a service for other plugins to register sidebar tabs and file viewers.",
     "repoUrl": "https://github.com/omdsh-dev/DSH-better-sidebar",

--- a/src-tauri/src/service/plugin/install/diagnose.rs
+++ b/src-tauri/src/service/plugin/install/diagnose.rs
@@ -97,6 +97,14 @@ pub(super) fn network_error_hint(output: &str) -> Option<&'static str> {
 pub(super) fn git_transport_hint(output: &str) -> Option<&'static str> {
     const SIGNALS: &[(&str, &str)] = &[
         (
+            "spawn git enoent",
+            "Git is not installed or not on PATH (pnpm could not spawn git: ENOENT). Install git (e.g. Debian/Ubuntu: `sudo apt install git`; macOS: `brew install git`) or uncheck git-hosted plugins and retry.",
+        ),
+        (
+            "command failed with enoent: git",
+            "Git is not installed or not on PATH (pnpm could not run git: ENOENT). Install git (e.g. Debian/Ubuntu: `sudo apt install git`; macOS: `brew install git`) or uncheck git-hosted plugins and retry.",
+        ),
+        (
             "host key verification failed",
             "git fell back to SSH and could not verify GitHub's host key (no known_hosts entry; the process ran non-interactively). Make sure GitHub is reachable over HTTPS.",
         ),
@@ -148,6 +156,15 @@ mod tests {
             git_transport_hint("ssh: connect to host github.com port 22: Connection refused")
                 .is_some()
         );
+    }
+
+    #[test]
+    fn git_transport_hint_detects_enoent_missing_git() {
+        // issue #369：Linux 无系统 git 时 pnpm spawn git 直接 ENOENT
+        let out = "[ENOENT] Command failed with ENOENT: git ls-remote 'git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git' HEAD\nspawn git ENOENT\n";
+        assert!(git_transport_hint(out).is_some());
+        // 单独一行也命中
+        assert!(git_transport_hint("spawn git ENOENT").is_some());
     }
 
     #[test]

--- a/src-tauri/src/service/plugin/install/env.rs
+++ b/src-tauri/src/service/plugin/install/env.rs
@@ -142,6 +142,31 @@ fn plugin_git_binary(_app_handle: &AppHandle) -> Option<PathBuf> {
     }
 }
 
+/// 当前环境是否实际可用的 git（供 git 托管插件安装前的预检）。
+///
+/// 背景：Windows 空白环境由桌面端安装 MinGit 并在子进程 PATH 注入其目录，因此
+/// `git_runtime_ready` 在 Windows 有完整判定；而 Linux/macOS 完全依赖系统 git，
+/// 不在自动配置范围（`config::git_runtime_ready` 非 Windows 恒真）。一旦系统缺
+/// git，`pnpm spawn git` 直接 `ENOENT`，用户只看到裸错误 + 误导性的 allowBuilds
+/// 提示（issue #369）。这里实际探测 git 可执行能否运行，供安装 git 托管插件前
+/// 给用户可读的失败原因；无法解析二进制 / 启动失败都视为不可用。
+pub(crate) fn git_available(app_handle: &AppHandle) -> bool {
+    let Some(git) = plugin_git_binary(app_handle) else {
+        return false;
+    };
+    let mut cmd = std::process::Command::new(&git);
+    cmd.arg("--version");
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NO_WINDOW：GUI 进程下禁止闪现控制台窗口
+        cmd.creation_flags(0x0800_0000);
+    }
+    cmd.output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
 /// 运行 `git config <scope> --get-regexp '^url\.'`，判断该作用域的配置里是否存在
 /// 把 GitHub HTTP(S) 改写为 SSH 的 insteadOf 规则。无匹配（git 返回 1）或命令
 /// 失败都视为不存在。

--- a/src-tauri/src/service/plugin/install/mod.rs
+++ b/src-tauri/src/service/plugin/install/mod.rs
@@ -124,6 +124,7 @@ async fn install_with_cancel(
         presets.iter().map(|p| (p.id.as_str(), p)).collect();
 
     let mut specs = Vec::with_capacity(ids.len());
+    let mut needs_git = false;
     for id in ids {
         let preset = preset_map
             .get(id.as_str())
@@ -150,7 +151,26 @@ async fn install_with_cancel(
             preset,
             bundled_dir_of(app_handle, preset),
         )?);
+        // 规范化后 `git+...` 前缀即 git 托管依赖：pnpm 安装时需要实际可用的 git
+        // （见下方预检）；npm 包名（如 `dshmarket`）与 `link:` 本地依赖无需 git。
+        if raw.starts_with("git+") {
+            needs_git = true;
+        }
         specs.push(shell_quote_spec(&raw));
+    }
+
+    // git 托管插件安装前预检（issue #369）：Linux/macOS 完全依赖系统 git（不在
+    // 空白 Windows 自动配置范围，`config::git_runtime_ready` 非 Windows 恒真），
+    // 系统缺 git 时 `pnpm spawn git` 直接 ENOENT，用户只看到裸错误 + 误导性的
+    // allowBuilds 提示。启动子进程前实际探测 git 可执行能否运行，缺失时给出
+    // 可读失败原因与修复指引，而不是等 pnpm 装到一半才失败。
+    if needs_git && !env::git_available(app_handle) {
+        return Err(
+            "GIT_NOT_FOUND: selected plugins include git-hosted dependencies, but no usable git \
+             was found on this system. Install git (e.g. Debian/Ubuntu: `sudo apt install git`; \
+             macOS: `brew install git`) or uncheck those plugins and retry."
+                .to_string(),
+        );
     }
 
     // 确保 pnpm/dsh shim 存在

--- a/src-tauri/src/service/plugin/install/spec.rs
+++ b/src-tauri/src/service/plugin/install/spec.rs
@@ -43,16 +43,27 @@ pub(super) fn preset_spec_for_install(
     Ok(bundled_dep_spec(&dir))
 }
 
-/// 把 `github:owner/repo[#ref]` 一类的 GitHub 简写规范为显式 HTTPS 依赖形式
+/// 把 `github:owner/repo[#ref]` 与裸 `git+ssh://git@github.com/...` 一类的
+/// GitHub 依赖 spec 规范为显式 HTTPS 依赖形式
 /// （`git+https://github.com/owner/repo.git[#ref]`）。
 ///
 /// 动机：pnpm 解析 GitHub 简写时，「HTTPS 可达性探测一旦失败就回退 git+ssh」
 /// 是已知缺陷（issue #3948 / #7243 / #13276，官方已 accepted 仍未修）。公开仓库
 /// 一旦落进 git+ssh，在无 SSH 配置的桌面机上（非交互子进程无法应答 known_hosts
 /// 询问）必然硬失败。规范为显式 `git+https:` 后 pnpm 直接走 HTTPS 克隆，绕开该
-/// 回退；非 `github:` 形式（如纯 npm 包名）原样返回。
+/// 回退。
+///
+/// 同时覆盖上游依赖锁定的裸 `git+ssh://git@github.com/owner/repo[.git][#ref]`
+/// spec（如 pnpm-lock 里 `github:` 被解析成的形态）：这类公开仓库经 SSH 拉取在
+/// 无 SSH 密钥的桌面机上同样必败（issue #369 的次要问题），一并改写为 HTTPS。
+/// 非 GitHub 形式（纯 npm 包名 / 其他主机的 git spec）原样返回。
 pub(super) fn normalize_git_spec(spec: &str) -> String {
-    let Some(rest) = spec.strip_prefix("github:") else {
+    // 兼容带 `#ref` fragment 的两种宿主形态：`github:owner/repo` 简写与
+    // `git+ssh://git@github.com/owner/repo[.git]` 裸 SSH URL
+    let rest = spec
+        .strip_prefix("github:")
+        .or_else(|| spec.strip_prefix("git+ssh://git@github.com/"));
+    let Some(rest) = rest else {
         return spec.to_string();
     };
     let (path, fragment) = match rest.split_once('#') {
@@ -183,11 +194,31 @@ mod tests {
     }
 
     #[test]
+    fn normalize_ssh_github_url_to_git_https() {
+        // issue #369：裸 git+ssh://git@github.com/... spec（pnpm-lock 常见形态）
+        // 同样改写为 HTTPS，避免公开仓库经 SSH 拉取在无密钥桌面机上必败
+        assert_eq!(
+            normalize_git_spec("git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar.git"),
+            "git+https://github.com/omdsh-dev/DSH-better-sidebar.git"
+        );
+        // 带 #ref 与不带 .git 后缀
+        assert_eq!(
+            normalize_git_spec("git+ssh://git@github.com/omdsh-dev/DSH-better-sidebar#next"),
+            "git+https://github.com/omdsh-dev/DSH-better-sidebar.git#next"
+        );
+    }
+
+    #[test]
     fn normalize_non_github_spec_passes_through() {
         assert_eq!(normalize_git_spec("dshmarket"), "dshmarket");
         assert_eq!(
             normalize_git_spec("git+https://github.com/foo/bar.git"),
             "git+https://github.com/foo/bar.git"
+        );
+        // 非 GitHub 主机的 SSH spec 不受影响（只规范 GitHub 公开仓库）
+        assert_eq!(
+            normalize_git_spec("git+ssh://git@gitlab.com/foo/bar.git"),
+            "git+ssh://git@gitlab.com/foo/bar.git"
         );
     }
 


### PR DESCRIPTION
## 问题

[#369](https://github.com/dsh-tauri-desk/deepseek-harness-desktop/issues/369)：Linux 环境缺少系统 git 时，首次启动预设插件向导安装 git 托管插件（如 DSH Better Sidebar）失败——`pnpm spawn git ENOENT`，且伴随误导性的 allowBuilds 提示。

## 根因

- Linux/macOS 完全依赖系统 git，不在空白 Windows 自动配置范围（`config::git_runtime_ready` 非 Windows 恒真），安装路径没有任何 `git --version` 预检。
- 失败后 diagnose 无法识别 `ENOENT`/`spawn git`，用户只看到裸错误。
- 预设插件 spec 为 git 托管（`github:`/`git+ssh:`），即便装了 git，无 SSH 密钥也会 `Permission denied (publickey)`。

## 改动

1. **安装前 git 预检**（`env::git_available` + `install_with_cancel`）：选中 git 托管插件时先探测 `git --version`，缺失即返回可读 `GIT_NOT_FOUND` 错误（含各平台安装命令），不再等 pnpm 裸失败。
2. **ENOENT 可读化**（`diagnose::git_transport_hint`）：新增 `spawn git ENOENT` / `command failed with ENOENT: git` 识别，安装/更新路径都能给出可操作提示。
3. **git+ssh → git+https 规范化**（`normalize_git_spec`）：裸 `git+ssh://git@github.com/...` spec 也改写为 HTTPS，公开仓库不再回退 SSH。
4. **预设改用 npm 源**：`dsh-better-sidebar` 改用 npm 包名（`dshmarket` 本就是 npm 源）。`dsh-session-context-menu` 保留 git 源（无对应 npm 包），由预检兜底。

## 验证

`cargo test -p deepseek-harness-desktop --lib service::plugin::install` → 64 个测试全部通过（含新增 ENOENT 识别与 git+ssh 规范化测试）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin installation for GitHub-based plugins, including support for additional GitHub URL formats and preserved version references.
  - Added clearer guidance when Git is missing or unavailable, including installation and PATH troubleshooting.
  - Installation now checks Git availability before proceeding, preventing confusing downstream errors.

- **Improvements**
  - Updated the bundled sidebar plugin reference to use the plugin registry identifier.
  - Improved handling of non-GitHub Git sources without altering their existing format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->