### PR TITLE
feat(pet): live activity bubbles, latest-3 toast cap, desc clamp

### DIFF
--- a/packages/dsh-tauri-pet/src/client/constants/index.ts
+++ b/packages/dsh-tauri-pet/src/client/constants/index.ts
@@ -45,10 +45,24 @@ export const PET_SIZE_STEP = 5
 export const PET_ACTIVITY_THROTTLE_MS = 300
 /** 思考文本只保留尾部窗口：展示「最新思考内容」，同时限制跨窗口传输体积。 */
 export const PET_REASONING_TAIL_LENGTH = 160
+/** 流式累积的工具参数最大长度：tool/call 离散事件随后会携带完整 arguments 替换，截断只影响 streaming 期间的一瞬展示。 */
+export const PET_TOOL_ARGS_MAX_LENGTH = 2000
 
-/** dsh 会话事件词汇表（@deepseek-ai/dsh-session KNOWN_SESSION_EVENT_TYPES）中实时活动折叠用到的类型。 */
+/**
+ * dsh 会话事件词汇表（@deepseek-ai/dsh-session KNOWN_SESSION_EVENT_TYPES）中实时活动
+ * 折叠用到的类型。窗口条目有两种信封：{ type:'event', event: SessionEvent }（离散事件，
+ * 事件类型即 SESSION_EVENT_*）与 { type:'chunks', event: ChunkRowEvent }（打包的流式
+ * delta 行，类型即 SESSION_EVENT_CHUNKROW_*，data.texts/args 为逐 token 增量数组）。
+ */
 export const SESSION_EVENT_ASSISTANT_CHUNK = 'assistant/chunk'
+export const SESSION_EVENT_ASSISTANT_MESSAGE = 'assistant/message'
 export const SESSION_EVENT_TOOL_CALL = 'tool/call'
 export const SESSION_EVENT_TOOL_RESULT = 'tool/result'
 export const SESSION_EVENT_STEP_START = 'step/start'
+export const SESSION_EVENT_STEP_END = 'step/end'
+export const SESSION_EVENT_TURN_START = 'turn/start'
 export const SESSION_EVENT_TURN_END = 'turn/end'
+export const SESSION_EVENT_USER_MESSAGE = 'user/message'
+export const SESSION_EVENT_CHUNKROW_TEXT = 'chunkrow/text-chunks'
+export const SESSION_EVENT_CHUNKROW_REASONING = 'chunkrow/reasoning-chunks'
+export const SESSION_EVENT_CHUNKROW_TOOL_CALL = 'chunkrow/tool-call-chunks'

--- a/packages/dsh-tauri-pet/src/client/constants/index.ts
+++ b/packages/dsh-tauri-pet/src/client/constants/index.ts
@@ -40,3 +40,15 @@ export const PET_DEFAULT_SIZE = 100
 export const PET_SIZE_MIN = 50
 export const PET_SIZE_MAX = 200
 export const PET_SIZE_STEP = 5
+
+/** 实时活动折叠：流式 delta 事件逐 token 触发，按会话做 trailing 节流合并推送。 */
+export const PET_ACTIVITY_THROTTLE_MS = 300
+/** 思考文本只保留尾部窗口：展示「最新思考内容」，同时限制跨窗口传输体积。 */
+export const PET_REASONING_TAIL_LENGTH = 160
+
+/** dsh 会话事件词汇表（@deepseek-ai/dsh-session KNOWN_SESSION_EVENT_TYPES）中实时活动折叠用到的类型。 */
+export const SESSION_EVENT_ASSISTANT_CHUNK = 'assistant/chunk'
+export const SESSION_EVENT_TOOL_CALL = 'tool/call'
+export const SESSION_EVENT_TOOL_RESULT = 'tool/result'
+export const SESSION_EVENT_STEP_START = 'step/start'
+export const SESSION_EVENT_TURN_END = 'turn/end'

--- a/packages/dsh-tauri-pet/src/client/service/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/service/activity.ts
@@ -1,12 +1,25 @@
 import type { ClientContext } from 'dsh-tauri/client'
+import type { SessionLiveActivity } from '../types'
 import { createLifecycleController } from 'dsh-tauri/client'
+import { PET_ACTIVITY_THROTTLE_MS } from '../constants'
+import { foldSessionActivity } from '../utils/activity'
 import { toTransferable } from '../utils/transferable'
 import { pushPetSession } from './pet'
 
 type SessionAction = 'create' | 'update' | 'remove'
 
+/**
+ * rc.2+ 会话 binding 附带的事件窗口（MutableSessionEventSource，service.js 组装
+ * binding 时挂在 eventSource 字段）；alpha 运行时缺失，必须探测使用。
+ */
+interface RawSessionEventSource {
+  getSnapshot: () => { entries: readonly unknown[] }
+  subscribe: (listener: () => void) => () => void
+}
+
 interface RawSessionBinding {
   sessionId: string
+  eventSource?: RawSessionEventSource
   session: {
     getSnapshot: () => unknown
     subscribe: (listener: () => void) => () => void
@@ -24,13 +37,24 @@ interface RawSessions {
   binding: (id: string) => RawSessionBinding | undefined
 }
 
+/** 每个已绑定会话的观察状态：订阅清理 + 折叠出的实时活动 + 节流定时器。 */
+interface SessionWatch {
+  disposers: Array<() => void>
+  /** 事件窗口折叠结果；undefined 表示该会话无事件窗口（alpha），null 表示当前无活动 */
+  activity?: SessionLiveActivity | null
+  activityTimer?: ReturnType<typeof setTimeout>
+}
+
 /**
  * 将 DSH 会话原始快照按生命周期推送给桌宠窗口，不生成宠物专用 projection。
+ * rc.2+ 会话额外订阅事件窗口（binding.eventSource）：流式 delta 逐 token 触发，
+ * 按会话做 trailing 节流，到期时按当前窗口重算实时活动（进行中的工具调用 /
+ * 思考流）并以 liveActivity 字段并入快照；alpha 缺失事件窗口时退级为纯快照转发。
  */
 export function installPetSessionForwarder(ctx: ClientContext): void {
   ctx.effect(() => {
     const controller = createLifecycleController()
-    const disposers = new Map<string, () => void>()
+    const watches = new Map<string, SessionWatch>()
     const known = new Set<string>()
     let disposed = false
 
@@ -53,7 +77,36 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
       const value = snapshot && typeof snapshot === 'object'
         ? snapshot as Record<string, unknown>
         : { value: snapshot }
-      return { id: binding.sessionId, ...(summary ?? {}), ...value }
+      const merged: Record<string, unknown> = { id: binding.sessionId, ...(summary ?? {}), ...value }
+      // 仅在探测到事件窗口的会话上附带 liveActivity；null 也是有效值（清除过期活动展示）
+      const watch = watches.get(id)
+      if (watch?.activity !== undefined)
+        merged.liveActivity = watch.activity
+      return merged
+    }
+
+    /** 订阅事件窗口：这里只做 trailing 节流，到期时按当前窗口整体重算一次，一次突发只推送一帧。 */
+    function attachEventSource(id: string, binding: RawSessionBinding, watch: SessionWatch): void {
+      const source = binding.eventSource
+      if (source === undefined || typeof source.getSnapshot !== 'function' || typeof source.subscribe !== 'function')
+        return
+      // 绑定即折叠一次，create 帧就携带已运行会话的实时活动
+      watch.activity = foldSessionActivity(source.getSnapshot().entries)
+      watch.disposers.push(source.subscribe(() => {
+        if (disposed || watches.get(id) !== watch || watch.activityTimer !== undefined)
+          return
+        watch.activityTimer = globalThis.setTimeout(() => {
+          watch.activityTimer = undefined
+          watch.activity = foldSessionActivity(source.getSnapshot().entries)
+          emit('update', snapshotOf(id, binding))
+        }, PET_ACTIVITY_THROTTLE_MS)
+      }))
+      watch.disposers.push(() => {
+        if (watch.activityTimer !== undefined) {
+          globalThis.clearTimeout(watch.activityTimer)
+          watch.activityTimer = undefined
+        }
+      })
     }
 
     function bind(id: string, action: SessionAction): void {
@@ -62,8 +115,20 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
         emit(action, { id })
         return
       }
+      const watch: SessionWatch = { disposers: [] }
+      watches.set(id, watch)
+      attachEventSource(id, binding, watch)
       emit(action, snapshotOf(id, binding))
-      disposers.set(id, binding.session.subscribe(() => emit('update', snapshotOf(id, binding))))
+      watch.disposers.push(binding.session.subscribe(() => emit('update', snapshotOf(id, binding))))
+    }
+
+    function unbind(id: string): void {
+      const watch = watches.get(id)
+      if (watch === undefined)
+        return
+      for (const dispose of watch.disposers)
+        dispose()
+      watches.delete(id)
     }
 
     function sync(): void {
@@ -71,8 +136,7 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
       const ids = new Set(list.ids)
       for (const id of known) {
         if (!ids.has(id)) {
-          disposers.get(id)?.()
-          disposers.delete(id)
+          unbind(id)
           emit('remove', { id })
         }
       }
@@ -83,7 +147,7 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
             bind(id, 'create')
           continue
         }
-        if (disposers.has(id))
+        if (watches.has(id))
           emit('update', snapshotOf(id, binding))
         else
           bind(id, known.has(id) ? 'update' : 'create')
@@ -98,9 +162,8 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
     controller.add(() => globalThis.clearInterval(retryTimer))
     controller.add(() => {
       disposed = true
-      for (const dispose of disposers.values())
-        dispose()
-      disposers.clear()
+      for (const id of [...watches.keys()])
+        unbind(id)
       known.clear()
     })
     sync()

--- a/packages/dsh-tauri-pet/src/client/service/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/service/activity.ts
@@ -213,12 +213,17 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
   }, 'dsh-tauri-pet: raw session events')
 }
 
