### PR TITLE
chore: release v0.10.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.6-beta.1",
+  "version": "0.10.6",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.6-beta.1"
+version = "0.10.6"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.6-beta.1"
+version = "0.10.6"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.6-beta.1",
+  "version": "0.10.6",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.6` (`0.10.6-beta.1` → `0.10.6`).

### Bug Fixes

- **download**: dsh update check uses installed list, not just active version (c33d2b0)

### Documentation

- refresh desktop README (7409eac)

### Other Changes

- Merge pull request #384 from dsh-tauri-desk/docs/pet-readme-sync (dd25736)
- Merge pull request #383 from coderstory/fix/dsh-update-max-installed-version (c94f182)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application version to **0.10.6**, replacing the previous beta designation.
  - Release metadata is now aligned across the application package and distribution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->