### PR TITLE
fix(desktop): error screen buttons on one row; pin preinstall title color

### DIFF
--- a/src-tauri/src/service/plugin/install/artifact.rs
+++ b/src-tauri/src/service/plugin/install/artifact.rs
@@ -42,7 +42,11 @@ pub(super) fn verify_installed_products(
     if missing.is_empty() {
         return Ok(());
     }
-    let detail = silent_install_failure_detail(&missing, command_output);
+    let detail = if let Some(source_detail) = bundled_source_missing_detail(app_handle, &missing) {
+        source_detail
+    } else {
+        silent_install_failure_detail(&missing, command_output)
+    };
     log::error!("{detail}");
     for (id, _) in &missing {
         if let Err(e) = errors::record(app_handle, id, "install", &detail) {
@@ -73,6 +77,47 @@ fn silent_install_failure_detail(missing: &[(String, PathBuf)], command_output: 
     format!(
         "PREINSTALL_SILENT_FAIL: dsh plugin exited with code 0, but no install artifact was created for [{ids}]. Expected package manifests: [{manifests}]. {output_hint} Retry the installation; if it repeats, include the preinstall log and these paths in the bug report."
     )
+}
+
+/// 当缺失产物来自「内置插件源目录缺失」时，返回精确、可操作的诊断；否则 None。
+///
+/// 内置插件以 `link:<捆绑目录绝对路径>` 形式安装（见 [`super::spec::preset_spec_for_install`]），
+/// 当应用安装目录被移动 / 盘符变更 / 资源目录被清理时，pnpm 对指向不存在目录的
+/// `link:` 依赖会**静默以 exit 0 成功**（日志特征 `Installing a dependency from a
+/// non-existent directory`），留下悬空 junction 而 `package.json` 不可读——这正是
+/// `PREINSTALL_SILENT_FAIL` 最常见的根因（表现为应用启动后 loader 抛
+/// `ERR_MODULE_NOT_FOUND`，见 issue 启动失败日志链）。此时如实报告缺失的源目录与
+/// 修复指引（重装应用 / 恢复资源），而不是让用户盲目重试。
+fn bundled_source_missing_detail(
+    app_handle: &AppHandle,
+    missing: &[(String, PathBuf)],
+) -> Option<String> {
+    let resolve = |id: &str| super::bundled_plugin_dir(app_handle, id);
+    bundled_source_missing_detail_with(missing, &resolve)
+}
+
+/// [`bundled_source_missing_detail`] 的纯函数形态：`resolve` 把插件 id 解析为内置
+/// 捆绑源目录（None 表示该 id 非内置插件 / 源目录不可解析）。便于无 AppHandle 单测。
+fn bundled_source_missing_detail_with(
+    missing: &[(String, PathBuf)],
+    resolve: &dyn Fn(&str) -> Option<PathBuf>,
+) -> Option<String> {
+    let mut source_missing: Vec<String> = Vec::new();
+    for (id, _) in missing {
+        let Some(dir) = resolve(id) else {
+            continue;
+        };
+        if !dir.join("package.json").is_file() {
+            source_missing.push(format!("{id}（{}）", dir.display()));
+        }
+    }
+    if source_missing.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "BUNDLED_PLUGIN_SOURCE_MISSING: 应用资源中的内置插件源目录缺失或不可读，pnpm 静默跳过安装（exit 0 无产物），导致以下内置插件未落盘: {}. 这些源目录随应用安装包分发；若应用安装目录被移动/删除、盘符变更或资源目录被清理，会触发此问题。请重新安装应用或恢复应用资源目录后重试。",
+        source_missing.join("; ")
+    ))
 }
 
 /// 解析插件包声明的主入口（与 cordis 加载器实际读取的字段一致）：
@@ -313,6 +358,73 @@ mod tests {
 
         assert!(detail.contains("Review the preinstall log above"));
         assert!(!detail.contains("produced no output"));
+    }
+
+    /// 内置插件源目录缺失：诊断应精确报出 BUNDLED_PLUGIN_SOURCE_MISSING 与源路径、
+    /// 修复指引，而不是笼统的 silent-fail 文案。
+    #[test]
+    fn bundled_source_missing_reports_actionable_detail() {
+        let missing = vec![
+            (
+                "dsh-tauri".to_string(),
+                PathBuf::from("C:\\Users\\t\\.dsh\\profiles\\safe\\node_modules\\dsh-tauri\\package.json"),
+            ),
+            (
+                "dsh-tauri-ui".to_string(),
+                PathBuf::from("C:\\Users\\t\\.dsh\\profiles\\safe\\node_modules\\dsh-tauri-ui\\package.json"),
+            ),
+        ];
+        // 两个内置插件都解析到源目录，但源目录下 package.json 均不可读（缺失源）
+        let resolve = |id: &str| {
+            Some(PathBuf::from(format!(
+                "E:\\Deepseek Harness Desktop\\resources\\node_modules\\{id}"
+            )))
+        };
+
+        let detail = bundled_source_missing_detail_with(&missing, &resolve).expect("diagnosed");
+
+        assert!(detail.starts_with("BUNDLED_PLUGIN_SOURCE_MISSING:"));
+        assert!(detail.contains("dsh-tauri"));
+        assert!(detail.contains("dsh-tauri-ui"));
+        // 源目录按平台原生分隔符展示（Windows 反斜杠 / Unix 正斜杠）
+        assert!(detail.contains("Deepseek Harness Desktop"));
+        assert!(detail.contains("resources"));
+        assert!(detail.contains("node_modules"));
+        assert!(detail.contains("重新安装应用"));
+    }
+
+    /// 源目录可解析且 package.json 可读（真实存在）时，不属于「源缺失」，返回 None，
+    /// 回落通用 silent-fail 诊断。
+    #[test]
+    fn bundled_source_present_falls_back_to_generic_detail() {
+        let root = std::env::temp_dir().join(format!(
+            "dsh-source-present-test-{}",
+            std::process::id()
+        ));
+        let dir = root.join("dsh-tauri");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("package.json"), r#"{"name":"dsh-tauri"}"#).unwrap();
+
+        let missing = vec![(
+            "dsh-tauri".to_string(),
+            root.join("node_modules/dsh-tauri/package.json"),
+        )];
+        let resolve = |_: &str| Some(dir.clone());
+
+        assert!(bundled_source_missing_detail_with(&missing, &resolve).is_none());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// 缺失插件不是内置插件（resolve 返回 None）时，不误报源缺失，回落通用诊断。
+    #[test]
+    fn non_internal_missing_plugin_falls_back_to_generic_detail() {
+        let missing = vec![(
+            "dshmarket".to_string(),
+            PathBuf::from("/tmp/profile/node_modules/dshmarket/package.json"),
+        )];
+        let resolve = |_: &str| None;
+
+        assert!(bundled_source_missing_detail_with(&missing, &resolve).is_none());
     }
 
     /// 构造独立的临时插件包目录（含 `package.json`），供入口解析用例使用。

--- a/src-tauri/src/service/plugin/internal/mod.rs
+++ b/src-tauri/src/service/plugin/internal/mod.rs
@@ -561,6 +561,16 @@ async fn ensure_inner(
             continue;
         };
         let name = installed_name(preset).to_string();
+        // 捆绑目录被解析到但源 package.json 不可读（悬空源/资源被清理）：pnpm 对指向
+        // 不存在目录的 `link:` 依赖会静默 exit 0（日志特征 `Installing a dependency
+        // from a non-existent directory`），重装必然再次假成功，形成启动死循环。这类
+        // 是「应用资源缺失」而非「路径变更」：直接给出精确错误，阻断本轮重装。
+        if !bundled.join("package.json").is_file() {
+            return Err(format!(
+                "INTERNAL_PLUGIN_SOURCE_MISSING: 内置插件 {name} 的捆绑源目录 {} 缺失或不可读（应用资源目录可能被移动/删除或盘符变更）。pnpm 会静默跳过安装（exit 0 无产物），导致服务启动时 loader 抛 ERR_MODULE_NOT_FOUND。请重新安装应用或恢复应用资源目录后重试。",
+                bundled.display()
+            ));
+        }
         let expected = bundled_dep_spec(&bundled);
         // ① 依赖声明：未声明，或声明的值不再指向当前捆绑目录（路径变更/被改
         // 写）→ 重装；② 依赖真实性：node_modules 链接/拷贝须真实存在（用户

--- a/src/layout/components/preinstall-setup.tsx
+++ b/src/layout/components/preinstall-setup.tsx
@@ -222,7 +222,7 @@ export function PreinstallSetup() {
     <div className="flex h-full w-full items-center justify-center bg-canvas">
       <div className="flex w-[min(560px,88vw)] flex-col gap-5">
         <header className="flex flex-col items-center gap-1.5 text-center">
-          <Typography type="h4">{t('preinstall.title')}</Typography>
+          <Typography type="h4" className="!text-ink">{t('preinstall.title')}</Typography>
           <Typography color="muted" type="body-sm" className="max-w-[440px]">{t('preinstall.subtitle')}</Typography>
         </header>
 

--- a/src/layout/components/setup.tsx
+++ b/src/layout/components/setup.tsx
@@ -68,29 +68,39 @@ export function Setup() {
       percentage={installing ? installer.percentage : undefined}
       logs={logs}
       errorMsg={error ? errorMsg : undefined}
-      onRetry={error ? store.harness.boot : undefined}
     >
       {hint && (
         <p className="m-0 text-xs leading-[18px] break-all text-load-muted">{hint}</p>
       )}
       <If cond={error}>
         <Then>
-          <button
-            className={button({ tone: 'ghost', size: 'sm' })}
-            onClick={() => copyLogsHandler(t)}
-          >
-            <Copy className="size-4" />
-            {t('buttons.copy_logs')}
-          </button>
-          <button
-            className={button({ tone: 'primary', size: 'sm' })}
-            onClick={() => {
-              void store.harness.enterSafeMode()
-            }}
-          >
-            <ShieldCheck className="size-4" />
-            {t('buttons.safe_mode')}
-          </button>
+          {/* 错误态操作区：重试 / 复制日志 / 安全模式 三按钮放同一行，避免叠罗汉 */}
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <button
+              className={button({ tone: 'primary', size: 'sm' })}
+              onClick={() => {
+                void store.harness.boot()
+              }}
+            >
+              {t('app.retry')}
+            </button>
+            <button
+              className={button({ tone: 'ghost', size: 'sm' })}
+              onClick={() => copyLogsHandler(t)}
+            >
+              <Copy className="size-4" />
+              {t('buttons.copy_logs')}
+            </button>
+            <button
+              className={button({ tone: 'primary', size: 'sm' })}
+              onClick={() => {
+                void store.harness.enterSafeMode()
+              }}
+            >
+              <ShieldCheck className="size-4" />
+              {t('buttons.safe_mode')}
+            </button>
+          </div>
           <p className="m-0 text-xs leading-[18px] break-all text-load-muted">
             {t('hints.safe_mode')}
           </p>


### PR DESCRIPTION
## 修复

### 1. Setup 错误页三按钮改一行（`src/layout/components/setup.tsx`）
错误态下「重试 / 复制日志 / 安全模式」原为竖排叠罗汉（重试由 Loadable 的 onRetry 渲染，复制日志/安全模式在 children 各占一行）。改为统一放进同一个 `flex flex-wrap` 行，视觉更紧凑。

### 2. 预装插件标题固定颜色（`src/layout/components/preinstall-setup.tsx`）
预装引导页标题用 HeroUI `<Typography type="h4">`，默认色为 `text-foreground`（可能回退/随主题变化，表现为"变色"）。显式加 `!text-ink` 固定为应用正式前景色，与页面其它主要文本一致。

### 3. 内置插件源缺失时的可操作诊断（`src-tauri/src/service/plugin/install/artifact.rs` + `internal/mod.rs`）
根因修复：内置插件以 `link:<捆绑目录绝对路径>` 安装，当应用安装目录被移动/删除、盘符变更或资源目录被清理时，pnpm 对指向不存在目录的 `link:` 依赖会**静默 exit 0**（日志特征 `Installing a dependency from a non-existent directory`），留下悬空 junction，最终表现为 `INTERNAL_PLUGIN_INSTALL_FAILED: PREINSTALL_SILENT_FAIL` → 服务启动时 loader 抛 `ERR_MODULE_NOT_FOUND` → 进程 exit 1 → `HARNESS_NOT_OWNED`。

- `artifact.rs`：`verify_installed_products` 现在会识别「内置插件源目录缺失」，报出 `BUNDLED_PLUGIN_SOURCE_MISSING`（含缺失源路径 + 重装/恢复资源指引），取代笼统的 "include in bug report"。
- `internal/mod.rs`：`ensure_inner` 对解析到但 `package.json` 不可读的捆绑源**快速失败**报 `INTERNAL_PLUGIN_SOURCE_MISSING`，不再把注定失败的重装推进启动循环。

## 验证

- `cargo check` 通过
- `cargo test --lib plugin::` 全部通过（175 passed），新增 3 个单测覆盖源缺失诊断
- 前端 `pnpm typecheck` / `eslint` 通过（前两次提交）
- 基于最新 `origin/main`（4250c22）创建分支，无冲突

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit Retry, Copy Logs, and Safe Mode actions to the setup error state.
  * Actions now appear in an inline, wrapping layout for improved accessibility and usability.

* **Bug Fixes**
  * Improved diagnostics and recovery guidance when bundled plugin sources are missing or incomplete.

* **Style**
  * Updated the preinstall page title to use the ink text color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->