-/** [pet-activity] 临时诊断：统计事件窗口内出现过的全部事件类型（去重排序），验证 fold 关注的事件是否真的在窗口里（定位后随打点移除）。 */
+/** [pet-activity] 临时诊断：统计事件窗口内出现过的全部事件类型（去重排序），验证 fold 关注的事件是否真的在窗口里。已按窗口信封解包 inner event（定位后随打点移除）。 */
 function describeEventTypes(entries: readonly unknown[]): string {
   const types = new Set<string>()
   for (const entry of entries) {
-    if (entry !== null && typeof entry === 'object' && typeof (entry as { type?: unknown }).type === 'string')
-      types.add((entry as { type: string }).type)
+    if (entry !== null && typeof entry === 'object') {
+      const outer = entry as Record<string, unknown>
+      // 窗口条目信封 { type:'event'|'chunks', event }：业务类型在内层 event.type
+      const inner = outer.type === 'event' || outer.type === 'chunks' ? outer.event : entry
+      if (inner !== null && typeof inner === 'object' && typeof (inner as { type?: unknown }).type === 'string')
+        types.add((inner as { type: string }).type)
+    }
   }
   return `[${[...types].sort().join(',')}]`
 }

--- a/packages/dsh-tauri-pet/src/client/service/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/service/activity.ts
@@ -43,10 +43,6 @@ interface SessionWatch {
   /** 事件窗口折叠结果；undefined 表示该会话无事件窗口（alpha），null 表示当前无活动 */
   activity?: SessionLiveActivity | null
   activityTimer?: ReturnType<typeof setTimeout>
-  /** [pet-activity] 临时诊断：上次输出的折叠结果签名，避免节流日志刷屏（定位后随打点一起移除） */
-  lastActivityLog?: string
-  /** [pet-activity] 临时诊断：上次输出的窗口类型集签名，类型集变化时才重打窗口快照（定位后随打点一起移除） */
-  lastRawLog?: string
 }
 
 /**
@@ -66,9 +62,6 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
       if (disposed)
         return
       const payload = toTransferable(session) as Record<string, unknown>
-      // [pet-activity] 临时诊断：liveActivity 应原样通过递归 JSON 克隆，被剥离说明序列化有洞（定位后移除）
-      if ('liveActivity' in session && !('liveActivity' in payload))
-        console.warn('[pet-activity] liveActivity stripped by toTransferable', session.id)
       void pushPetSession(action, payload).catch((error) => {
         if (!disposed)
           console.error(`[dsh-tauri-pet] session ${action} push failed:`, error)
@@ -95,23 +88,11 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
     /** 订阅事件窗口：这里只做 trailing 节流，到期时按当前窗口整体重算一次，一次突发只推送一帧。 */
     function attachEventSource(id: string, binding: RawSessionBinding, watch: SessionWatch): void {
       const source = binding.eventSource
-      if (source === undefined || typeof source.getSnapshot !== 'function' || typeof source.subscribe !== 'function') {
-        // [pet-activity] 临时诊断：未探测到事件窗口 → liveActivity 不可用，输出 binding 实际字段辅助定位（定位后移除）
-        console.warn('[pet-activity] bind', id, 'eventSource=NO keys=', Object.keys(binding).join(','))
+      if (source === undefined || typeof source.getSnapshot !== 'function' || typeof source.subscribe !== 'function')
         return
-      }
       // 绑定即折叠一次，create 帧就携带已运行会话的实时活动
       const initial = source.getSnapshot()
       watch.activity = foldSessionActivity(initial.entries)
-      // [pet-activity] 临时诊断：窗口规模 + 窗口内出现过的全部事件类型 + 初始折叠结果，
-      // 用于验证 fold 关注的 tool/call、assistant/chunk 是否真的进入客户端事件窗口（定位后移除）
-      console.warn(
-        '[pet-activity] bind',
-        id,
-        `entries=${initial.entries.length}`,
-        `types=${describeEventTypes(initial.entries)}`,
-        `initial=${JSON.stringify(watch.activity ?? null)}`,
-      )
       watch.disposers.push(source.subscribe(() => {
         if (disposed || watches.get(id) !== watch || watch.activityTimer !== undefined)
           return
@@ -119,19 +100,6 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
           watch.activityTimer = undefined
           const current = source.getSnapshot()
           watch.activity = foldSessionActivity(current.entries)
-          // [pet-activity] 临时诊断：窗口类型集变化时输出类型清单 + 最新两条原始条目，
-          // 用来判断 fold 为什么总返回 null：窗口是否压根不含流式事件 / 顶层字段名是否非 type（定位后移除）
-          const types = describeEventTypes(current.entries)
-          if (types !== watch.lastRawLog) {
-            watch.lastRawLog = types
-            console.warn('[pet-activity] window', id, `#${current.entries.length}`, types, 'last=', describeTail(current.entries))
-          }
-          // [pet-activity] 临时诊断：折叠结果变化（含 null→有值→null）时输出一条，静默 = 无新事件（定位后移除）
-          const signature = JSON.stringify(watch.activity ?? null)
-          if (signature !== watch.lastActivityLog) {
-            watch.lastActivityLog = signature
-            console.warn('[pet-activity] fold', id, `#${current.entries.length}`, signature)
-          }
           emit('update', snapshotOf(id, binding))
         }, PET_ACTIVITY_THROTTLE_MS)
       }))
@@ -184,10 +152,8 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
         if (watches.has(id)) {
           const watch = watches.get(id)
           // activity 保持 undefined 说明事件窗口此前不可用；运行中补挂一次（成功 attach 后值为 null，不会重复订阅）
-          if (watch !== undefined && watch.activity === undefined && binding.eventSource !== undefined) {
-            console.warn('[pet-activity] late attach eventSource', id)
+          if (watch !== undefined && watch.activity === undefined && binding.eventSource !== undefined)
             attachEventSource(id, binding, watch)
-          }
           emit('update', snapshotOf(id, binding))
         }
         else {
@@ -211,32 +177,4 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
     sync()
     return () => controller.dispose()
   }, 'dsh-tauri-pet: raw session events')
-}
-
-/** [pet-activity] 临时诊断：统计事件窗口内出现过的全部事件类型（去重排序），验证 fold 关注的事件是否真的在窗口里。已按窗口信封解包 inner event（定位后随打点移除）。 */
-function describeEventTypes(entries: readonly unknown[]): string {
-  const types = new Set<string>()
-  for (const entry of entries) {
-    if (entry !== null && typeof entry === 'object') {
-      const outer = entry as Record<string, unknown>
-      // 窗口条目信封 { type:'event'|'chunks', event }：业务类型在内层 event.type
-      const inner = outer.type === 'event' || outer.type === 'chunks' ? outer.event : entry
-      if (inner !== null && typeof inner === 'object' && typeof (inner as { type?: unknown }).type === 'string')
-        types.add((inner as { type: string }).type)
-    }
-  }
-  return `[${[...types].sort().join(',')}]`
-}
-
-/** [pet-activity] 临时诊断：最新两条条目的原始形状（截断到 110 字符），确认顶层字段名与 data 结构（定位后随打点移除）。 */
-function describeTail(entries: readonly unknown[]): string {
-  const tail = entries.slice(-2).map((entry) => {
-    if (entry === null || typeof entry !== 'object') {
-      const text = String(entry)
-      return text.length > 110 ? `${text.slice(0, 110)}…` : text
-    }
-    const text = JSON.stringify(entry)
-    return text.length > 110 ? `${text.slice(0, 110)}…` : text
-  })
-  return `[${tail.join(', ')}]`
 }

--- a/packages/dsh-tauri-pet/src/client/service/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/service/activity.ts
@@ -43,6 +43,8 @@ interface SessionWatch {
   /** 事件窗口折叠结果；undefined 表示该会话无事件窗口（alpha），null 表示当前无活动 */
   activity?: SessionLiveActivity | null
   activityTimer?: ReturnType<typeof setTimeout>
+  /** [pet-activity] 临时诊断：上次输出的折叠结果签名，避免节流日志刷屏（定位后随打点一起移除） */
+  lastActivityLog?: string
 }
 
 /**
@@ -62,6 +64,9 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
       if (disposed)
         return
       const payload = toTransferable(session) as Record<string, unknown>
+      // [pet-activity] 临时诊断：liveActivity 应原样通过递归 JSON 克隆，被剥离说明序列化有洞（定位后移除）
+      if ('liveActivity' in session && !('liveActivity' in payload))
+        console.warn('[pet-activity] liveActivity stripped by toTransferable', session.id)
       void pushPetSession(action, payload).catch((error) => {
         if (!disposed)
           console.error(`[dsh-tauri-pet] session ${action} push failed:`, error)
@@ -88,16 +93,36 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
     /** 订阅事件窗口：这里只做 trailing 节流，到期时按当前窗口整体重算一次，一次突发只推送一帧。 */
     function attachEventSource(id: string, binding: RawSessionBinding, watch: SessionWatch): void {
       const source = binding.eventSource
-      if (source === undefined || typeof source.getSnapshot !== 'function' || typeof source.subscribe !== 'function')
+      if (source === undefined || typeof source.getSnapshot !== 'function' || typeof source.subscribe !== 'function') {
+        // [pet-activity] 临时诊断：未探测到事件窗口 → liveActivity 不可用，输出 binding 实际字段辅助定位（定位后移除）
+        console.warn('[pet-activity] bind', id, 'eventSource=NO keys=', Object.keys(binding).join(','))
         return
+      }
       // 绑定即折叠一次，create 帧就携带已运行会话的实时活动
-      watch.activity = foldSessionActivity(source.getSnapshot().entries)
+      const initial = source.getSnapshot()
+      watch.activity = foldSessionActivity(initial.entries)
+      // [pet-activity] 临时诊断：窗口规模 + 窗口内出现过的全部事件类型 + 初始折叠结果，
+      // 用于验证 fold 关注的 tool/call、assistant/chunk 是否真的进入客户端事件窗口（定位后移除）
+      console.warn(
+        '[pet-activity] bind',
+        id,
+        `entries=${initial.entries.length}`,
+        `types=${describeEventTypes(initial.entries)}`,
+        `initial=${JSON.stringify(watch.activity ?? null)}`,
+      )
       watch.disposers.push(source.subscribe(() => {
         if (disposed || watches.get(id) !== watch || watch.activityTimer !== undefined)
           return
         watch.activityTimer = globalThis.setTimeout(() => {
           watch.activityTimer = undefined
-          watch.activity = foldSessionActivity(source.getSnapshot().entries)
+          const current = source.getSnapshot()
+          watch.activity = foldSessionActivity(current.entries)
+          // [pet-activity] 临时诊断：折叠结果变化（含 null→有值→null）时输出一条，静默 = 无新事件（定位后移除）
+          const signature = JSON.stringify(watch.activity ?? null)
+          if (signature !== watch.lastActivityLog) {
+            watch.lastActivityLog = signature
+            console.warn('[pet-activity] fold', id, `#${current.entries.length}`, signature)
+          }
           emit('update', snapshotOf(id, binding))
         }, PET_ACTIVITY_THROTTLE_MS)
       }))
@@ -147,10 +172,18 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
             bind(id, 'create')
           continue
         }
