### PR TITLE
fix(pet): open session event stream for unselected subagent sessions

### DIFF
--- a/packages/dsh-tauri-pet/src/client/service/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/service/activity.ts
@@ -23,6 +23,7 @@ interface RawSessionBinding {
   session: {
     getSnapshot: () => unknown
     subscribe: (listener: () => void) => () => void
+    open?: () => Promise<unknown>
   }
 }
 
@@ -103,6 +104,15 @@ export function installPetSessionForwarder(ctx: ClientContext): void {
           emit('update', snapshotOf(id, binding))
         }, PET_ACTIVITY_THROTTLE_MS)
       }))
+      // dsh 只在会话被选中（open）时才建立事件流；子代理等未选中会话的
+      // 窗口保持空窗，折叠恒为 null。主动打开会话流（幂等，UI 已开的会话
+      // 直接返回），让任何选中状态下的事件都能进入窗口并触发上面的订阅。
+      if (typeof binding.session.open === 'function') {
+        void binding.session.open().catch((error: unknown) => {
+          if (!disposed)
+            console.warn(`[dsh-tauri-pet] open event stream for ${id} failed:`, error)
+        })
+      }
       watch.disposers.push(() => {
         if (watch.activityTimer !== undefined) {
           globalThis.clearTimeout(watch.activityTimer)


### PR DESCRIPTION
## 问题

PR #391 合入后父会话气泡能显示实时活动，但子代理会话只显示「思考中」。

**根因**：dsh 客户端只为被选中（open）的会话建立事件流（\SessionEventStream\，见 \dsh-api-session-controller/.../client/sessions/session.js\ 的 \doOpen\/\cceptEventChange\）。子代理会话默认从未被 open，事件窗口保持空窗，\oldSessionActivity\ 恒为 \
ull\ → \liveActivity: null\ → 气泡回退到「思考中」。

## 修复

\packages/dsh-tauri-pet/src/client/service/activity.ts\：attach 事件源时强制调用 \inding.session.open()\（官方公开 API，幂等——UI 已打开的会话立即 resolve，无副作用）。事件流建立后窗口经 replace/append 填充并发布，插件已有的订阅自动折叠出新活动，与选中状态无关。

## 验证

- \pnpm run lint --fix\：0 errors
- \pnpm --filter dsh-tauri-pet typecheck\ / 根 \pnpm run typecheck\：通过
- \pnpm run test -- --run\：35 files / 251 tests 全绿
- \pnpm run build\：通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event streams now open automatically when an event source is attached.
  * Failures while opening event streams are logged while existing subscriptions and throttling continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->