### PR TITLE
fix(pet): 未安装的默认预设宠物显示下载入口与可见提示

### DIFF
--- a/packages/dsh-tauri-pet/src/client/utils/preset-card.test.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/preset-card.test.ts
@@ -10,9 +10,12 @@ type PresetDownloadPhase = 'idle' | 'downloading' | 'extracting' | 'done' | 'fai
 describe('resolvePresetCardAction', () => {
   const maid = { id: 'maid-deepseek-whale', installed: false, phase: 'idle' as const }
 
-  it('已选优先于下载/启用状态', () => {
-    expect(resolvePresetCardAction(maid, 'maid-deepseek-whale', progress('downloading'))).toBe('selected')
+  it('已选仅限已安装的当前宠物；未安装的当前宠物（默认预设）给出下载入口', () => {
+    // 内置归一 id 与预设卡 id 相同：新装环境默认宠物未下载，卡片不能显示已选（issue #401）。
+    expect(resolvePresetCardAction(maid, 'maid-deepseek-whale', progress('downloading'))).toBe('downloading')
+    expect(resolvePresetCardAction(maid, 'maid-deepseek-whale', null)).toBe('download')
     expect(resolvePresetCardAction({ ...maid, installed: true }, 'maid-deepseek-whale', null)).toBe('selected')
+    expect(resolvePresetCardAction({ ...maid, installed: true }, 'maid-deepseek-whale', progress('downloading'))).toBe('selected')
   })
 
   it('下载/解压中显示 downloading，不因已安装而跳到 enable', () => {

--- a/packages/dsh-tauri-pet/src/client/utils/preset-card.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/preset-card.ts
@@ -6,6 +6,10 @@ import type { PresetDownloadProgress, PresetPetItem } from '../types'
  * 优先级：已选（selected）> 下载/解压中（downloading）> 已安装（enable）>
  * 未安装（download）。与设置页 `presetCardAction` 一一对应。
  *
+ * 已选必须同时满足「已安装且为当前激活宠物」：内置归一 id（maid-deepseek-whale）
+ * 与预设卡 id 相同，新装环境 active_pet 归一为内置 id 但产物尚未下载，此时卡片
+ * 必须给出下载入口，而不是显示已选禁用（issue #401）。
+ *
  * 下载中状态有两个来源：`progress.phase`（进行中的轮询快照）与 `item.phase`
  * （`list_preset_pets` 返回的进程内注册表阶段，跨挂载恢复下载中视图用——组件
  * 卸载后重进设置页时，轮询未启动、`progress` 为 null，但清单已带 phase）。
@@ -15,7 +19,7 @@ export function resolvePresetCardAction(
   active: string,
   progress: PresetDownloadProgress | null | undefined,
 ): 'download' | 'downloading' | 'enable' | 'selected' {
-  if (item.id === active)
+  if (item.installed && item.id === active)
     return 'selected'
   const phase = progress?.phase ?? item.phase
   if (phase === 'downloading' || phase === 'extracting')

--- a/src/pet/components/pet.tsx
+++ b/src/pet/components/pet.tsx
@@ -16,6 +16,10 @@ import {
 } from '../pet-config'
 
 const BUILT_IN_PET_ID = 'maid-deepseek-whale'
+/** 默认预设宠物未安装时的提示文案：桌宠窗口无 i18n 基础设施（气泡文案同样硬编码），按窗口语言就近显示。 */
+const PRESET_MISSING_HINT = (document.documentElement.lang || navigator.language || 'zh-CN').toLowerCase().startsWith('zh')
+  ? '预设宠物未安装，请在设置中下载'
+  : 'Preset pet not installed. Download it in Settings.'
 const PET_BASE_WIDTH = 220
 const PET_DEFAULT_SIZE_PERCENT = 100
 const PET_SIZE_MIN_PERCENT = 50
@@ -107,6 +111,8 @@ export function Pet(props: PetProps) {
     pet: string
     config: PetConfig | null
     assets: Record<string, string>
+    /** 预设资源拉取失败的错误信息（如 PET_PRESET_NOT_INSTALLED）；null = 成功。 */
+    error: string | null
   } | null>(null)
   const [reducedMotion, setReducedMotion] = useState(() => globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false)
   const videoARef = useRef<HTMLVideoElement | null>(null)
@@ -127,13 +133,17 @@ export function Pet(props: PetProps) {
   const isPreset = !activePet.includes(':')
   // 预设宠物资源按当前激活宠物生效：切换宠物时旧资源保持到新 fetch 完成，避免闪烁。
   // 统一 memo 成稳定的 config/assets 引用，避免每次渲染产生新对象导致视频 effect 重跑。
-  const { config, assets } = useMemo(() => {
+  const { config, assets, error } = useMemo(() => {
     const preset = petResources !== null && petResources.pet === activePet ? petResources : null
     return {
       config: preset?.config ?? null,
       assets: preset?.assets ?? {},
+      error: preset?.error ?? null,
     }
   }, [activePet, petResources])
+  // 默认预设宠物未安装（新装环境 active_pet 归一为内置 id，但产物需手动下载）：
+  // 资源拉取失败时视频层静默空白，这里给出可见提示引导去设置页下载（issue #401）。
+  const presetMissing = isPreset && error?.includes('PET_PRESET_NOT_INSTALLED') === true
   // 预设宠物配置驱动动画池：池条目是动画名（webm 文件名主名，如 待机呼吸休闲），
   // 点击/拖拽/待机链按名字从 assets map 取 URL。配置缺失或命令失败时回落与旧
   // 实现一致的默认池（idle/turn/wave），这些名字在 assets 中不存在时自然不播放。
@@ -204,20 +214,23 @@ export function Pet(props: PetProps) {
     if (isPreset === false)
       return undefined
     let disposed = false
+    let loadError: string | null = null
     void Promise.all([
       invoke<PetConfig>('get_preset_pet_config', { id: activePet }).catch((error) => {
         console.warn('[pet] PET_PRESET_CONFIG_LOAD_FAILED:', error)
+        loadError ??= String(error)
         return null
       }),
       invoke<{ assets?: Record<string, string> }>('get_preset_pet_assets', { id: activePet }).catch((error) => {
         console.warn('[pet] PET_PRESET_ASSETS_LOAD_FAILED:', error)
+        loadError ??= String(error)
         return { assets: {} }
       }),
     ]).then(([config, value]) => {
       if (disposed)
         return
       // 一起提交，避免 config 与 assets 不同步导致短暂按旧池解析。
-      setPetResources({ pet: activePet, config, assets: value.assets ?? {} })
+      setPetResources({ pet: activePet, config, assets: value.assets ?? {}, error: loadError })
     })
     return () => {
       disposed = true
@@ -551,6 +564,14 @@ export function Pet(props: PetProps) {
           className="pointer-events-auto absolute cursor-grab touch-none select-none"
           style={PET_HIT_BOX}
         />
+        <If cond={presetMissing}>
+          {/* 预设宠物未安装：视频层无可播放资产会静默空白，用可见提示引导去设置页下载（issue #401）。 */}
+          <div className="pointer-events-none absolute inset-x-0 bottom-full mb-2 flex justify-center select-none">
+            <div className="max-w-[95%] rounded-lg bg-black/60 px-3 py-1.5 text-center text-xs leading-relaxed text-white">
+              {PRESET_MISSING_HINT}
+            </div>
+          </div>
+        </If>
       </div>
     </main>
   )


### PR DESCRIPTION
Fix #401 — 新装环境下默认预设宠物（内置归一 id 与预设卡 id 相同）未下载时：

- **设置页**：esolvePresetCardAction 的 selected 分支增加 installed 条件。未安装的当前宠物（如默认 whale）不再显示「已选」禁用按钮，而是给出「下载」入口；「已选」仅限已安装的当前宠物。
- **桌宠窗口**：预设资源拉取返回 PET_PRESET_NOT_INSTALLED 时显示可见提示（按窗口语言显示中/英文），引导去设置页下载，避免动画区静默空白。
- 同步更新 preset-card.test.ts 断言。

本地已通过：vitest 96/96、	sc --noEmit、eslint（0 errors）、pnpm build:plugins。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Presets that are active but not installed now correctly appear as downloadable rather than selected.
  - Download progress is shown for presets currently being installed.
  - Added localized guidance prompting users to download missing preset resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->