### PR TITLE
chore: release v0.10.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.4"
+version = "0.10.5"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.5` (`0.10.4` → `0.10.5`).

### Bug Fixes

- **plugin**: git-hosted preset install fails on Linux without system git (#369) (685976b)
- **updater**: show breaking-change confirm on update click, not detection (1aac842)
- 预装插件引导页无变更时避免出现两个「跳过」按钮 (#371) (29c3170)
- dedupe compareVersions after #323 moved it to core-version.ts (4538687)
- move semver import after react-if-lite (b87e68e)
- correct import order in config-core.tsx (3ed313c)
- add semver runtime dep and handle dsh-src- prefix (923265c)

### Refactors

- replace hand-rolled compareVersions with semver package (4f0533f)

### Chores

- fix catalog config for @types/semver (7bdd0a9)

### Other Changes

- Merge pull request #324 from coderstory/fix/semver-dedup (592289c)
- Merge pull request #376 from hairyf/fix/issue-369-git-hosted-preflight (f8ba9ee)
- Merge pull request #374 from hairyf/fix/update-breaking-confirm-timing (113b506)
- Merge pull request #373 from hairyf/fix/issue-371-duplicate-skip-button (3b6743d)
- Update README.md (2d3b788)
- Merge branch 'main' into fix/semver-dedup (b8f5891)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 0.10.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->