-        if (watches.has(id))
+        if (watches.has(id)) {
+          const watch = watches.get(id)
+          // activity 保持 undefined 说明事件窗口此前不可用；运行中补挂一次（成功 attach 后值为 null，不会重复订阅）
+          if (watch !== undefined && watch.activity === undefined && binding.eventSource !== undefined) {
+            console.warn('[pet-activity] late attach eventSource', id)
+            attachEventSource(id, binding, watch)
+          }
           emit('update', snapshotOf(id, binding))
-        else
+        }
+        else {
           bind(id, known.has(id) ? 'update' : 'create')
+        }
       }
       known.clear()
       for (const id of ids)
@@ -169,4 +202,14 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
     sync()
     return () => controller.dispose()
   }, 'dsh-tauri-pet: raw session events')
+}
+
+/** [pet-activity] 临时诊断：统计事件窗口内出现过的全部事件类型（去重排序），验证 fold 关注的事件是否真的在窗口里（定位后随打点移除）。 */
+function describeEventTypes(entries: readonly unknown[]): string {
+  const types = new Set<string>()
+  for (const entry of entries) {
+    if (entry !== null && typeof entry === 'object' && typeof (entry as { type?: unknown }).type === 'string')
+      types.add((entry as { type: string }).type)
+  }
+  return `[${[...types].sort().join(',')}]`
 }

--- a/packages/dsh-tauri-pet/src/client/service/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/service/activity.ts
@@ -45,6 +45,8 @@ interface SessionWatch {
   activityTimer?: ReturnType<typeof setTimeout>
   /** [pet-activity] 临时诊断：上次输出的折叠结果签名，避免节流日志刷屏（定位后随打点一起移除） */
   lastActivityLog?: string
+  /** [pet-activity] 临时诊断：上次输出的窗口类型集签名，类型集变化时才重打窗口快照（定位后随打点一起移除） */
+  lastRawLog?: string
 }
 
 /**
@@ -117,6 +119,13 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
           watch.activityTimer = undefined
           const current = source.getSnapshot()
           watch.activity = foldSessionActivity(current.entries)
+          // [pet-activity] 临时诊断：窗口类型集变化时输出类型清单 + 最新两条原始条目，
+          // 用来判断 fold 为什么总返回 null：窗口是否压根不含流式事件 / 顶层字段名是否非 type（定位后移除）
+          const types = describeEventTypes(current.entries)
+          if (types !== watch.lastRawLog) {
+            watch.lastRawLog = types
+            console.warn('[pet-activity] window', id, `#${current.entries.length}`, types, 'last=', describeTail(current.entries))
+          }
           // [pet-activity] 临时诊断：折叠结果变化（含 null→有值→null）时输出一条，静默 = 无新事件（定位后移除）
           const signature = JSON.stringify(watch.activity ?? null)
           if (signature !== watch.lastActivityLog) {
@@ -212,4 +221,17 @@ function describeEventTypes(entries: readonly unknown[]): string {
       types.add((entry as { type: string }).type)
   }
   return `[${[...types].sort().join(',')}]`
+}
+
+/** [pet-activity] 临时诊断：最新两条条目的原始形状（截断到 110 字符），确认顶层字段名与 data 结构（定位后随打点移除）。 */
+function describeTail(entries: readonly unknown[]): string {
+  const tail = entries.slice(-2).map((entry) => {
+    if (entry === null || typeof entry !== 'object') {
+      const text = String(entry)
+      return text.length > 110 ? `${text.slice(0, 110)}…` : text
+    }
+    const text = JSON.stringify(entry)
+    return text.length > 110 ? `${text.slice(0, 110)}…` : text
+  })
+  return `[${tail.join(', ')}]`
 }

--- a/packages/dsh-tauri-pet/src/client/types/index.ts
+++ b/packages/dsh-tauri-pet/src/client/types/index.ts
@@ -50,6 +50,22 @@ export interface WorkspaceItem {
   workspaceId?: string
 }
 
