### PR TITLE
fix(pet): 延后桌宠点击穿透，规避 Linux/Wayland 启动崩溃 (issue #394)

### DIFF
--- a/src/pet/hooks/use-omit-ignore-cursor-events.ts
+++ b/src/pet/hooks/use-omit-ignore-cursor-events.ts
@@ -15,12 +15,24 @@ interface DeviceMousePosition {
  * 穿透后 WebView 不再收到 mouseenter/mouseleave，因此通过 Rust 端 rdev
  * 全局鼠标流获取设备像素坐标，再与元素的 DOMRect 命中区比较。调用方只需
  * 传入可交互元素的 ref，不需要管理启动监听、窗口移动、缩放或穿透状态。
+ *
+ * # 兼容性（issue #394）
+ *
+ * 初始整体穿透**不**在挂载时急切调用 `setIgnoreCursorEvents(true)`：Linux /
+ * Wayland 下窗口是异步 realize 的，挂载时 GDK 窗口实体可能尚未建立，tao
+ * 0.35.3 收到 `CursorIgnoreEvents` 请求会走 `window.window().unwrap()` →
+ * panic 崩掉整个事件循环。改为延后到首个 `device-mouse-move` 事件（此时窗口
+ * 已 realize、事件循环健康）再按命中区计算应用，与 BongoCat 只在鼠标移动回调
+ * 里才 `setIgnoreCursorEvents` 的做法一致。
  */
 export function useOmitIgnoreCursorEvents(elementRef: RefObject<HTMLElement | null>): void {
   useEffect(() => {
     const appWindow = getCurrentWindow()
     let disposed = false
-    let isIgnored = true
+    // 初始为 false 以对齐真实 OS 状态（窗口创建后默认不穿透）：我们不再在挂载
+    // 时急切开启穿透（见函数上方的 #394 说明），穿透态由首个 device-mouse-move
+    // 事件按命中区计算后应用。
+    let isIgnored = false
     let windowPosition: { x: number, y: number } | undefined
     let geometryRevision = 0
     let unlistenMouseMove: (() => void) | undefined
@@ -55,8 +67,9 @@ export function useOmitIgnoreCursorEvents(elementRef: RefObject<HTMLElement | nu
       return x >= left && x <= left + width && y >= top && y <= top + height
     }
 
-    // 初始整窗穿透；穿透态下交互恢复完全由全局鼠标流驱动。
-    void appWindow.setIgnoreCursorEvents(true).catch(() => {})
+    // 初始整窗穿透延后应用（见上方 #394 说明）：这里只启动鼠标流与窗口几何追踪，
+    // 首个 device-mouse-move 事件到来后再按命中区决定穿透态，避免挂载即调用
+    // setIgnoreCursorEvents 触发 tao 在未 realize 窗口上的 unwrap（issue #394）。
     void invoke('start_pet_mouse_stream').catch(() => {})
     void refreshWindowPosition()
 
@@ -67,6 +80,10 @@ export function useOmitIgnoreCursorEvents(elementRef: RefObject<HTMLElement | nu
       void refreshWindowPosition()
     })
     const mouseMovePromise = listen<DeviceMousePosition>('device-mouse-move', ({ payload }) => {
+      // 挂载时的位置刷新是异步的，首个事件到来时可能还没拿到窗口坐标；补拉一次，
+      // 让初始命中判定尽快给出明确结果，由此把初始穿透态一次应用到位。
+      if (windowPosition === undefined)
+        void refreshWindowPosition()
       const inElement = isCursorInElement(payload.x, payload.y)
       if (inElement !== undefined)
         setIgnoreCursorEvents(!inElement)


### PR DESCRIPTION
- issue: #394

## 问题
桌宠窗口在 Linux/Wayland 下启动即崩溃。日志在插件重装后出现：
`thread 'main' panicked at tao-0.35.3/.../event_loop.rs:457: called Option::unwrap() on a None value`。

## 根因
`src/pet/hooks/use-omit-ignore-cursor-events.ts` 在窗口挂载时**急切**调用
`appWindow.setIgnoreCursorEvents(true)`，投递 tao 的 `WindowRequest::CursorIgnoreEvents`。
Linux/Wayland 下窗口是**异步 realize** 的，挂载时 GDK 窗口实体可能尚未建立，
tao 0.35.3 在该请求分支走 `window.window().unwrap()`；当 `GtkWindow::window()` 返回 None 时
触发 unwind panic，进而崩掉整个事件循环（SIGABRT）。

## 修复
参照 BongoCat（`src/composables/useDevice.ts`：只在鼠标移动回调里才
`setIgnoreCursorEvents`），改为**延后应用**：
- 挂载时不再急切调用 `setIgnoreCursorEvents(true)`；
- 穿透态由**首个 `device-mouse-move` 事件**按命中区计算后应用（此时窗口已 realize、
  事件循环健康，再发起请求即安全）；
- 初始 `isIgnored` 对齐真实 OS 状态（false），避免守卫与真实状态失联；
- 首个事件若仍未拿到窗口坐标则**补拉一次 `refreshWindowPosition()`**，让初始命中判定尽快收敛。

仅改动 `src/pet/hooks/use-omit-ignore-cursor-events.ts`。

## 关于 #397（macOS 修饰键崩溃）
#397 已由 PR #398（macOS 用 CGEventTap 直监听鼠标，绕开 rdev 0.5.3 的
TSMGetInputSourceProperty → dispatch_assert_queue SIGTRAP）修复并合入，本次**保持
该鼠标-only 方案不变**，未改动 Cargo.toml / pet_mouse.rs。

## 验证
- 改动文件 `eslint` 通过；
- 全量 `pnpm typecheck` 的报错均位于 `packages/dsh-tauri-*`（worktree 未构建内部包导致的
  模块类型声明缺失，TS2307/TS7006），与本次改动无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor and click-through behavior during window startup.
  * The window now waits for the first mouse movement before applying cursor-ignore behavior, helping ensure accurate hit testing.
  * Improved compatibility with Linux and Wayland environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->