### PR TITLE
[codex] feat(navbar): 设置/帮助改图标并移除前进后退（#331 部分实现）

### DIFF
--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -1,7 +1,5 @@
 import type { RefObject } from 'react'
 import {
-  CircleQuestion,
-  Gear,
   LayoutSideContent,
   LayoutSideContentLeft,
   Minus,
@@ -241,26 +239,23 @@ export function Navbar({ iframeRef }: NavbarProps) {
         </Button>
       </If>
       <If cond={!IS_MACOS}>
-        <div className="ml-1 flex items-center gap-0.5">
+        <div className="ml-1">
           <Button
-            className="rounded-lg size-7"
-            isIconOnly
+            className="rounded-lg h-6 text-xs px-1.5"
             size="sm"
             variant="ghost"
-            aria-label={t('app.config')}
             onPress={handleOpenConfig}
           >
-            <Gear />
+            {t('app.config')}
           </Button>
           <Dropdown>
             <Button
-              className="rounded-lg size-7"
-              isIconOnly
+              className="rounded-lg h-6 text-xs px-1.5"
               size="sm"
               variant="ghost"
               aria-label={t('app.help')}
             >
-              <CircleQuestion />
+              {t('app.help')}
             </Button>
             <Dropdown.Popover className="rounded-md w-5!">
               <Dropdown.Menu>

--- a/src/layout/components/navbar.tsx
+++ b/src/layout/components/navbar.tsx
@@ -1,7 +1,7 @@
 import type { RefObject } from 'react'
 import {
-  ArrowLeft,
-  ArrowRight,
+  CircleQuestion,
+  Gear,
   LayoutSideContent,
   LayoutSideContentLeft,
   Minus,
@@ -30,13 +30,11 @@ import { useMacOSAppMenu } from './use-macos-app-menu'
 /**
  * 壳层窗口顶部导航栏（44px，常驻）：
  *
- *   [侧边栏(展开/收起)] [后退] [前进] [  空白拖拽区  ] [最小化][最大化][后台化(X)]
+ *   [侧边栏(展开/收起)] [  空白拖拽区  ] [最小化][最大化][后台化(X)]
  *
- * - 侧边栏/后退/前进：经 postMessage 操控 iframe 内的 dsh 应用
- *   （`dsh://sidebar:toggle` / `dsh://page:prev` / `dsh://page:next`，
- *   由 dsh-tauri 插件或桌面端注入的导航桥脚本 NAV_SHIM_JS 执行）；
- *   折叠图标与按钮禁用态由 iframe 回报的
- *   `dsh://sidebar:collapsed` / `dsh://page:firsted` / `dsh://page:lasted` 同步。
+ * - 侧边栏：经 postMessage 操控 iframe 内的 dsh 应用
+ *   （`dsh://sidebar:toggle`，由 dsh-tauri 插件或桌面端注入的导航桥脚本
+ *   NAV_SHIM_JS 执行）；折叠图标由 iframe 回报的 `dsh://sidebar:collapsed` 同步。
  *   左侧控件只在「dsh-tauri 插件已启用（已安装）」且存在 iframe 时渲染：
  *   原生桥缺席时控件没有可靠接收方，避免出现点了没反应的死按钮。
  * - 空白拖拽区：Tauri 原生 `data-tauri-drag-region`（顶层文档直接生效），
@@ -121,7 +119,7 @@ export function Navbar({ iframeRef }: NavbarProps) {
   const { t } = useTranslation()
   const isFullscreen = useMacOSFullscreen()
   const { plugins } = useDshPlugins()
-  const { sidebarCollapsed, canGoBack, canGoForward, sendNav } = useIframeTauri(iframeRef)
+  const { sidebarCollapsed, sendNav } = useIframeTauri(iframeRef)
   const { updateInfo } = useStore(store.desktopUpdater)
 
   const openConfigDialog = useOverlay(ConfigDialog)
@@ -241,48 +239,28 @@ export function Navbar({ iframeRef }: NavbarProps) {
             else={<LayoutSideContent />}
           />
         </Button>
-
-        <Button
-          className="rounded-lg size-7"
-          isIconOnly
-          size="sm"
-          variant="ghost"
-          aria-label={t('nav.back')}
-          isDisabled={!canGoBack}
-          onPress={() => { sendNav('page:prev') }}
-        >
-          <ArrowLeft />
-        </Button>
-        <Button
-          className="rounded-lg size-7"
-          isIconOnly
-          size="sm"
-          variant="ghost"
-          aria-label={t('nav.forward')}
-          isDisabled={!canGoForward}
-          onPress={() => { sendNav('page:next') }}
-        >
-          <ArrowRight />
-        </Button>
       </If>
       <If cond={!IS_MACOS}>
-        <div className="ml-1">
+        <div className="ml-1 flex items-center gap-0.5">
           <Button
-            className="rounded-lg h-6 text-xs px-1.5"
+            className="rounded-lg size-7"
+            isIconOnly
             size="sm"
             variant="ghost"
+            aria-label={t('app.config')}
             onPress={handleOpenConfig}
           >
-            {t('app.config')}
+            <Gear />
           </Button>
           <Dropdown>
             <Button
-              className="rounded-lg h-6 text-xs px-1.5"
+              className="rounded-lg size-7"
+              isIconOnly
               size="sm"
               variant="ghost"
-              aria-label={t('app.expand_sidebar')}
+              aria-label={t('app.help')}
             >
-              {t('app.help')}
+              <CircleQuestion />
             </Button>
             <Dropdown.Popover className="rounded-md w-5!">
               <Dropdown.Menu>


### PR DESCRIPTION
## 内容

按 **#331** 的建议实现其中两条（**部分实现**）：

1. **「配置/帮助」文字按钮改为图标**：`配置` → `Gear` 齿轮图标，`帮助` → `CircleQuestion` 问号图标（改为 `isIconOnly`，与导航栏其它图标按钮同尺寸），并修正帮助按钮原先错误的 `aria-label`（`app.expand_sidebar` → `app.help`）。
2. **移除「前进/后退」按钮**：删除导航栏中的后退/前进按钮及对应的 `dsh://page:prev` / `dsh://page:next` 发送逻辑，组件中不再使用的 `canGoBack` / `canGoForward` 一并清理；`useIframeTauri` 桥与 `dsh://page:*` 协议本身保持不变。

未包含 #331 其余两项（顶部栏高度变窄、托盘增加“重启 DSH”）。

## 改动文件

- `src/layout/components/navbar.tsx`（+16 / -38）

## 验证情况

⚠️ **未做运行时 / UI 测试**（本环境无法启动桌面应用）。已通过：

- `pnpm typecheck`（tsc --noEmit）无错误
- `pnpm eslint src/layout/components/navbar.tsx` 通过

建议合入前在 Windows/Linux 上启动应用目验：导航栏图标渲染、下拉菜单、设置对话框可达性。

Closes 不适用（部分实现），关联 #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed back and forward navigation controls from the navigation bar.
  * Updated the help button’s accessible label to accurately describe its function.
* **Documentation**
  * Updated navigation bar documentation to reflect the available sidebar controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->