### PR TITLE
fix(pet-mouse): macOS CGEventTap 直监听，绕开 rdev 0.5.3 的 SIGTRAP

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -911,6 +911,8 @@ dependencies = [
  "async-trait",
  "auto-launch",
  "base64 0.22.1",
+ "core-foundation 0.9.4",
+ "core-graphics 0.25.0",
  "dunce",
  "flate2",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,6 +75,12 @@ objc2-foundation = { version = "=0.3.2", default-features = false, features = [
   "NSObject",
   "NSProcessInfo",
 ] }
+# CGEventTap 直监听：绕开 rdev 0.5.3 在 macOS 上对 KeyPress 事件无条件调
+# TSMGetInputSourceProperty（必须 main queue）导致的 dispatch_assert_queue SIGTRAP。
+# 见 issue #397。core-graphics / core-foundation 在 rdev 传递依赖里已有，
+# 不引入新的下载源。
+core-graphics = "0.25"
+core-foundation = "0.9"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/desktop/pet_mouse.rs
+++ b/src-tauri/src/desktop/pet_mouse.rs
@@ -143,7 +143,15 @@ fn listen_mouse_macos(store: Arc<Mutex<Option<MouseCursorPos>>>) -> Result<(), S
         CGEventTapOptions::ListenOnly,
         MACOS_MOUSE_EVENTS.to_vec(),
         move |_proxy, event_type, event| {
-            if matches!(event_type, CGEventType::MouseMoved) {
+            // 所有 MACOS_MOUSE_EVENTS 中带位置语义的类型都要更新光标位置。
+            // ScrollWheel 是滚轮 delta 没有位置，跳过。
+            if matches!(
+                event_type,
+                CGEventType::MouseMoved
+                    | CGEventType::LeftMouseDragged
+                    | CGEventType::RightMouseDragged
+                    | CGEventType::OtherMouseDragged
+            ) {
                 let point = event.location();
                 *store.lock().expect("pet mouse store poisoned") = Some(MouseCursorPos {
                     x: point.x,

--- a/src-tauri/src/desktop/pet_mouse.rs
+++ b/src-tauri/src/desktop/pet_mouse.rs
@@ -7,19 +7,29 @@
 //! （tauri issue #6164：官方 forward 选项一直未实现）。
 //!
 //! 解决方案（参考 Xinyu-Li-123/tauri-clickthrough-demo 与
-//! codecnmc/tauri2-transparent-through）：用 rdev 低级全局钩子（Windows
-//! `WH_MOUSE_LL`）在独立线程监听系统级鼠标移动，把物理像素光标坐标限频
-//! 通过 `device-mouse-move` 事件发给前端；前端用命中区（窗口尺寸固定百分比）
-//! 判定光标是否落在可交互区域，据此翻转 `setIgnoreCursorEvents`，
-//! 穿透态下同样能感知光标位置，死锁解除。
+//! codecnmc/tauri2-transparent-through）：用系统级全局钩子在独立线程监听鼠标
+//! 移动，把物理像素光标坐标限频通过 `device-mouse-move` 事件发给前端；前端用
+//! 命中区（窗口尺寸固定百分比）判定光标是否落在可交互区域，据此翻转
+//! `setIgnoreCursorEvents`，穿透态下同样能感知光标位置，死锁解除。
 //!
-//! 性能：rdev 事件频率取决于鼠标报告率（125Hz–1000Hz），这里做两级收敛——
-//! 监听线程只把最新坐标写入共享槽（覆盖不积压，回调不阻塞钩子）；节流线程
-//! 每 16ms 读取一次，坐标有变化才 emit（鼠标静止时零事件）。
+//! 性能：事件频率取决于鼠标报告率（125Hz–1000Hz），这里做两级收敛——监听线程
+//! 只把最新坐标写入共享槽（覆盖不积压，回调不阻塞钩子）；节流线程每 16ms
+//! 读取一次，坐标有变化才 emit（鼠标静止时零事件）。
 //!
 //! 生命周期：鼠标流由前端 `start_pet_mouse_stream` 命令幂等启动，线程随进程
-//! 常驻（rdev::listen 为阻塞式，无停止 API）；桌宠隐藏时前端不再检查命中，
-//! 线程开销可忽略。
+//! 常驻（监听 API 为阻塞式，无停止 API）；桌宠隐藏时前端不再检查命中，线程
+//! 开销可忽略。
+//!
+//! # 平台差异
+//!
+//! - **macOS**：用 `core-graphics` 的 `CGEventTap` 直接监听 mouse 事件。**不能**
+//!   使用 `rdev`，因为 rdev 0.5.3 的 macOS 后端在 `CGEvent` 回调里对**所有**
+//!   `KeyPress` 事件无条件调 `TSMGetInputSourceProperty`（HIToolbox API，必须
+//!   在 main queue 上调用），而 rdev 在自己的后台线程上跑 `CFRunLoopRun`，触发
+//!   `_dispatch_assert_queue_fail` → SIGTRAP。按单独 Cmd / Option / Control 键
+//!   会发出 `FlagsChanged` 事件并经 rdev 转为 `KeyPress`，导致 100% 崩溃（issue
+//!   #397）。只订阅 mouse 事件彻底绕开 TSM 路径。
+//! - **Windows / Linux**：用 `rdev::listen`（这两平台 rdev 不调 TSM，无此 bug）。
 
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -33,13 +43,26 @@ pub const PET_MOUSE_MOVE_EVENT: &str = "device-mouse-move";
 /// 节流间隔（16ms ≈ 60FPS）：光标自身刷新率远超此频率，超出部分无意义。
 const THROTTLE_INTERVAL: Duration = Duration::from_millis(16);
 
+/// macOS CGEventTap 只订阅的鼠标事件类型。**显式排除** KeyDown / KeyUp /
+/// FlagsChanged，彻底切断 rdev 0.5.3 触发 `TSMGetInputSourceProperty`
+/// （HIToolbox，必须 main queue）导致的 `dispatch_assert_queue` SIGTRAP
+/// 崩溃链（issue #397）。
+#[cfg(target_os = "macos")]
+const MACOS_MOUSE_EVENTS: &[core_graphics::event::CGEventType] = &[
+    core_graphics::event::CGEventType::MouseMoved,
+    core_graphics::event::CGEventType::LeftMouseDragged,
+    core_graphics::event::CGEventType::RightMouseDragged,
+    core_graphics::event::CGEventType::ScrollWheel,
+    core_graphics::event::CGEventType::OtherMouseDragged,
+];
+
 /// 全局鼠标流的进程级状态（幂等启动标记）。
 #[derive(Default)]
 pub struct PetMouseStreamState {
     started: Arc<AtomicBool>,
 }
 
-/// 物理像素的光标位置（rdev 坐标为虚拟屏幕全局坐标，副屏可含负值）。
+/// 物理像素的光标位置（CGEvent 坐标为虚拟屏幕全局坐标，副屏可含负值）。
 #[derive(Serialize, Clone, Copy, PartialEq)]
 struct MouseCursorPos {
     x: f64,
@@ -56,16 +79,11 @@ pub fn start_pet_mouse_stream(window: WebviewWindow, state: State<'_, PetMouseSt
     let started_on_error = state.started.clone();
     let latest: Arc<Mutex<Option<MouseCursorPos>>> = Arc::default();
 
-    // 监听线程：rdev::listen 为阻塞式，回调只写最新坐标，不做任何 IO。
+    // 监听线程：只把最新坐标写入共享槽，不做任何 IO。
     let store = latest.clone();
     thread::spawn(move || {
-        let callback = move |event: rdev::Event| {
-            if let rdev::EventType::MouseMove { x, y } = event.event_type {
-                *store.lock().expect("pet mouse store poisoned") = Some(MouseCursorPos { x, y });
-            }
-        };
-        if let Err(error) = rdev::listen(callback) {
-            log::error!("[pet-mouse] rdev listen failed: {error:?}");
+        if let Err(error) = listen_mouse(store.clone()) {
+            log::error!("[pet-mouse] mouse listen failed: {error:?}");
             started_on_error.store(false, Ordering::SeqCst);
         }
     });
@@ -85,4 +103,94 @@ pub fn start_pet_mouse_stream(window: WebviewWindow, state: State<'_, PetMouseSt
             thread::sleep(THROTTLE_INTERVAL);
         }
     });
+}
+
+/// 平台分发：macOS 走 CGEventTap，其它平台走 rdev。
+fn listen_mouse(store: Arc<Mutex<Option<MouseCursorPos>>>) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        listen_mouse_macos(store)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        listen_mouse_rdev(store)
+    }
+}
+
+/// rdev 监听（Windows / Linux）。
+#[cfg(not(target_os = "macos"))]
+fn listen_mouse_rdev(store: Arc<Mutex<Option<MouseCursorPos>>>) -> Result<(), String> {
+    let callback = move |event: rdev::Event| {
+        if let rdev::EventType::MouseMove { x, y } = event.event_type {
+            *store.lock().expect("pet mouse store poisoned") = Some(MouseCursorPos { x, y });
+        }
+    };
+    rdev::listen(callback).map_err(|e| format!("rdev::listen: {e:?}"))
+}
+
+/// macOS CGEventTap 监听 mouse 事件（绕过 rdev 的 keyboard/TSM 路径，issue #397）。
+#[cfg(target_os = "macos")]
+fn listen_mouse_macos(store: Arc<Mutex<Option<MouseCursorPos>>>) -> Result<(), String> {
+    use core_foundation::runloop::CFRunLoop;
+    use core_graphics::event::{
+        CallbackResult, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement,
+        CGEventType,
+    };
+
+    CGEventTap::with_enabled(
+        CGEventTapLocation::HID,
+        CGEventTapPlacement::HeadInsertEventTap,
+        CGEventTapOptions::ListenOnly,
+        MACOS_MOUSE_EVENTS.to_vec(),
+        move |_proxy, event_type, event| {
+            if matches!(event_type, CGEventType::MouseMoved) {
+                let point = event.location();
+                *store.lock().expect("pet mouse store poisoned") = Some(MouseCursorPos {
+                    x: point.x,
+                    y: point.y,
+                });
+            }
+            // ListenOnly 模式：返回值会被忽略；用 Keep 表达"原样放行"语义。
+            CallbackResult::Keep
+        },
+        CFRunLoop::run_current,
+    )
+    .map_err(|()| "CGEventTap::with_enabled failed (accessibility permission denied or HID unavailable)".to_string())?;
+
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+    use core_graphics::event::CGEventType;
+
+    /// CGEventType 不实现 PartialEq，借助 `#[repr(u32)]` 转整数比较。
+    fn mask_codes() -> Vec<u32> {
+        MACOS_MOUSE_EVENTS.iter().map(|e| *e as u32).collect()
+    }
+
+    /// 防止有人将来误把 keyboard / FlagsChanged 加进 `MACOS_MOUSE_EVENTS`，
+    /// 重新触发 rdev 触发的 `TSMGetInputSourceProperty` → `dispatch_assert_queue`
+    /// SIGTRAP（issue #397）。
+    #[test]
+    fn macos_mouse_events_exclude_keyboard() {
+        let codes = mask_codes();
+        for forbidden in [
+            CGEventType::KeyDown,
+            CGEventType::KeyUp,
+            CGEventType::FlagsChanged,
+        ] {
+            assert!(
+                !codes.contains(&(forbidden as u32)),
+                "MACOS_MOUSE_EVENTS must not include {forbidden:?} (issue #397)"
+            );
+        }
+    }
+
+    /// 确认 mouse 事件主路径（`MouseMoved`）仍然在 mask 里——只测排除容易漏删。
+    #[test]
+    fn macos_mouse_events_include_mouse_moved() {
+        assert!(mask_codes().contains(&(CGEventType::MouseMoved as u32)));
+    }
 }

--- a/src/layout/components/preinstall-setup.tsx
+++ b/src/layout/components/preinstall-setup.tsx
@@ -50,13 +50,11 @@ function PluginRow({ plugin, checked, toUninstall, disabled, onToggle, onOpenRep
 }) {
   const { t } = useTranslation()
 
-
-
   return (
     <Item
       left={(
         <>
-          <Label className={`min-w-0 truncate text-sm font-medium`}>
+          <Label className="min-w-0 truncate text-sm font-medium">
             {plugin.name}
           </Label>
           <If cond={plugin.recommended && !plugin.installed && !toUninstall}>


### PR DESCRIPTION
## 问题

修复 issue #397：按单独 Cmd / Option / Control 键时 macOS 应用立即崩溃。

崩溃栈（triggering thread）：



## 根因

`rdev` 0.5.3 的 macOS 后端在 `CGEvent` 回调 `convert` 里对**所有** `KeyPress` 事件无条件调 `TSMGetInputSourceProperty`（HIToolbox API，必须在 main queue 上调用）。`FlagsChanged`（按 / 放修饰键）经 rdev 转为 `KeyPress`，但 rdev 在自己后台线程的 `CFRunLoopRun` 上跑，不在 main queue，触发 `_dispatch_assert_queue_fail` → SIGTRAP。

rdev 0.5.3 `macos/common.rs:136-144` 行为：

```rust
let name = match event_type {
    EventType::KeyPress(_) => {
        let code = cg_event.get_integer_value_field(...) as u32;
        let flags = cg_event.get_flags();
        keyboard_state.create_string_for_key(code, flags)   // 触发 TSM API
    }
    _ => None,
};
```

## 修复

macOS 端不再走 rdev，改用 `core-graphics` 的 `CGEventTap::with_enabled` 直监听，event mask 显式只列 mouse 事件，**根本不让 keyboard 事件进 CGEventTap**，彻底切掉 TSM 路径。Windows / Linux 保留 `rdev::listen`（这俩平台 rdev 不调 TSM，无此 bug）。

```rust
const MACOS_MOUSE_EVENTS: &[CGEventType] = &[
    CGEventType::MouseMoved,
    CGEventType::LeftMouseDragged,
    CGEventType::RightMouseDragged,
    CGEventType::ScrollWheel,
    CGEventType::OtherMouseDragged,
];

CGEventTap::with_enabled(
    CGEventTapLocation::HID,
    CGEventTapPlacement::HeadInsertEventTap,
    CGEventTapOptions::ListenOnly,
    MACOS_MOUSE_EVENTS.to_vec(),
    callback,
    CFRunLoop::run_current,
)?;
```

共享 `Arc<Mutex<Option<MouseCursorPos>>>` 槽位和 16ms 节流 emit 线程全部复用。`start_pet_mouse_stream` 命令签名 / builder 注册 / 前端事件名 `device-mouse-move` 全部不变。

## 改动

| 文件 | 改动 |
| --- | --- |
| `src-tauri/Cargo.toml` | 新增 macOS-only 依赖 `core-graphics = "0.25"`、`core-foundation = "0.9"` |
| `src-tauri/Cargo.lock` | 仅更新顶层依赖声明（已在 lockfile 间接存在，零新下载源） |
| `src-tauri/src/desktop/pet_mouse.rs` | 提取 `MACOS_MOUSE_EVENTS` 常量；新增 macOS 端 `listen_mouse_macos`；保留非 macOS 端 `listen_mouse_rdev`；2 个 regression 测试 |
| `src-layout/components/preinstall-setup.tsx` | 顺手修 rebase 上游后浮出的 2 个 lint 错误（多空行 + 模板字面量）——见下方 Out of Scope 说明 |

## 测试

- `cargo test --lib`：**471 passed**（2 个新增 pet_mouse regression 测试）
  - `macos_mouse_events_exclude_keyboard`：保护 KeyDown / KeyUp / FlagsChanged 不会进 mask
  - `macos_mouse_events_include_mouse_moved`：保护主路径不漏删
- `pnpm typecheck`：pass
- `pnpm lint`：**0 errors / 25 warnings**（warnings 全是 pre-existing jsdoc multiline-blocks，与本 PR 无关）
- `pnpm test`：254/254
- 本机实测：`pnpm tauri build` → `cp` 到 `/Applications/Deepseek Harness Desktop.app` → 按 Cmd / Option / Control 各 10 次 → 应用不再崩溃

## Out of Scope

- `preinstall-setup.tsx` 的 lint 修复：这是 rebase 上游 main 后浮出的 pre-existing 问题（与 issue #397 无关）。本 PR 里**故意**带上，因为上游 main 一旦有变更，CI 的 Frontend job 就会因此 fail；想保持 CI 全绿必须带这个 rebase cleanup。
- 不修复 rdev 上游 `convert` bug（那是 `rdev-0.5.3` 维护者的责任）。
- 不升级 rdev 版本（如果上游已修，会单独走一个 dep bump PR）。
- 不动 `desktop/builder.rs` 和 `desktop/mod.rs`（模块签名不变）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS mouse-tracking stability by preventing crashes associated with keyboard event handling.
  * Preserved mouse movement and drag tracking across macOS, Windows, and Linux.
  * Excluded keyboard and scroll-wheel events from macOS mouse monitoring.
* **Refactor**
  * Simplified an internal setup label declaration without changing its appearance or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->