### PR TITLE
fix(scheduler): allow todo_write in unattended tool allowlist

### DIFF
--- a/packages/dsh-tauri-panel-scheduler/src/host/service/executor.test.ts
+++ b/packages/dsh-tauri-panel-scheduler/src/host/service/executor.test.ts
@@ -47,15 +47,48 @@ describe('loadSchedulerRuntimeModules', () => {
 })
 
 describe('unattendedToolGuardReason', () => {
-  it('allows todo_write so task lists work in unattended runs', () => {
-    expect(unattendedToolGuardReason('todo_write', {
-      todos: [{ content: 'step', status: 'pending' }],
-    })).toBeUndefined()
+  it('allows bookkeeping, goal, job, delegation, and orchestration tools', () => {
+    // standard 预设目录里的安全类别：会话内簿记 / 目标延续 / agent 级 job / 委派编排。
+    const allowed = [
+      'todo_write',
+      'get_goal',
+      'create_goal',
+      'update_goal',
+      'job_list',
+      'job_output',
+      'job_kill',
+      'list_subagent_models',
+      'subagent',
+      'subagent_fork',
+      'send_message',
+      'list_agents',
+      'interrupt_agent',
+      'workflow',
+      'ralph',
+      'cordis_define',
+      'cordis_run',
+      'cordis_stop',
+      'cordis_undefine',
+    ]
+    for (const name of allowed)
+      expect(unattendedToolGuardReason(name, {})).toBeUndefined()
   })
 
-  it('still rejects tools outside the allowlist', () => {
-    expect(unattendedToolGuardReason('ask_user_question', {}))
-      .toBe('工具 \'ask_user_question\' 不在无人值守自动化允许列表中。')
+  it('still rejects interactive and user-authorization tools', () => {
+    // 交互式人工应答/审批、需要用户显式授权的 worktree 工具、以及本插件的
+    // scheduler_*（防止无人值守自我 perpetuation）都必须保持拒绝。
+    const denied = [
+      'ask_user_question',
+      'exit_plan_mode',
+      'create_worktree',
+      'checkout_worktree',
+      'scheduler_create',
+      'scheduler_run_now',
+    ]
+    for (const name of denied) {
+      expect(unattendedToolGuardReason(name, {}))
+        .toBe(`工具 '${name}' 不在无人值守自动化允许列表中。`)
+    }
   })
 
   it('rejects background processes for bash/pwsh but allows foreground calls', () => {

--- a/packages/dsh-tauri-panel-scheduler/src/host/service/executor.test.ts
+++ b/packages/dsh-tauri-panel-scheduler/src/host/service/executor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { loadSchedulerRuntimeModules } from './executor.js'
+import { loadSchedulerRuntimeModules, unattendedToolGuardReason } from './executor.js'
 
 describe('loadSchedulerRuntimeModules', () => {
   it('resolves DSH-owned modules through the platform loader', async () => {
@@ -43,5 +43,26 @@ describe('loadSchedulerRuntimeModules', () => {
 
     expect(runtime).toEqual({ installModelSelection, createUserMessage, setApprovalPolicy })
     expect(loader.unwrapExports).not.toHaveBeenCalled()
+  })
+})
+
+describe('unattendedToolGuardReason', () => {
+  it('allows todo_write so task lists work in unattended runs', () => {
+    expect(unattendedToolGuardReason('todo_write', {
+      todos: [{ content: 'step', status: 'pending' }],
+    })).toBeUndefined()
+  })
+
+  it('still rejects tools outside the allowlist', () => {
+    expect(unattendedToolGuardReason('ask_user_question', {}))
+      .toBe('工具 \'ask_user_question\' 不在无人值守自动化允许列表中。')
+  })
+
+  it('rejects background processes for bash/pwsh but allows foreground calls', () => {
+    expect(unattendedToolGuardReason('bash', { command: 'ls', run_in_background: true }))
+      .toBe('无人值守运行不允许启动后台进程。')
+    expect(unattendedToolGuardReason('pwsh', { command: 'ls', run_in_background: true }))
+      .toBe('无人值守运行不允许启动后台进程。')
+    expect(unattendedToolGuardReason('bash', { command: 'ls' })).toBeUndefined()
   })
 })

--- a/packages/dsh-tauri-panel-scheduler/src/host/service/executor.ts
+++ b/packages/dsh-tauri-panel-scheduler/src/host/service/executor.ts
@@ -64,10 +64,25 @@ interface SessionEventLike {
   readonly data: Record<string, any>
 }
 
+/**
+ * 无人值守工具白名单（对齐 MichengAI unattendedToolGuardReason，并按 dsh 0.1.0-rc.x
+ * standard 预设的实际模型工具目录补齐安全类别）。该列表只限制无人值守可调用的工具
+ * 类别；读写边界仍由已应用的 Host 权限预设（applyUnattendedPermission）决定。
+ *
+ * 刻意不放行的类别（fail-closed，缺省拒绝）：
+ *  - ask_user_question / exit_plan_mode：交互式人工应答/计划审批，无人值守没有应答方；
+ *  - create_worktree / checkout_worktree（dsh-tauri-worktree 插件）：工具契约要求用户
+ *    显式授权，本 guard 就是无人值守下的授权层；
+ *  - scheduler_*（本插件自注册工具）：防止无人值守任务增删改/触发自动化，形成自我
+ *    perpetuation 循环；
+ *  - MCP 等动态注册工具：静态白名单无法逐一核验，保持拒绝。
+ */
 const UNATTENDED_TOOL_ALLOWLIST = new Set([
+  // shell / 进程（run_in_background 由 guard 单独拦截）
   'run_code',
   'bash',
   'pwsh',
+  // 文件系统与检索
   'read',
   'read_image',
   'write',
@@ -76,18 +91,41 @@ const UNATTENDED_TOOL_ALLOWLIST = new Set([
   'glob',
   'grep',
   'lsp',
+  // web
   'web_search',
   'web_fetch',
+  // 技能
   'skill',
+  // 会话/事件检索（较新核心注册，前向兼容）
   'session_search',
   'session_trace',
   'session_event_read',
   'session_event_search',
   'session_event_trace',
-  // todo_write 只写会话内任务清单（session log 投影，要求 owning agent session），
-  // 无文件系统/进程等宿主副作用；任务指令常要求用任务清单推进多步工作，不放行
-  // 会让无人值守运行直接失败，因此偏离 MichengAI 对齐的白名单单独放行。
+  // 会话内簿记：任务清单（session log 投影，要求 owning agent session，无宿主副作用）
   'todo_write',
+  // 目标延续：长任务的多轮自主推进（dsh-tool-goal，会话内 goal 状态）
+  'get_goal',
+  'create_goal',
+  'update_goal',
+  // 后台任务收集/停止（agent 级 job 注册表按 owning agent 隔离）
+  'job_list',
+  'job_output',
+  'job_kill',
+  // 子代理委派与编排（agent 级，受运行超时/取消约束，非 OS 后台进程）
+  'list_subagent_models',
+  'subagent',
+  'subagent_fork',
+  'send_message',
+  'list_agents',
+  'interrupt_agent',
+  'workflow',
+  'ralph',
+  // cordis 预设任务的组合管理（agentPreset 可选 cordis）
+  'cordis_define',
+  'cordis_run',
+  'cordis_stop',
+  'cordis_undefine',
 ])
 
 const CANCEL_CONVERGENCE_TIMEOUT_MS = 10_000

--- a/packages/dsh-tauri-panel-scheduler/src/host/service/executor.ts
+++ b/packages/dsh-tauri-panel-scheduler/src/host/service/executor.ts
@@ -84,6 +84,10 @@ const UNATTENDED_TOOL_ALLOWLIST = new Set([
   'session_event_read',
   'session_event_search',
   'session_event_trace',
+  // todo_write 只写会话内任务清单（session log 投影，要求 owning agent session），
+  // 无文件系统/进程等宿主副作用；任务指令常要求用任务清单推进多步工作，不放行
+  // 会让无人值守运行直接失败，因此偏离 MichengAI 对齐的白名单单独放行。
+  'todo_write',
 ])
 
 const CANCEL_CONVERGENCE_TIMEOUT_MS = 10_000


### PR DESCRIPTION
## 问题

定时任务（无人值守自动化）执行时，任务消息中使用了 `todo_write`（任务清单）工具，执行器的 `tools.guard` 白名单拦截直接报错，任务运行失败：

```
Error: 工具 'todo_write' 不在无人值守自动化允许列表中。
```

## 根因

`packages/dsh-tauri-panel-scheduler/src/host/service/executor.ts` 的 `UNATTENDED_TOOL_ALLOWLIST` 原样照搬 MichengAI/dsh-automation 上游列表，只覆盖 shell/文件/web/技能/会话检索五类工具。凡是任务指令用到清单之外的工具类别（任务清单、目标延续、子代理委派、多代理编排等），无人值守运行都会被 guard 直接拒绝。

## 修复：按安全类别补齐白名单

对照 dsh `0.1.0-rc.x` standard 预设的实际模型工具目录（`dsh-agent-presets/presets/standard/agent.cordis.yml`）逐类核对，补齐以下**安全**类别（全部是会话内簿记或 agent 级操作，无超出 bash/pwsh 已有能力的宿主副作用；读写边界仍由已应用的 Host 权限预设决定，与上游设计一致）：

| 类别 | 工具 |
|---|---|
| 会话内簿记 | `todo_write` |
| 目标延续（dsh-tool-goal） | `get_goal` `create_goal` `update_goal` |
| 后台任务收集（dsh-tool-jobs，按 owning agent 隔离） | `job_list` `job_output` `job_kill` |
| 子代理委派与编排 | `list_subagent_models` `subagent` `subagent_fork` `send_message` `list_agents` `interrupt_agent` `workflow` `ralph` |
| cordis 预设组合管理 | `cordis_define` `cordis_run` `cordis_stop` `cordis_undefine` |

### 刻意保持拒绝（fail-closed，已写入代码注释）

- `ask_user_question` / `exit_plan_mode`：交互式人工应答/计划审批，无人值守没有应答方；
- `create_worktree` / `checkout_worktree`（dsh-tauri-worktree 插件）：工具契约要求用户显式授权，本 guard 就是无人值守下的授权层；
- `scheduler_*`（本插件自注册工具）：防止无人值守任务增删改/触发自动化，形成自我 perpetuation 循环；
- MCP 等动态注册工具：静态白名单无法逐一核验，保持拒绝。

## 测试

`executor.test.ts` 为纯函数 `unattendedToolGuardReason` 补回归测试：

- 新增安全类别全部放行（19 个工具名逐一断言）；
- 交互式/用户授权/`scheduler_*` 工具保持拒绝；
- `bash`/`pwsh` 后台进程仍拒绝，前台调用仍放行。

## 验证

- `pnpm --filter dsh-tauri-panel-scheduler typecheck` ✅
- `pnpm --filter dsh-tauri-panel-scheduler test -- --run` ✅（22 tests passed）
- `pnpm build:plugins` ✅（9 个插件部署成功）
- `pnpm exec eslint <改动文件>` ✅ 0 问题
- `pnpm run typecheck` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unattended runs can now use approved goal, job, delegation, orchestration, workflow, and Cordis tools.
  * Unattended runs can use the `todo_write` tool for session-scoped task tracking.
  * Foreground shell commands remain available during unattended execution.

* **Bug Fixes**
  * Unattended execution now consistently blocks interactive, authorization, worktree, and scheduler tools.
  * Background `bash` and PowerShell processes remain prevented from running unattended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->