+/**
+ * 会话实时活动：dsh-tauri-pet 从会话事件窗口（binding.eventSource）折叠，随会话
+ * 快照以 liveActivity 字段推送给桌宠窗口；无活动时为 null，会话无事件窗口
+ * （alpha 运行时）则整个字段缺席。展示端把 kind=tool 的 name/args 映射为
+ * 「Pwsh · 命令 / 编辑 · 文件 / 工具调用 · 工具名」，kind=reasoning 映射为「思考 · 文本」。
+ */
+export interface SessionLiveActivity {
+  kind: 'reasoning' | 'tool'
+  /** kind=reasoning：思考块文本尾部（最新的思考内容） */
+  text?: string
+  /** kind=tool：工具注册名（pwsh / bash / str_replace_editor / read …） */
+  name?: string
+  /** kind=tool：模型输出的原始 arguments JSON 串，由展示端按工具提取细节 */
+  args?: string
+}
+
 export interface PetRuntimeContext {
   sessions: {
     list: {

--- a/packages/dsh-tauri-pet/src/client/utils/activity.test.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/activity.test.ts
@@ -1,96 +1,108 @@
-import type { SessionLiveActivity } from '../types'
 import { describe, expect, it } from 'vitest'
 import { PET_REASONING_TAIL_LENGTH } from '../constants'
 import { foldSessionActivity } from './activity'
 
-function chunkEvent(chunk: Record<string, unknown>): Record<string, unknown> {
-  return { type: 'assistant/chunk', data: { chunk } }
+/** 构造窗口条目：离散事件信封 `{ type:'event', event }`。 */
+function ev(type: string, data: Record<string, unknown> = {}): unknown {
+  return { type: 'event', event: { type, seq: 0, time: 0, data } }
 }
 
-function toolCallEvent(callId: string, name: string, args?: string): Record<string, unknown> {
-  return { type: 'tool/call', data: { callId, name, arguments: args } }
-}
-
-function toolResultEvent(callId: string): Record<string, unknown> {
-  return { type: 'tool/result', data: { message: { source: { callId }, content: [] } } }
+/** 构造窗口条目：打包 chunk 行信封 `{ type:'chunks', event }`。 */
+function chunks(type: string, data: Record<string, unknown>): unknown {
+  return { type: 'chunks', event: { type, seq: 0, time: 0, data } }
 }
 
 describe('foldSessionActivity', () => {
-  it('累积 reasoning-delta 为思考活动，且只保留尾部窗口', () => {
-    const text = 'a'.repeat(PET_REASONING_TAIL_LENGTH + 20)
-    const entries = [
-      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
-      chunkEvent({ type: 'reasoning-delta', index: 0, text }),
-    ]
-    const activity = foldSessionActivity(entries)
-    expect(activity?.kind).toBe('reasoning')
-    expect(activity?.text).toBe('a'.repeat(PET_REASONING_TAIL_LENGTH))
-  })
-
-  it('block-end 关闭思考块后无活动', () => {
-    const entries = [
-      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
-      chunkEvent({ type: 'reasoning-delta', index: 0, text: '推理中' }),
-      chunkEvent({ type: 'block-end', index: 0 }),
-    ]
-    expect(foldSessionActivity(entries)).toBeNull()
-  })
-
-  it('进行中的工具调用（无对应 result）优先于思考流', () => {
-    const entries = [
-      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
-      chunkEvent({ type: 'reasoning-delta', index: 0, text: '先想一下' }),
-      chunkEvent({ type: 'block-end', index: 0 }),
-      toolCallEvent('call-1', 'pwsh', '{"command":"pnpm build"}'),
-    ]
-    const activity = foldSessionActivity(entries)
-    expect(activity).toEqual({ kind: 'tool', name: 'pwsh', args: '{"command":"pnpm build"}' })
-  })
-
-  it('tool/result 按 message.source.callId 关闭调用；多个未完成调用取最新', () => {
-    const entries = [
-      toolCallEvent('call-1', 'read', '{"file_path":"a.ts"}'),
-      toolCallEvent('call-2', 'str_replace_editor', '{"path":"b.ts"}'),
-      toolResultEvent('call-1'),
-    ]
-    const activity = foldSessionActivity(entries)
-    expect(activity?.kind).toBe('tool')
-    expect(activity?.name).toBe('str_replace_editor')
-  })
-
-  it('step/start 边界清空上一段残留（中止调用不污染下一步）', () => {
-    const entries = [
-      toolCallEvent('call-1', 'bash', '{"command":"exit 1"}'),
-      { type: 'step/start', data: { turn: 1, step: 2 } },
-      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
-      chunkEvent({ type: 'reasoning-delta', index: 0, text: '重新思考' }),
-    ]
-    const activity = foldSessionActivity(entries)
-    expect(activity).toEqual({ kind: 'reasoning', text: '重新思考' })
-  })
-
-  it('turn/end 后无活动；非对象条目与未知事件类型被忽略', () => {
-    const entries = [
-      toolCallEvent('call-1', 'pwsh', '{"command":"pnpm test"}'),
-      { type: 'turn/end', data: { turn: 1 } },
-      null,
-      42,
-      { type: 'user/message', data: { text: 'hi' } },
-    ]
-    expect(foldSessionActivity(entries)).toBeNull()
-  })
-
-  it('空窗口返回 null', () => {
+  it('returns null for an empty window', () => {
     expect(foldSessionActivity([])).toBeNull()
   })
 
-  it('返回 null 而不是未定义字段的对象（text/name 只在对应 kind 出现）', () => {
+  it('ignores foreign events and non-object entries', () => {
     const entries = [
-      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
-      chunkEvent({ type: 'reasoning-delta', index: 0, text: '思考' }),
+      null,
+      'raw',
+      42,
+      ev('sandbox/mode', { mode: 'workspace-write' }),
+      ev('approval/policy', { policy: 'ask' }),
     ]
-    const activity = foldSessionActivity(entries) as SessionLiveActivity
-    expect('name' in activity).toBe(false)
-    expect('args' in activity).toBe(false)
+    expect(foldSessionActivity(entries)).toBeNull()
+  })
+
+  it('folds a running reasoning block from packed rows and keeps the tail window', () => {
+    const entries = [
+      ev('step/start', { turn: 1, step: 1 }),
+      chunks('chunkrow/reasoning-chunks', { turn: 1, step: 1, index: 0, dt: [], texts: ['alpha', ' beta ', 'gamma'] }),
+      chunks('chunkrow/reasoning-chunks', { turn: 1, step: 1, index: 0, dt: [], texts: [' more'] }),
+    ]
+    expect(foldSessionActivity(entries)).toEqual({ kind: 'reasoning', text: 'alpha beta gamma more' })
+  })
+
+  it('a new reasoning block index restarts the buffer', () => {
+    const entries = [
+      chunks('chunkrow/reasoning-chunks', { turn: 1, step: 1, index: 0, dt: [], texts: ['old reasoning'] }),
+      chunks('chunkrow/reasoning-chunks', { turn: 1, step: 2, index: 1, dt: [], texts: ['new reasoning'] }),
+    ]
+    expect(foldSessionActivity(entries)).toEqual({ kind: 'reasoning', text: 'new reasoning' })
+  })
+
+  it('truncates reasoning text to the tail window', () => {
+    const text = 'a'.repeat(PET_REASONING_TAIL_LENGTH + 20)
+    const entries = [
+      chunks('chunkrow/reasoning-chunks', { turn: 1, step: 1, index: 0, dt: [], texts: [text] }),
+      chunks('chunkrow/reasoning-chunks', { turn: 1, step: 1, index: 0, dt: [], texts: ['bbb'] }),
+    ]
+    const activity = foldSessionActivity(entries)
+    expect(activity?.kind).toBe('reasoning')
+    expect(activity?.text).toBe(`${'a'.repeat(PET_REASONING_TAIL_LENGTH - 3)}bbb`)
+  })
+
+  it('raw block-start opens and block-end closes reasoning', () => {
+    const open = [
+      ev('assistant/chunk', { turn: 1, step: 1, chunk: { type: 'block-start', index: 0, blockType: 'reasoning' } }),
+      ev('assistant/chunk', { turn: 1, step: 1, chunk: { type: 'reasoning-delta', index: 0, text: 'delta' } }),
+    ]
+    expect(foldSessionActivity(open)).toEqual({ kind: 'reasoning', text: 'delta' })
+    expect(foldSessionActivity([...open, ev('assistant/chunk', { turn: 1, step: 1, chunk: { type: 'block-end', index: 0 } })])).toBeNull()
+  })
+
+  it('prefers an in-flight tool call over reasoning', () => {
+    const entries = [
+      ev('step/start', { turn: 1, step: 1 }),
+      chunks('chunkrow/reasoning-chunks', { turn: 1, step: 1, index: 0, dt: [], texts: ['think'] }),
+      ev('assistant/chunk', { turn: 1, step: 1, chunk: { type: 'block-end', index: 0 } }),
+      ev('tool/call', { callId: 'call-1', name: 'pwsh', arguments: '{"command":"ls"}' }),
+    ]
+    expect(foldSessionActivity(entries)).toEqual({ kind: 'tool', name: 'pwsh', args: '{"command":"ls"}' })
+  })
+
+  it('tool/result closes the tool state', () => {
+    const entries = [
+      ev('tool/call', { callId: 'call-1', name: 'pwsh', arguments: '{"command":"ls"}' }),
+      ev('tool/result', { message: { source: { callId: 'call-1' } }, content: [] }),
+    ]
+    expect(foldSessionActivity(entries)).toBeNull()
+  })
+
+  it('streaming tool-call chunks produce a tool activity with joined args', () => {
+    const entries = [chunks('chunkrow/tool-call-chunks', { turn: 1, step: 1, index: 0, id: 'call-1', name: 'pwsh', dt: [], args: ['{"com', 'mand":"ls"}'] })]
+    expect(foldSessionActivity(entries)).toEqual({ kind: 'tool', name: 'pwsh', args: '{"command":"ls"}' })
+  })
+
+  it('step/turn boundaries clear stale activity', () => {
+    const entries = [
+      chunks('chunkrow/reasoning-chunks', { turn: 1, step: 1, index: 0, dt: [], texts: ['stale'] }),
+      ev('turn/end', { turn: 1, reason: { kind: 'completed' } }),
+    ]
+    expect(foldSessionActivity(entries)).toBeNull()
+  })
+
+  it('plain text output is not an activity', () => {
+    const entries = [chunks('chunkrow/text-chunks', { turn: 1, step: 1, index: 1, dt: [], texts: ['the', ' answer'] })]
+    expect(foldSessionActivity(entries)).toBeNull()
+  })
+
+  it('accepts bare SessionEvents as well as window envelopes', () => {
+    const bare = [{ type: 'tool/call', seq: 1, time: 0, data: { callId: 'c', name: 'read', arguments: '{"file_path":"a.ts"}' } }]
+    expect(foldSessionActivity(bare)).toEqual({ kind: 'tool', name: 'read', args: '{"file_path":"a.ts"}' })
   })
 })

--- a/packages/dsh-tauri-pet/src/client/utils/activity.test.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/activity.test.ts
@@ -1,0 +1,96 @@
+import type { SessionLiveActivity } from '../types'
+import { describe, expect, it } from 'vitest'
+import { PET_REASONING_TAIL_LENGTH } from '../constants'
+import { foldSessionActivity } from './activity'
+
+function chunkEvent(chunk: Record<string, unknown>): Record<string, unknown> {
+  return { type: 'assistant/chunk', data: { chunk } }
+}
+
+function toolCallEvent(callId: string, name: string, args?: string): Record<string, unknown> {
+  return { type: 'tool/call', data: { callId, name, arguments: args } }
+}
+
+function toolResultEvent(callId: string): Record<string, unknown> {
+  return { type: 'tool/result', data: { message: { source: { callId }, content: [] } } }
+}
+
+describe('foldSessionActivity', () => {
+  it('累积 reasoning-delta 为思考活动，且只保留尾部窗口', () => {
+    const text = 'a'.repeat(PET_REASONING_TAIL_LENGTH + 20)
+    const entries = [
+      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
+      chunkEvent({ type: 'reasoning-delta', index: 0, text }),
+    ]
+    const activity = foldSessionActivity(entries)
+    expect(activity?.kind).toBe('reasoning')
+    expect(activity?.text).toBe('a'.repeat(PET_REASONING_TAIL_LENGTH))
+  })
+
+  it('block-end 关闭思考块后无活动', () => {
+    const entries = [
+      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
+      chunkEvent({ type: 'reasoning-delta', index: 0, text: '推理中' }),
+      chunkEvent({ type: 'block-end', index: 0 }),
+    ]
+    expect(foldSessionActivity(entries)).toBeNull()
+  })
+
+  it('进行中的工具调用（无对应 result）优先于思考流', () => {
+    const entries = [
+      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
+      chunkEvent({ type: 'reasoning-delta', index: 0, text: '先想一下' }),
+      chunkEvent({ type: 'block-end', index: 0 }),
+      toolCallEvent('call-1', 'pwsh', '{"command":"pnpm build"}'),
+    ]
+    const activity = foldSessionActivity(entries)
+    expect(activity).toEqual({ kind: 'tool', name: 'pwsh', args: '{"command":"pnpm build"}' })
+  })
+
+  it('tool/result 按 message.source.callId 关闭调用；多个未完成调用取最新', () => {
+    const entries = [
+      toolCallEvent('call-1', 'read', '{"file_path":"a.ts"}'),
+      toolCallEvent('call-2', 'str_replace_editor', '{"path":"b.ts"}'),
+      toolResultEvent('call-1'),
+    ]
+    const activity = foldSessionActivity(entries)
+    expect(activity?.kind).toBe('tool')
+    expect(activity?.name).toBe('str_replace_editor')
+  })
+
+  it('step/start 边界清空上一段残留（中止调用不污染下一步）', () => {
+    const entries = [
+      toolCallEvent('call-1', 'bash', '{"command":"exit 1"}'),
+      { type: 'step/start', data: { turn: 1, step: 2 } },
+      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
+      chunkEvent({ type: 'reasoning-delta', index: 0, text: '重新思考' }),
+    ]
+    const activity = foldSessionActivity(entries)
+    expect(activity).toEqual({ kind: 'reasoning', text: '重新思考' })
+  })
+
+  it('turn/end 后无活动；非对象条目与未知事件类型被忽略', () => {
+    const entries = [
+      toolCallEvent('call-1', 'pwsh', '{"command":"pnpm test"}'),
+      { type: 'turn/end', data: { turn: 1 } },
+      null,
+      42,
+      { type: 'user/message', data: { text: 'hi' } },
+    ]
+    expect(foldSessionActivity(entries)).toBeNull()
+  })
+
+  it('空窗口返回 null', () => {
+    expect(foldSessionActivity([])).toBeNull()
+  })
+
+  it('返回 null 而不是未定义字段的对象（text/name 只在对应 kind 出现）', () => {
+    const entries = [
+      chunkEvent({ type: 'block-start', index: 0, blockType: 'reasoning' }),
+      chunkEvent({ type: 'reasoning-delta', index: 0, text: '思考' }),
+    ]
+    const activity = foldSessionActivity(entries) as SessionLiveActivity
+    expect('name' in activity).toBe(false)
+    expect('args' in activity).toBe(false)
+  })
+})

--- a/packages/dsh-tauri-pet/src/client/utils/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/activity.ts
@@ -1,130 +1,180 @@
 import type { SessionLiveActivity } from '../types'
 import {
   PET_REASONING_TAIL_LENGTH,
+  PET_TOOL_ARGS_MAX_LENGTH,
   SESSION_EVENT_ASSISTANT_CHUNK,
+  SESSION_EVENT_ASSISTANT_MESSAGE,
+  SESSION_EVENT_CHUNKROW_REASONING,
+  SESSION_EVENT_CHUNKROW_TEXT,
+  SESSION_EVENT_CHUNKROW_TOOL_CALL,
+  SESSION_EVENT_STEP_END,
   SESSION_EVENT_STEP_START,
   SESSION_EVENT_TOOL_CALL,
   SESSION_EVENT_TOOL_RESULT,
   SESSION_EVENT_TURN_END,
+  SESSION_EVENT_TURN_START,
+  SESSION_EVENT_USER_MESSAGE,
 } from '../constants'
 
-/** 会话事件窗口单条事件：只声明折叠用到的信封字段（SessionEvent { seq, time, type, data }）。 */
-interface SessionEventLike {
-  type?: unknown
-  data?: unknown
+/**
+ * 会话事件窗口条目（SessionEventLikeEntry，dsh-api-session-controller pageRecords）：
+ * `{ type:'event', event: SessionEvent }`（离散事件，供已提交的完整消息/生命周期使用）
+ * 与 `{ type:'chunks', event: ChunkRowEvent }`（打包的流式 delta 行）。真正的业务类型
+ * 在 event.type，data 在 event.data，两层都只有这几个字段被折叠消费。
+ */
+interface UnwrappedEvent {
+  type: string | undefined
+  data: Record<string, unknown>
 }
 
-/** assistant/chunk 事件 data：chunk 为 LLM 流式块（dsh-llm 流块联合类型）。 */
-interface AssistantChunkData {
-  chunk?: { type?: unknown, blockType?: unknown, text?: unknown }
-}
-
-/** tool/call 事件 data：arguments 为模型输出的原始 args JSON 串。 */
-interface ToolCallData {
-  arguments?: unknown
-  callId?: unknown
-  name?: unknown
-}
-
-/** tool/result 事件 data：callId 记录在 message.source（旧版本兼容 message.callId）。 */
-interface ToolResultData {
-  message?: { callId?: unknown, source?: { callId?: unknown } }
-}
-
-interface PendingToolCall {
-  args?: string
-  callId: string
-  name: string
-}
+/** 折叠状态机：按时间正序推进，最终状态即「当前正在进行的活动」。 */
+type FoldState
+  = | { kind: 'none' }
+    | { kind: 'reasoning', index: number, text: string }
+    | { kind: 'tool', callId: string, name: string, args?: string }
+    | { kind: 'text' }
 
 /**
- * 从会话事件窗口（MutableSessionEventSource 的 entries，按时间正序）折叠出当前
- * 正在进行的活动：进行中的工具调用（tool/call 尚无对应 tool/result）优先，其次
- * 是仍在流式输出的思考块（reasoning-delta 累积，只保留尾部窗口）。
+ * 从会话事件窗口（binding.eventSource.getSnapshot().entries，按时间正序）折叠出当前
+ * 正在进行的活动：仍在流式输出的思考块（chunkrow/reasoning-chunks 与未打包的
+ * reasoning-delta，按块累积、只留尾部）或进行中的工具调用（chunkrow/tool-call-chunks
+ * 流式参数，随后 tool/call 权威参数替换，tool/result 关闭）。模型输出正文
+ * （text-chunks / assistant/message）不算活动，返回 null 让气泡回落到状态标签。
  *
  * 事件形状对照已安装 dsh 运行时（@deepseek-ai/dsh 0.1.2-rc.1）核实：
- * dsh-agent-loop appendToolCall / appendToolResult / assistant/chunk，以及
- * dsh-client-ui-chat 的 rootCall / rootResult fold。
+ * dsh-session/lib/types/chunk-rows.js（打包行语义 + data.texts/args 增量数组）、
+ * dsh-api-session-controller pageRecords / chunkEntryFor（条目信封）、
+ * dsh-client-ui-chat 的 rootCall / rootResult fold（tool/call 的 callId/name/arguments、
+ * tool/result 的 message.source.callId）。
  */
 export function foldSessionActivity(entries: readonly unknown[]): SessionLiveActivity | null {
-  let reasoningOpen = false
-  let reasoningTail = ''
-  const pendingCalls: PendingToolCall[] = []
+  let state: FoldState = { kind: 'none' }
 
   for (const entry of entries) {
-    if (!entry || typeof entry !== 'object')
+    const event = unwrapEntry(entry)
+    if (event === undefined || event.type === undefined)
       continue
-    const event = entry as SessionEventLike
-    if (typeof event.type !== 'string')
-      continue
-    const data = (event.data ?? {}) as Record<string, unknown>
+    const data = event.data
 
     switch (event.type) {
+      // ---- 流式思考（打包行 / 未打包 delta，>=3 与 <3 的块分别走两种信封）----
+      case SESSION_EVENT_CHUNKROW_REASONING: {
+        const texts = asStringArray(data.texts)
+        if (state.kind === 'reasoning' && state.index === data.index)
+          state = { kind: 'reasoning', index: state.index, text: appendTail(state.text, texts.join('')) }
+        else
+          state = { kind: 'reasoning', index: asNumber(data.index, 0), text: appendTail('', texts.join('')) }
+        break
+      }
       case SESSION_EVENT_ASSISTANT_CHUNK: {
-        const { chunk } = data as AssistantChunkData
+        const chunk = data.chunk
         if (!chunk || typeof chunk !== 'object')
           break
-        if (chunk.type === 'block-start') {
-          // 块按顺序开关：新块开始即关闭遗留思考块（异常流的防御，正常流先收到 block-end）
-          reasoningOpen = false
-          reasoningTail = ''
-          if (chunk.blockType === 'reasoning')
-            reasoningOpen = true
+        const block = chunk as Record<string, unknown>
+        if (block.type === 'block-start') {
+          // 块按顺序开关：新块开始即关闭遗留思考块（异常流的防御，正常流先收到 block-end）；
+          // 仅 reasoning 块进入思考态，text/tool-call 块开始视为离开思考
+          if (block.blockType === 'reasoning')
+            state = { kind: 'reasoning', index: asNumber(block.index, 0), text: '' }
+          else
+            state = { kind: 'text' }
           break
         }
-        if (chunk.type === 'reasoning-delta' && reasoningOpen && typeof chunk.text === 'string') {
-          reasoningTail = (reasoningTail + chunk.text).slice(-PET_REASONING_TAIL_LENGTH)
+        if (block.type === 'block-end') {
+          if (state.kind === 'reasoning')
+            state = { kind: 'none' }
+          else if (state.kind === 'text')
+            state = { kind: 'none' }
           break
         }
-        if (chunk.type === 'block-end' && reasoningOpen) {
-          reasoningOpen = false
-          reasoningTail = ''
+        if (block.type === 'reasoning-delta' && state.kind === 'reasoning' && typeof block.text === 'string') {
+          state = { kind: 'reasoning', index: state.index, text: appendTail(state.text, block.text) }
+          break
+        }
+        if (block.type === 'text-delta')
+          state = { kind: 'text' }
+        break
+      }
+
+      // ---- 流式工具调用参数（打包行）：id/name 与逐 token argumentsDelta 数组 ----
+      case SESSION_EVENT_CHUNKROW_TOOL_CALL: {
+        const args = data.args
+        state = {
+          kind: 'tool',
+          callId: typeof data.id === 'string' ? data.id : '',
+          name: typeof data.name === 'string' ? data.name : '',
+          args: asStringArray(args).join('').slice(0, PET_TOOL_ARGS_MAX_LENGTH),
         }
         break
       }
 
-      case SESSION_EVENT_TOOL_CALL: {
-        const { callId, name, arguments: args } = data as ToolCallData
-        if (typeof callId !== 'string' || callId.length === 0)
-          break
-        // 同 callId 重放（日志回放/窗口重建）时替换旧记录，保持最新顺序
-        const existing = pendingCalls.findIndex(call => call.callId === callId)
-        if (existing >= 0)
-          pendingCalls.splice(existing, 1)
-        pendingCalls.push({
-          callId,
-          name: typeof name === 'string' ? name : '',
-          args: typeof args === 'string' ? args : undefined,
-        })
+      // ---- 离散工具生命周期：tool/call 权威（name + 完整 arguments），tool/result 关闭 ----
+      case SESSION_EVENT_TOOL_CALL:
+        state = {
+          kind: 'tool',
+          callId: typeof data.callId === 'string' ? data.callId : '',
+          name: typeof data.name === 'string' ? data.name : '',
+          args: typeof data.arguments === 'string' ? data.arguments : undefined,
+        }
         break
-      }
-
-      case SESSION_EVENT_TOOL_RESULT: {
-        const { message } = data as ToolResultData
-        const callId = message?.source?.callId ?? message?.callId
-        if (typeof callId !== 'string')
-          break
-        const existing = pendingCalls.findIndex(call => call.callId === callId)
-        if (existing >= 0)
-          pendingCalls.splice(existing, 1)
+      case SESSION_EVENT_TOOL_RESULT:
+        if (state.kind === 'tool')
+          state = { kind: 'none' }
         break
-      }
 
+      // ---- 正文输出：不算气泡活动 ----
+      case SESSION_EVENT_CHUNKROW_TEXT:
+      case SESSION_EVENT_ASSISTANT_MESSAGE:
+        state = { kind: 'text' }
+        break
+
+      // ---- 步/轮/用户边界：清空上一段活动，被中止的调用或中断的思考块不残留展示 ----
       case SESSION_EVENT_STEP_START:
-      case SESSION_EVENT_TURN_END: {
-        // 步/轮边界清空上一段活动：被中止的调用或中断的思考块不残留到下一段展示
-        pendingCalls.length = 0
-        reasoningOpen = false
-        reasoningTail = ''
+      case SESSION_EVENT_STEP_END:
+      case SESSION_EVENT_TURN_START:
+      case SESSION_EVENT_TURN_END:
+      case SESSION_EVENT_USER_MESSAGE:
+        state = { kind: 'none' }
         break
-      }
     }
   }
 
-  const current = pendingCalls.at(-1)
-  if (current !== undefined)
-    return { kind: 'tool', name: current.name, args: current.args }
-  if (reasoningOpen && reasoningTail.length > 0)
-    return { kind: 'reasoning', text: reasoningTail }
+  if (state.kind === 'reasoning' && state.text.length > 0)
+    return { kind: 'reasoning', text: state.text }
+  if (state.kind === 'tool')
+    return { kind: 'tool', name: state.name, args: state.args }
   return null
+}
+
+/**
+ * 解析窗口条目信封：`{ type:'event'|'chunks', event }` 时取内层 event 的业务类型与 data；
+ * 兼容直接传入的裸 SessionEvent（旧窗口/测试），复用同一份 unwrap 便于两种形态互操作。
+ */
+function unwrapEntry(entry: unknown): UnwrappedEvent | undefined {
+  if (entry === null || typeof entry !== 'object')
+    return undefined
+  const outer = entry as Record<string, unknown>
+  const inner = outer.type === 'event' || outer.type === 'chunks' ? outer.event : entry
+  if (inner === null || typeof inner !== 'object')
+    return undefined
+  const record = inner as Record<string, unknown>
+  const data = record.data !== null && typeof record.data === 'object' ? record.data as Record<string, unknown> : {}
+  return { type: typeof record.type === 'string' ? record.type : undefined, data }
+}
+
+/** data.texts / data.args 的结构化阅读：缺失或非数组视为空串数组（逐 token 增量 join 语义）。 */
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+/** 块 index 结构化阅读：非 number 视为 0（单块流无歧义）。 */
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' ? value : fallback
+}
+
+/** 追加思考 delta 并只保留尾部窗口，限制跨窗口传输体积。 */
+function appendTail(current: string, delta: string): string {
+  if (delta.length === 0)
+    return current
+  return `${current}${delta}`.slice(-PET_REASONING_TAIL_LENGTH)
 }

--- a/packages/dsh-tauri-pet/src/client/utils/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/activity.ts
@@ -1,0 +1,130 @@
+import type { SessionLiveActivity } from '../types'
+import {
+  PET_REASONING_TAIL_LENGTH,
+  SESSION_EVENT_ASSISTANT_CHUNK,
+  SESSION_EVENT_STEP_START,
+  SESSION_EVENT_TOOL_CALL,
+  SESSION_EVENT_TOOL_RESULT,
+  SESSION_EVENT_TURN_END,
+} from '../constants'
+
+/** 会话事件窗口单条事件：只声明折叠用到的信封字段（SessionEvent { seq, time, type, data }）。 */
+interface SessionEventLike {
+  type?: unknown
+  data?: unknown
+}
+
+/** assistant/chunk 事件 data：chunk 为 LLM 流式块（dsh-llm 流块联合类型）。 */
+interface AssistantChunkData {
+  chunk?: { type?: unknown, blockType?: unknown, text?: unknown }
+}
+
+/** tool/call 事件 data：arguments 为模型输出的原始 args JSON 串。 */
+interface ToolCallData {
+  arguments?: unknown
+  callId?: unknown
+  name?: unknown
+}
+
+/** tool/result 事件 data：callId 记录在 message.source（旧版本兼容 message.callId）。 */
+interface ToolResultData {
+  message?: { callId?: unknown, source?: { callId?: unknown } }
+}
+
+interface PendingToolCall {
+  args?: string
+  callId: string
+  name: string
+}
+
+/**
+ * 从会话事件窗口（MutableSessionEventSource 的 entries，按时间正序）折叠出当前
+ * 正在进行的活动：进行中的工具调用（tool/call 尚无对应 tool/result）优先，其次
+ * 是仍在流式输出的思考块（reasoning-delta 累积，只保留尾部窗口）。
+ *
+ * 事件形状对照已安装 dsh 运行时（@deepseek-ai/dsh 0.1.2-rc.1）核实：
+ * dsh-agent-loop appendToolCall / appendToolResult / assistant/chunk，以及
+ * dsh-client-ui-chat 的 rootCall / rootResult fold。
+ */
+export function foldSessionActivity(entries: readonly unknown[]): SessionLiveActivity | null {
+  let reasoningOpen = false
+  let reasoningTail = ''
+  const pendingCalls: PendingToolCall[] = []
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object')
+      continue
+    const event = entry as SessionEventLike
+    if (typeof event.type !== 'string')
+      continue
+    const data = (event.data ?? {}) as Record<string, unknown>
+
+    switch (event.type) {
+      case SESSION_EVENT_ASSISTANT_CHUNK: {
+        const { chunk } = data as AssistantChunkData
+        if (!chunk || typeof chunk !== 'object')
+          break
+        if (chunk.type === 'block-start') {
+          // 块按顺序开关：新块开始即关闭遗留思考块（异常流的防御，正常流先收到 block-end）
+          reasoningOpen = false
+          reasoningTail = ''
+          if (chunk.blockType === 'reasoning')
+            reasoningOpen = true
+          break
+        }
+        if (chunk.type === 'reasoning-delta' && reasoningOpen && typeof chunk.text === 'string') {
+          reasoningTail = (reasoningTail + chunk.text).slice(-PET_REASONING_TAIL_LENGTH)
+          break
+        }
+        if (chunk.type === 'block-end' && reasoningOpen) {
+          reasoningOpen = false
+          reasoningTail = ''
+        }
+        break
+      }
+
+      case SESSION_EVENT_TOOL_CALL: {
+        const { callId, name, arguments: args } = data as ToolCallData
+        if (typeof callId !== 'string' || callId.length === 0)
+          break
+        // 同 callId 重放（日志回放/窗口重建）时替换旧记录，保持最新顺序
+        const existing = pendingCalls.findIndex(call => call.callId === callId)
+        if (existing >= 0)
+          pendingCalls.splice(existing, 1)
+        pendingCalls.push({
+          callId,
+          name: typeof name === 'string' ? name : '',
+          args: typeof args === 'string' ? args : undefined,
+        })
+        break
+      }
+
+      case SESSION_EVENT_TOOL_RESULT: {
+        const { message } = data as ToolResultData
+        const callId = message?.source?.callId ?? message?.callId
+        if (typeof callId !== 'string')
+          break
+        const existing = pendingCalls.findIndex(call => call.callId === callId)
+        if (existing >= 0)
+          pendingCalls.splice(existing, 1)
+        break
+      }
+
+      case SESSION_EVENT_STEP_START:
+      case SESSION_EVENT_TURN_END: {
+        // 步/轮边界清空上一段活动：被中止的调用或中断的思考块不残留到下一段展示
+        pendingCalls.length = 0
+        reasoningOpen = false
+        reasoningTail = ''
+        break
+      }
+    }
+  }
+
+  const current = pendingCalls.at(-1)
+  if (current !== undefined)
+    return { kind: 'tool', name: current.name, args: current.args }
+  if (reasoningOpen && reasoningTail.length > 0)
+    return { kind: 'reasoning', text: reasoningTail }
+  return null
+}

--- a/src-tauri/src/bridge/pet.rs
+++ b/src-tauri/src/bridge/pet.rs
@@ -252,12 +252,6 @@ pub fn push_pet_session(
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
         .ok_or_else(|| "PET_SESSION_ID_INVALID: raw session must include id".to_string())?;
-    // [pet-activity] 临时诊断：桥接层收到非空 liveActivity 时输出（定位后移除；stderr 仅 tauri dev 终端可见）
-    if let Some(activity) = session.get("liveActivity") {
-        if !activity.is_null() {
-            eprintln!("[pet-activity] bridge push {action} {id} liveActivity={activity}");
-        }
-    }
     let event = match action {
         "create" => "session:create",
         "update" => "session:update",

--- a/src-tauri/src/bridge/pet.rs
+++ b/src-tauri/src/bridge/pet.rs
@@ -252,6 +252,12 @@ pub fn push_pet_session(
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
         .ok_or_else(|| "PET_SESSION_ID_INVALID: raw session must include id".to_string())?;
+    // [pet-activity] 临时诊断：桥接层收到非空 liveActivity 时输出（定位后移除；stderr 仅 tauri dev 终端可见）
+    if let Some(activity) = session.get("liveActivity") {
+        if !activity.is_null() {
+            eprintln!("[pet-activity] bridge push {action} {id} liveActivity={activity}");
+        }
+    }
     let event = match action {
         "create" => "session:create",
         "update" => "session:update",

--- a/src/pet/components/pet.tsx
+++ b/src/pet/components/pet.tsx
@@ -298,7 +298,13 @@ export function Pet(props: PetProps) {
     const source = assets[name]
     if (source === undefined)
       return undefined
-    const once = !(override?.loop ?? isLoopingAnimation(activity))
+    // adHoc（点击回应/待机插播）是一次性动画：是否循环只由动画自身决定，不能继承
+    // override 的 loop 标志——否则会话运行（override.loop=true）期间双击的点击回应
+    // 视频会被加载成循环播放，ended 永不触发、adHoc 永不清除，宠物卡在双击动画
+    // 里回不到会话动画（待机时 override 为 null 走 isLoopingAnimation，故不复现）。
+    const once = adHoc === null
+      ? !(override?.loop ?? isLoopingAnimation(activity))
+      : !isLoopingAnimation(activity)
     const revision = override?.revision
     // adHoc seq：点击同一动画时 seq 递增强制重播（对应 dsh-pet 的 seq 重放）。
     const seq = adHoc?.seq ?? 0
@@ -343,7 +349,7 @@ export function Pet(props: PetProps) {
       if (pendingRef.current?.gen === gen)
         pendingRef.current = null
     }
-  }, [activity, adHoc?.seq, assets, isPreset, override?.loop, override?.revision, pools])
+  }, [activity, adHoc, assets, isPreset, override?.loop, override?.revision, pools])
 
   // 点击回应：clickCount 变化（useDrag 判定「500ms 内两次按下且未拖拽 = 双击」后递增）
   // → 播放一次点击回应动画。adHoc 优先级在会话 override 之上：双击回应可打断会话状态，
@@ -403,7 +409,12 @@ export function Pet(props: PetProps) {
       return undefined
     const element = sprite
     const loadedAsset = asset
-    const sequence = spriteSequence(activity, reducedMotion, override?.loop ?? isLoopingAnimation(activity))
+    // 与视频路径同理：adHoc 播放期间 loop 只由动画自身决定，不继承 override 的
+    // loop 标志，避免会话运行期间点击回应精灵动作循环到 adHoc 计时器到期才回落。
+    const loop = adHoc === null
+      ? (override?.loop ?? isLoopingAnimation(activity))
+      : isLoopingAnimation(activity)
+    const sequence = spriteSequence(activity, reducedMotion, loop)
     let index = 0
     let timer: number | undefined
     function paint() {
@@ -421,7 +432,7 @@ export function Pet(props: PetProps) {
       if (timer !== undefined)
         window.clearTimeout(timer)
     }
-  }, [activity, activePet, adHoc?.seq, customAsset, customAssetPet, isPreset, override?.loop, reducedMotion])
+  }, [activity, activePet, adHoc, customAsset, customAssetPet, isPreset, override?.loop, reducedMotion])
 
   useEffect(() => {
     if (override?.loop !== false || override === null || isPreset || !hasCustomAsset)

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -144,6 +144,10 @@ export function useBubble(): BubbleHandle {
       if (key === undefined) {
         if (dismissed.has(session.id))
           return
+        // 气泡被 toast 层「仅保留最新三条」丢弃后，仅在状态跃迁时重建：
+        // 同状态心跳重建会与丢弃逻辑互相触发，形成每 250ms 的关闭-重建循环。
+        if (previous !== undefined && previous === current)
+          return
         let createdKey = ''
         createdKey = toast(content.title, {
           isLoading: content.isLoading,
@@ -263,6 +267,7 @@ function toastContent(session: BubbleSession): {
     session.description,
     session.message,
     session.lastAgentError ? `失败：${String(session.lastAgentError)}` : undefined,
+    liveActivityLabel(session),
     statusLabel(status),
   ), DESCRIPTION_MAX_LENGTH)
   return {
@@ -306,6 +311,71 @@ function statusLabel(status: PetStatus | undefined): string {
     case 'running': return '思考中'
     default: return '空闲'
   }
+}
+
+/**
+ * 运行中会话的活动行（插件从会话事件流 fold 出的 liveActivity）：
+ * 优先「思考 · 片段」/「工具调用 · 细节」，无活动数据时回退 statusLabel 的「思考中」。
+ * liveActivity 为 null（事件窗口无进行中的活动）或 undefined（旧插件无此字段）都返回 undefined。
+ */
+function liveActivityLabel(session: BubbleSession): string | undefined {
+  if (sessionStatus(session) !== 'running')
+    return undefined
+  const activity = session.liveActivity
+  if (!activity || typeof activity !== 'object')
+    return undefined
+  const { kind, text, name, args } = activity as {
+    kind?: unknown
+    text?: unknown
+    name?: unknown
+    args?: unknown
+  }
+  if (kind === 'reasoning' && typeof text === 'string' && text.trim().length > 0)
+    return `思考 · ${collapseWhitespace(text)}`
+  if (kind === 'tool' && typeof name === 'string' && name.length > 0)
+    return toolLabel(name, args)
+  return undefined
+}
+
+/** 工具注册名 → 气泡标签：shell 显示命令，编辑类显示目标文件，其余兜底「工具调用 · 工具名」。 */
+function toolLabel(name: string, args: unknown): string {
+  const detail = toolDetail(name, args)
+  if (name === 'pwsh')
+    return `Pwsh · ${detail ?? '命令执行'}`
+  if (name === 'bash')
+    return `Bash · ${detail ?? '命令执行'}`
+  if (name === 'str_replace_editor' || name === 'edit' || name === 'write')
+    return `编辑 · ${detail ?? name}`
+  return `工具调用 · ${name}`
+}
+
+/** 从模型原始 arguments JSON 串提取展示细节：shell 取 command，str_replace_editor 取 path，其余取 file_path/path。 */
+function toolDetail(name: string, args: unknown): string | undefined {
+  if (typeof args !== 'string' || args.length === 0)
+    return undefined
+  try {
+    const parsed: unknown = JSON.parse(args)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+      return undefined
+    const record = parsed as Record<string, unknown>
+    const keys = name === 'pwsh' || name === 'bash'
+      ? ['command']
+      : name === 'str_replace_editor' ? ['path'] : ['file_path', 'path']
+    for (const key of keys) {
+      const value = record[key]
+      if (typeof value === 'string' && value.trim().length > 0)
+        return collapseWhitespace(value)
+    }
+    return undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+/** 气泡单行展示：换行/连续空白折叠为单空格，多行命令不至于占满两行 clamp。 */
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
 }
 
 /**

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -28,6 +28,8 @@ const SUCCESS_TOAST_TIMEOUT = 3000
  * lastAgentError 经插件 250ms 心跳重发后永久占用 'failed'、阻塞其他会话的动画切换。
  */
 const FAILED_PULSE_TTL = 1800
+/** [pet-activity] 临时诊断：按会话去重 liveActivity 日志（定位后随打点移除）。 */
+const activityDebugSeen = new Map<string, string>()
 
 /** 桌宠窗口的会话气泡：DSH 发送原始会话快照，本 hook 私有管理会话→toast key 映射，仅暴露聚合宠物状态。 */
 export function useBubble(): BubbleHandle {
@@ -321,6 +323,13 @@ function statusLabel(status: PetStatus | undefined): string {
 function liveActivityLabel(session: BubbleSession): string | undefined {
   if (sessionStatus(session) !== 'running')
     return undefined
+  // [pet-activity] 临时诊断：运行中会话实际收到的 liveActivity 原始值
+  // （"null" = 插件没推字段或明确为空 → 问题在插件侧；有对象但气泡仍「思考中」→ 问题在本文件）（定位后移除）
+  const raw = JSON.stringify(session.liveActivity ?? null)
+  if (activityDebugSeen.get(session.id) !== raw) {
+    activityDebugSeen.set(session.id, raw)
+    console.warn('[pet-activity] pet running activity', session.id, raw)
+  }
   const activity = session.liveActivity
   if (!activity || typeof activity !== 'object')
     return undefined

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -28,8 +28,6 @@ const SUCCESS_TOAST_TIMEOUT = 3000
  * lastAgentError 经插件 250ms 心跳重发后永久占用 'failed'、阻塞其他会话的动画切换。
  */
 const FAILED_PULSE_TTL = 1800
-/** [pet-activity] 临时诊断：按会话去重 liveActivity 日志（定位后随打点移除）。 */
-const activityDebugSeen = new Map<string, string>()
 
 /** 桌宠窗口的会话气泡：DSH 发送原始会话快照，本 hook 私有管理会话→toast key 映射，仅暴露聚合宠物状态。 */
 export function useBubble(): BubbleHandle {
@@ -323,13 +321,6 @@ function statusLabel(status: PetStatus | undefined): string {
 function liveActivityLabel(session: BubbleSession): string | undefined {
   if (sessionStatus(session) !== 'running')
     return undefined
-  // [pet-activity] 临时诊断：运行中会话实际收到的 liveActivity 原始值
-  // （"null" = 插件没推字段或明确为空 → 问题在插件侧；有对象但气泡仍「思考中」→ 问题在本文件）（定位后移除）
-  const raw = JSON.stringify(session.liveActivity ?? null)
-  if (activityDebugSeen.get(session.id) !== raw) {
-    activityDebugSeen.set(session.id, raw)
-    console.warn('[pet-activity] pet running activity', session.id, raw)
-  }
   const activity = session.liveActivity
   if (!activity || typeof activity !== 'object')
     return undefined

--- a/src/pet/main.css
+++ b/src/pet/main.css
@@ -14,6 +14,14 @@
   width: calc(90vw - 2rem);
 }
 
+/* Toast 正文最多两行（-webkit-line-clamp）：思考片段/命令超长时截断省略。 */
+[data-slot='toast-description'] {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
 @layer base {
   html,
   body,

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -12,6 +12,16 @@
   -webkit-app-region: drag;
 }
 
+/* Toast 正文最多两行：超长描述（思考片段/命令）截断省略，避免单条气泡膨胀
+   挤压其他 toast。主窗口与宠物窗口的渲染路径（HeroUI 默认渲染与自定义渲染）
+   都带 data-slot="toast-description"，一处选择器同时覆盖两端。 */
+[data-slot='toast-description'] {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
 /* 主题变量：默认深色，html[data-theme="light"] 切换到浅色。
    取值与官方 dsw alias token（design-platform.css）逐项一致 */
 :root {

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -23,12 +23,18 @@ export const placements = [
   'bottom end',
 ] as const
 
+/**
+ * 单个 placement 同时存在的 toast 上限：渲染层（maxVisibleToasts）与丢弃层
+ * （placementKeys 超限关最旧）共用同一数值。
+ */
+const MAX_VISIBLE_TOASTS = 3
+
 export const queues = Object.fromEntries(
-  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3 })]),
+  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: MAX_VISIBLE_TOASTS })]),
 ) as Record<Placement, ToastQueue>
 
 const linuxQueues = Object.fromEntries(
-  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: 3, wrapUpdate: fn => fn() })]),
+  placements.map(p => [p, new ToastQueue({ maxVisibleToasts: MAX_VISIBLE_TOASTS, wrapUpdate: fn => fn() })]),
 ) as Record<Placement, ToastQueue>
 
 export const activeQueues = navigator.platform.toLowerCase().includes('linux')
@@ -37,6 +43,29 @@ export const activeQueues = navigator.platform.toLowerCase().includes('linux')
 
 const toastContents = new Map<string, ToastContentValue>()
 const placementsKeys = new Map<string, Placement>()
+/**
+ * 每个 placement 的存活 key（按创建顺序，旧→新）。stately queue 对超出
+ * maxVisibleToasts 的条目只做「窗口外排队、等旧条目关闭后复现」，常驻
+ * （timeout: 0）气泡会无限积压并在旧气泡关闭时复现；这里在新 toast 入队后
+ * 直接关闭最旧的条目，保证任何时刻只存在最新的 MAX_VISIBLE_TOASTS 条。
+ */
+const placementOrder = new Map<Placement, string[]>()
+
+function forgetKey(key: string): void {
+  toastContents.delete(key)
+  const placement = placementsKeys.get(key)
+  placementsKeys.delete(key)
+  if (placement === undefined)
+    return
+  const order = placementOrder.get(placement)
+  if (order === undefined)
+    return
+  const index = order.indexOf(key)
+  if (index >= 0)
+    order.splice(index, 1)
+  if (order.length === 0)
+    placementOrder.delete(placement)
+}
 
 /**
  * 统一 toast API：直接调用创建，toast.update/close/clear 通过 key 管理。
@@ -47,18 +76,26 @@ export const toast = Object.assign(
   (message: string | ReactNode, options?: ToastOptions) => {
     // 默认右下角；个别调用方需要其他位置时显式传 placement
     const { placement = 'bottom end', timeout, onClose, ...rest } = options || {}
-    let key = ''
     const content = { title: message, ...rest }
-    key = activeQueues[placement].add(content, {
+    const key = activeQueues[placement].add(content, {
       timeout,
       onClose: () => {
-        toastContents.delete(key)
-        placementsKeys.delete(key)
+        // 自动超时 / 用户关闭 / 外部 close 都会走到这里（HeroUI 包了一层 rAF 异步）
+        forgetKey(key)
         onClose?.()
       },
     })
     toastContents.set(key, content)
     placementsKeys.set(key, placement)
+    const order = placementOrder.get(placement) ?? []
+    order.push(key)
+    placementOrder.set(placement, order)
+    // 丢弃超出上限的最旧条目（含 rAF 清理延迟期内的死 key），维持「仅最新 N 条」
+    while (order.length > MAX_VISIBLE_TOASTS) {
+      const oldest = order.shift()
+      if (oldest !== undefined)
+        activeQueues[placement].close(oldest)
+    }
     return key
   },
   {
@@ -71,15 +108,20 @@ export const toast = Object.assign(
 
     close(key: string): void {
       const placement = placementsKeys.get(key)
-      if (placement)
+      if (placement) {
         activeQueues[placement].close(key)
-      else
+        // onClose 是 rAF 异步回调，这里同步清理登记，紧随其后的 add 不会把死 key 计入限额
+        forgetKey(key)
+      }
+      else {
         toastContents.delete(key)
+      }
     },
 
     clear(): void {
       toastContents.clear()
       placementsKeys.clear()
+      placementOrder.clear()
       placements.forEach(p => activeQueues[p].clear())
     },
   },


### PR DESCRIPTION
## 概要

宠物气泡从「只显示思考中」升级为显示会话正在做什么；Toast 渲染收敛为仅最新三条；正文最多两行。

### 1. 宠物气泡实时活动

数据流：插件折叠会话事件窗口 → `liveActivity` 字段随会话快照推送 → 宠物端映射为中文标签。

- **`packages/dsh-tauri-pet/src/client/utils/activity.ts`（新增）**：`foldSessionActivity(entries)` 按时间正序折叠 `MutableSessionEventSource` 事件窗口——`tool/call` 记录进行中调用（callId→name/args），`tool/result` 按 `message.source.callId` 关闭，`assistant/chunk` 的 `reasoning-delta` 累积为思考尾部（保留末 160 字符），`block-end` / `step/start` / `turn/end` 边界清场；进行中的工具调用优先于思考流，无活动返回 `null`。事件形状对照已安装运行时（@deepseek-ai/dsh 0.1.2-rc.1 的 dsh-agent-loop / dsh-llm）核实。
- **`packages/dsh-tauri-pet/src/client/service/activity.ts`**：按会话探测并订阅 `binding.eventSource`；流式 delta 逐 token 触发，按会话 300ms trailing 节流（突发只推送一帧，到期按当前窗口整体重算）；折叠结果以 `liveActivity` 并入快照 payload（`null` 也是有效值，清除过期展示）。alpha 运行时缺失事件窗口时**整体退级为原纯快照转发**，不半工作。
- **`src/pet/hooks/use-bubble.ts`**：运行中显示 `思考 · [最新思考片段]` / `Pwsh · [命令]` / `编辑 · [文件]` / `工具调用 · [工具名]`（shell 取 `args.command`、str_replace_editor 取 `args.path`、fs 类取 `args.file_path`），无活动数据时回退「思考中」。同时修复：气泡被 toast 层丢弃后仅状态跃迁才重建，避免与下方第 2 条的丢弃逻辑在 250ms 心跳下互相触发形成关闭-重建循环。

### 2. Toast 仅保留最新三条

`src/utils/toast.ts`：HeroUI 的 `maxVisibleToasts: 3` 只是「可见 3 条 + 其余窗口外排队、旧条目关闭后复现」，宠物常驻气泡（timeout: 0）会无限积压。现在每个 placement 维护存活 key 顺序表，入队后超出 3 条即关闭最旧的（同步清理登记，覆盖 onClose 的 rAF 延迟期）。

### 3. Toast 正文最多两行

`[data-slot='toast-description']` 加 `-webkit-line-clamp: 2`，同时写入 `src/style/main.css`（主窗口，HeroUI 默认渲染）与 `src/pet/main.css`（宠物窗口）——两个渲染路径都带该 data-slot。

## 验证

- `pnpm run lint --fix`：0 errors（22 warnings 均为其他包预存）
- `pnpm run typecheck`、`pnpm --filter dsh-tauri-pet typecheck`：通过
- `pnpm run test -- --run`：35 文件 / 247 测试全过（含新增 `activity.test.ts` 8 例）
- `pnpm run build`（prebuild 部署插件 → tsc → vite）：通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added real-time session activity updates for reasoning and tool usage.
  - Running-session notifications now show live activity details, including tool names and command or file information when available.

- **Bug Fixes**
  - Prevented repeated notification close-and-recreate cycles caused by identical heartbeat updates.
  - Improved activity tracking across steps, turns, and completed tool calls.
  - Fixed ad hoc animations so click and idle-interruption animations finish correctly.

- **Style**
  - Limited notification descriptions to two lines with overflow handling.
  - Capped visible notifications at three and improved ordering as notifications open and close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->