### PR TITLE
fix(download): legacy_tags reverse-lookup must inspect every match, not just first

### DIFF
--- a/src-tauri/src/service/download/github.rs
+++ b/src-tauri/src/service/download/github.rs
@@ -629,26 +629,32 @@ pub fn resolve_update(
     match record_tag.and_then(parse_version_from_tag) {
         Some(record_version) if record_behind_latest(&record_version) => UpdateCheck::HealUpToDate,
         Some(_) => UpdateCheck::UpdateAvailable,
-        None => match legacy_tags
-            .iter()
-            .find(|(_, commit)| Some(commit.as_str()) == record_commit)
-        {
-            // 反查到的 tag 与最新 release 同名 → 同一发布（之前 record_tag 缺失
-            // 没能提前命中 record_matches_latest_release，常见于 API 限流期安装把
-            // commit 写成完整 SHA、本次检查又限流把 latest.commit 兜底成 build-id，
-            // 此时 tag/commit 两种形态互不相等，单看 commit 反查到原 tag 后必须再
-            // 对齐一次 tag）。原逻辑在此分支一律按「同版本热修」处理会误报更新。
-            Some((tag, _)) if tag.as_str() == latest.tag.as_str() => UpdateCheck::UpToDate,
-            Some((tag, _)) => match parse_version_from_tag(tag) {
+        None => {
+            // 收集所有反查命中 record_commit 的 tag（不仅首条）：同一个 git commit
+            // 可能被多个 tag 指向（stable / latest 别名、不同命名规范的同源 tag），
+            // `.find()` 只取首个会在 alias 场景错过 latest.tag 的对齐。
+            let matches: Vec<&(String, String)> = legacy_tags
+                .iter()
+                .filter(|(_, commit)| Some(commit.as_str()) == record_commit)
+                .collect();
+            match matches.as_slice() {
+            // 唯一命中且 tag 与最新 release 同名 → 同一发布（API 限流 commit 兜底
+            // 造成的 tag 差异，承接 #379 的修复场景）。
+            [(tag, _)] if tag.as_str() == latest.tag.as_str() => UpdateCheck::UpToDate,
+            // 唯一命中但 tag 与最新 release 不一致 → 同版本热修或滞后记录。
+            [(tag, _)] => match parse_version_from_tag(tag) {
                 Some(record_version) if record_behind_latest(&record_version) => {
                     UpdateCheck::HealUpToDate
                 }
                 // 反查到的版本与最新版本相同（或解析失败）→ 视为同版本热修
                 _ => UpdateCheck::UpdateAvailable,
             },
+            // 多 tag 共指同一 commit → 模糊，按更新提示以免漏报。
+            _ if matches.len() > 1 => UpdateCheck::UpdateAvailable,
             // 无法考证记录对应的版本 → 以实际安装文件为准，修正记录
-            None => UpdateCheck::HealUpToDate,
-        },
+            _ => UpdateCheck::HealUpToDate,
+            }
+        }
     }
 }
 
@@ -1225,6 +1231,49 @@ mod tests {
         )];
         let decision = resolve_update(
             Some("11122233344455556666777788899900aaaabbbb"),
+            None,
+            Some("0.1.2-rc.1"),
+            &latest,
+            &tags,
+        );
+        assert_eq!(decision, UpdateCheck::UpdateAvailable);
+    }
+    #[test]
+    fn resolve_legacy_tag_match_not_first_in_list_is_up_to_date() {
+        // 顺序无关：legacy_tags 把匹配项放在末尾，前面的非匹配项不能让 `.find()`
+        // 提前截走、必须仍然识别为同一发布。
+        let latest = latest(
+            "dsh-0.1.2-rc.1-33729514615",
+            "33729514615",
+        );
+        let tags = vec![
+            ("unrelated/v0.0.1".to_string(), "fff000fff000fff000fff000fff000fff000f0000".to_string()),
+            ("dsh-0.1.2-rc.1-33729514615".to_string(), "abc123def4567890abcdef1234567890abcdef12".to_string()),
+        ];
+        let decision = resolve_update(
+            Some("abc123def4567890abcdef1234567890abcdef12"),
+            None,
+            Some("0.1.2-rc.1"),
+            &latest,
+            &tags,
+        );
+        assert_eq!(decision, UpdateCheck::UpToDate);
+    }
+
+    #[test]
+    fn resolve_legacy_tag_multiple_matches_is_update_available() {
+        // 防御：同一 commit 被多个 tag 指向（stable / latest 别名、不同命名规范的
+        // 同源 tag），反查不唯一 → 模糊场景，按更新提示以免漏报。
+        let latest = latest(
+            "dsh-0.1.2-rc.1-33729514615",
+            "33729514615",
+        );
+        let tags = vec![
+            ("dsh-0.1.2-rc.1-stable".to_string(), "abc123def4567890abcdef1234567890abcdef12".to_string()),
+            ("dsh-0.1.2-rc.1-33729514615".to_string(), "abc123def4567890abcdef1234567890abcdef12".to_string()),
+        ];
+        let decision = resolve_update(
+            Some("abc123def4567890abcdef1234567890abcdef12"),
             None,
             Some("0.1.2-rc.1"),
             &latest,


### PR DESCRIPTION
## Follow-up to #379

PR #379 fixed the false-positive `UpdateAvailable` for the case where
`record_tag` is missing and `latest.commit` falls back to the
build-id. That fix uses `legacy_tags.iter().find(...)`, which only
inspects the **first** tag whose commit equals `record_commit`.

When the same commit is referenced by multiple aliases — stable /
latest / variant-named tags — `.find()` may pick an entry that does
**not** equal `latest.tag`, even though another sibling tag does.
The code then wrongly falls through to the version-comparison hotfix
branch instead of recognising the user is already on the latest release.

## Fix

Switch the reverse-lookup to `.filter().collect()` so all matches are
inspected. The new branch tree:

- unique match whose tag equals `latest.tag` → `UpdateCheck::UpToDate`
  (same release rendered with a different commit-format due to API state);
- unique match with a different tag → existing hotfix / heal logic
  (preserves the #379 fix and existing tests);
- multiple matches → `UpdateCheck::UpdateAvailable` (ambiguous; default
  to update rather than silently masking the alias case);
- no matches → `UpdateCheck::HealUpToDate` (existing fallback).

## Tests

- `resolve_legacy_tag_match_not_first_in_list_is_up_to_date` — matching
  entry preceded by an unrelated entry, still `UpToDate`.
- `resolve_legacy_tag_multiple_matches_is_update_available` — alias
  scenario with two tags sharing `record_commit`; returns
  `UpdateAvailable`.

All 24 tests in `service::download::github::tests` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update detection when multiple release tags reference the same commit.
  - Update status is now determined consistently regardless of tag ordering.
  - Correctly identifies when an installed version is current, requires an update, or needs its version information repaired.
  - Added safeguards for ambiguous release-tag matches to prevent incorrectly reporting an installation as up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->