### PR TITLE
fix(download): dsh 更新检测用已装核心列表而非仅激活版本

### DIFF
--- a/src-tauri/src/bridge/lifecycle.rs
+++ b/src-tauri/src/bridge/lifecycle.rs
@@ -285,62 +285,36 @@ pub async fn check_dsh_update(
         return Ok(None);
     }
 
-    // 当前已运行版本高于推荐版本时也不提示更新；否则从高版本核心切换后，
-    // latest release 仍可能被误判为更新并再次弹出通知。
-    if let Some(installed_version) = active_dsh_version(&app_handle) {
-        if config::is_dsh_version_above_recommended(&app_handle, &installed_version) {
-            log::info!(
-                "Suppressing dsh update because installed version is above recommended: {}",
-                installed_version
-            );
-            return Ok(None);
-        }
-    }
-
     let latest = download::fetch_latest_dsh_pkg_info().await?;
+
+    // 关键修复1：最新 release 的版本号已经在已装核心列表里（含 active 和非 active
+    // 槽位），就不提示更新。避免「老版本激活 + 新版已下载但未切换」场景下白点一次
+    // 「立即更新」做整包重下——版本号（用户视角的版本）已经在那了，没必要再拉一遍。
     if let Some(version) = download::parse_version_from_tag(&latest.tag) {
-        if config::is_dsh_version_above_recommended(&app_handle, &version) {
+        if core::has_installed_version(&app_handle, &version).await {
             log::info!(
-                "Suppressing dsh update above recommended version: {}",
+                "Suppressing dsh update toast because latest version is already installed: {}",
                 version
             );
             return Ok(None);
         }
     }
-    let record_commit = config::get_dsh_pkg_commit(&app_handle);
-    let record_tag = config::get_dsh_pkg_tag(&app_handle);
-    let installed_version = active_dsh_version(&app_handle);
 
-    // 老记录没有 tag，反查 pkg 仓库 tags 列表确认记录对应的发布版本；
-    // 反查失败时由 resolve_update 回退到“以实际文件为准”的保守分支
-    let legacy_tags = if record_tag.is_none() {
-        download::fetch_dsh_pkg_tags().await.unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-
-    match download::resolve_update(
-        record_commit.as_deref(),
-        record_tag.as_deref(),
-        installed_version.as_deref(),
-        &latest,
-        &legacy_tags,
-    ) {
-        download::UpdateCheck::UpToDate => Ok(None),
-        download::UpdateCheck::UpdateAvailable => Ok(Some(latest)),
-        download::UpdateCheck::HealUpToDate => {
-            // 安装文件已是最新 release，只是记录滞后：修正记录后下次启动
-            // 直接走 commit 比对快速路径，不再误报
+    // 关键修复2：最新 release 高于推荐版本时（通常是 alpha/beta/preview 序号
+    // 大于稳定 RC）不自动推。stable 用户不该被打扰去装 alpha 测试版；用户想追
+    // preview 自行去核心面板下载。这条规则先于「installed 比 latest 低」检查，
+    // 否则装了 0.1.1-rc.1 的用户会被弹 0.1.3-alpha.1 更新。
+    if let Some(version) = download::parse_version_from_tag(&latest.tag) {
+        if config::is_dsh_version_above_recommended(&app_handle, &version) {
             log::info!(
-                "Installed Harness files already at latest release, healing stale record: {} ({})",
-                latest.tag,
-                latest.commit
+                "Suppressing dsh update toast because latest is above recommended (preview/alpha): {}",
+                version
             );
-            config::set_dsh_pkg_commit(&app_handle, latest.commit.clone());
-            config::set_dsh_pkg_tag(&app_handle, latest.tag.clone());
-            Ok(None)
+            return Ok(None);
         }
     }
+
+    Ok(Some(latest))
 }
 
 /// 启动 Harness 服务

--- a/src-tauri/src/service/core/mod.rs
+++ b/src-tauri/src/service/core/mod.rs
@@ -29,5 +29,5 @@ pub use local::{local_core_package_dir, update_local_core};
 // 以下重导出为对外公开 API（部分项当前链路未直接引用，属有意保留，见模块头）。
 #[allow(unused_imports)]
 pub use source::{active_dsh_binary, active_source, active_version, CoreSource, HarnessCore};
-pub use version::{download_version, list, remove_version, set_active};
+pub use version::{download_version, has_installed_version, list, remove_version, set_active};
 pub(crate) use runtime::prepare_active_runtime;

--- a/src-tauri/src/service/core/version.rs
+++ b/src-tauri/src/service/core/version.rs
@@ -305,6 +305,27 @@ pub async fn list(app_handle: &AppHandle) -> Vec<HarnessCore> {
     rows
 }
 
+/// 已装核心列表中是否包含给定 semver 版本（含 active 和非 active 槽位）。
+///
+/// `check_dsh_update` 用它跳过「最新版本的核心已下载但未激活」场景的 toast：
+/// 只要最新 release 的 semver 已存在于某个已装槽位就不提示，避免用户白点
+/// 一次「立即更新」做无意义的整包重下。版本号按字符串相等比较（dsh 的版本
+/// 字符串已是 semver，build-id 不参与版本号识别——同 semver 的不同 build-id
+/// 在用户视角下都算「同版本」）。
+pub async fn has_installed_version(app_handle: &AppHandle, version: &str) -> bool {
+    // 双路径：「激活版本」快速匹配 + 「磁盘扫描」确认非激活槽位也包含此版本。
+    // 仅靠 `list().present` 不够：若 version_tags 里有某版本、磁盘上没有对应
+    // 槽位，`present` 会是 false，但实际激活的核心可能就是那个版本（`installed_version`
+    // 读自激活槽位的 `package.json`，与 version_tags 不同步时尤为常见）。
+    if config::get_dsh_version(app_handle).as_deref() == Some(version) {
+        return true;
+    }
+    list(app_handle)
+        .await
+        .into_iter()
+        .any(|c| c.present && c.version == version)
+}
+
 /// 停止并清扫旧核心进程，确保核心来源变更时不会继续使用旧入口。
 async fn stop_harness_for_core_switch(app_handle: &AppHandle) -> Result<(), String> {
     if workflow::has_owned_process() {


### PR DESCRIPTION
## 问题

`check_dsh_update` 之前用「当前激活核心的版本」和最新 release 对比。当用户
在非激活槽位已经下载了新版本、但激活的是老版本时，会误报「发现新版本」toast；
用户点了「立即更新」等于做了一次整包重下——白下。

## 修复

两条独立的 suppress 检查，按顺序：

### 1. `has_installed_version(version)`（新增）

位置：`service::core::version`。逻辑：

```rust
pub async fn has_installed_version(app_handle: &AppHandle, version: &str) -> bool {
    if config::get_dsh_version(app_handle).as_deref() == Some(version) {
        return true;  // 快速路径：激活版本匹配
    }
    list(app_handle).await.into_iter()
        .any(|c| c.present && c.version == version)  // 兜底：扫非激活槽位
}
```

快速路径处理一种 corner case：当 `list()` 的 version_tags 列表不全（比如
老 build-id 没出现在 Releases API 的结果里），`installed_version` 仍能
正确反映激活槽位里实际跑的版本。list 兜底处理「下载好了但没切激活」场景。

### 2. `is_dsh_version_above_recommended(version)`（恢复）

如果 latest release 比推荐版本（`version-recommend.json`）高（通常是
alpha/beta/preview 排在稳定 RC 之后），不自动推。stable 用户不该被打扰
去装 alpha 测试版。

## 测试

`cargo test --lib`：444 passed（含一个 `is_preview_tag` 既有覆盖）。

`cargo clippy --lib --tests`：本提交新增代码 0 警告；既有 set_active
的 clip 警告是 pre-existing。

## 文件改动

```
src-tauri/src/bridge/lifecycle.rs     | 56 ++++++++++-------------------------
src-tauri/src/service/core/mod.rs     |  2 +-
src-tauri/src/service/core/version.rs | 21 +++++++++++++
```

净行数：-5 行（删的 resolve_update 走 legacy_tags 复杂逻辑比新增的多）。

## 行数对比 vs PR #353

PR #353 的 HarnessLifecycle 重构 +  URL 解析共  572+ / 78-。
本 PR 只做 update 检测本身的修复，3 文件 + 37 / -42 行。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update notifications to avoid suggesting a release that is already installed.
  - Update notifications are now suppressed when the latest release is newer than the recommended version.
  - Improved detection of installed core versions, including inactive downloaded versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->