### PR TITLE
fix(pet|invoke): 停止高频转发未变化会话状态并清理 invoke 超时

### DIFF
--- a/packages/dsh-tauri-pet/src/client/constants/index.ts
+++ b/packages/dsh-tauri-pet/src/client/constants/index.ts
@@ -43,6 +43,8 @@ export const PET_SIZE_STEP = 5
 
 /** 实时活动折叠：流式 delta 事件逐 token 触发，按会话做 trailing 节流合并推送。 */
 export const PET_ACTIVITY_THROTTLE_MS = 300
+/** 会话快照转发合并节流：多个会话的更新事件一次突发只触发一次批量 flush，避免背压。 */
+export const PET_SESSION_UPDATE_THROTTLE_MS = 100
 /** 思考文本只保留尾部窗口：展示「最新思考内容」，同时限制跨窗口传输体积。 */
 export const PET_REASONING_TAIL_LENGTH = 160
 /** 流式累积的工具参数最大长度：tool/call 离散事件随后会携带完整 arguments 替换，截断只影响 streaming 期间的一瞬展示。 */

--- a/packages/dsh-tauri-pet/src/client/service/activity.test.ts
+++ b/packages/dsh-tauri-pet/src/client/service/activity.test.ts
@@ -1,0 +1,302 @@
+import type { SessionLiveActivity } from '../types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerPetSessionForwarder } from './activity'
+
+/**
+ * 可变的 mock 状态（vi.mock 工厂被提升到文件顶部，只能引用 vi.hoisted 返回的容器）。
+ * petState.status 控制 fetchPetStatus 返回值；storeState.status 控制 getPetUiSnapshot
+ * 返回值（活动转发引擎的 enabled 门控来源）。
+ */
+const h = vi.hoisted(() => {
+  const storeState = {
+    listeners: [] as Array<() => void>,
+    status: null as { enabled: boolean, active_pet: string, visible: boolean } | null,
+  }
+  const petState = {
+    pushed: [] as Array<{ action: string, session: unknown }>,
+    status: { enabled: true, active_pet: 'maid', visible: true },
+  }
+  return { storeState, petState }
+})
+
+vi.mock('../store', () => ({
+  subscribePetUi: (listener: () => void) => {
+    h.storeState.listeners.push(listener)
+    return () => {
+      const i = h.storeState.listeners.indexOf(listener)
+      if (i >= 0)
+        h.storeState.listeners.splice(i, 1)
+    }
+  },
+  getPetUiSnapshot: () => ({ status: h.storeState.status }),
+  beginPetStatusFetch: () => 1,
+  commitPetStatusFetch: () => true,
+}))
+
+// dsh-tauri/client 的 dist 在模块顶层引用 window（桌面 iframe 环境中存在），node 测试环境
+// 无法加载。这里 mock 掉它，只提供与真实实现语义一致的轻量 createLifecycleController。
+vi.mock('dsh-tauri/client', () => {
+  function createLifecycleController() {
+    const timers = new Set<ReturnType<typeof setTimeout>>()
+    const intervals = new Set<ReturnType<typeof setInterval>>()
+    const disposers: Array<() => void> = []
+    let disposed = false
+    return {
+      add: (disposer: () => void) => {
+        if (!disposed)
+          disposers.push(disposer)
+      },
+      timeout: (fn: () => void, ms: number) => {
+        if (disposed)
+          return () => {}
+        const timer = setTimeout(() => {
+          timers.delete(timer)
+          if (!disposed)
+            fn()
+        }, ms)
+        timers.add(timer)
+        return () => {
+          timers.delete(timer)
+          clearTimeout(timer)
+        }
+      },
+      interval: (fn: () => void, ms: number) => {
+        if (disposed)
+          return () => {}
+        const timer = setInterval(() => {
+          if (!disposed)
+            fn()
+        }, ms)
+        intervals.add(timer)
+        return () => {
+          intervals.delete(timer)
+          clearInterval(timer)
+        }
+      },
+      listen: () => () => {},
+      observe: () => ({ disconnect: () => {} }),
+      isDisposed: () => disposed,
+      dispose: () => {
+        if (disposed)
+          return
+        disposed = true
+        for (const timer of timers)
+          clearTimeout(timer)
+        timers.clear()
+        for (const timer of intervals)
+          clearInterval(timer)
+        intervals.clear()
+        for (const disposer of disposers)
+          disposer()
+        disposers.length = 0
+      },
+    }
+  }
+  return { createLifecycleController }
+})
+
+vi.mock('./pet', () => ({
+  pushPetSession: async (action: string, session: unknown) => {
+    h.petState.pushed.push({ action, session })
+  },
+  fetchPetStatus: async () => h.petState.status,
+}))
+
+/** 一个可控的假会话：getSnapshot 稳定返回同一引用直到 setSnapshot 换引用 (并触发订阅)。 */
+function makeSession(id: string, initial: Record<string, unknown>) {
+  let snapshot = initial
+  const listeners: Array<() => void> = []
+  return {
+    sessionId: id,
+    session: {
+      getSnapshot: () => snapshot,
+      subscribe: (listener: () => void) => {
+        listeners.push(listener)
+        return () => {
+          const i = listeners.indexOf(listener)
+          if (i >= 0)
+            listeners.splice(i, 1)
+        }
+      },
+    },
+    /** 换引用并触发订阅（模拟会话状态真实变化）。 */
+    setSnapshot(next: Record<string, unknown>) {
+      snapshot = next
+      for (const listener of [...listeners])
+        listener()
+    },
+  }
+}
+
+interface SessionsHarness {
+  list: {
+    getSnapshot: () => { byId?: Record<string, Record<string, unknown>>, ids: readonly string[] }
+    subscribe: (listener: () => void) => () => void
+  }
+  binding: (id: string) => unknown
+}
+
+function makeSessions(byId: Record<string, Record<string, unknown>>, bindings: Array<ReturnType<typeof makeSession>>): SessionsHarness {
+  const ids = Object.keys(byId)
+  const bindingBySessionId = new Map(bindings.map(b => [b.sessionId, b]))
+  const list = { byId, ids }
+  const listListeners: Array<() => void> = []
+  return {
+    list: {
+      getSnapshot: () => list,
+      subscribe: (listener: () => void) => {
+        listListeners.push(listener)
+        return () => {
+          const i = listListeners.indexOf(listener)
+          if (i >= 0)
+            listListeners.splice(i, 1)
+        }
+      },
+    },
+    binding: (id: string) => bindingBySessionId.get(id),
+  }
+}
+
+function register(ctxSessions: SessionsHarness): () => void {
+  let cleanup: () => void = () => {}
+  const ctx = {
+    sessions: ctxSessions,
+    effect: (fn: () => () => void) => { cleanup = fn() },
+  }
+  registerPetSessionForwarder(ctx as never)
+  return cleanup
+}
+
+const IDLE_SUMMARY = (id: string): Record<string, unknown> => ({ id, title: `会话${id}`, status: 'idle' })
+
+describe('dsh-tauri-pet registerPetSessionForwarder', () => {
+  let cleanup: () => void
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    h.storeState.listeners = []
+    h.storeState.status = { enabled: true, active_pet: 'maid', visible: true }
+    h.petState.pushed = []
+    h.petState.status = { enabled: true, active_pet: 'maid', visible: true }
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    vi.useRealTimers()
+  })
+
+  it('未变化的空闲会话不反复转发（只 create 一次，update 0 次）', () => {
+    const a = makeSession('a', { id: 'a', status: 'idle' })
+    const b = makeSession('b', { id: 'b', status: 'idle' })
+    const sessions = makeSessions({ a: IDLE_SUMMARY('a'), b: IDLE_SUMMARY('b') }, [a, b])
+    cleanup = register(sessions)
+
+    // 注册即 reconcile：两个会话各发一次 create
+    expect(h.petState.pushed).toHaveLength(2)
+    expect(h.petState.pushed.map(p => p.action)).toEqual(['create', 'create'])
+
+    // 推进 4 个 250ms 的 reconcile 周期，状态未变，不再转发 update
+    vi.advanceTimersByTime(250 * 4)
+    expect(h.petState.pushed.filter(p => p.action === 'update')).toHaveLength(0)
+    expect(h.petState.pushed).toHaveLength(2)
+  })
+
+  it('宠物未启用（disabled）时完全不转发', () => {
+    h.storeState.status = { enabled: false, active_pet: 'maid', visible: false }
+    h.petState.status = { enabled: false, active_pet: 'maid', visible: false }
+    const a = makeSession('a', { id: 'a', status: 'idle' })
+    const sessions = makeSessions({ a: IDLE_SUMMARY('a') }, [a])
+    cleanup = register(sessions)
+
+    expect(h.petState.pushed).toHaveLength(0)
+    // 会话变化也只进待发队列，但 enabled=false，flush 同样不转发
+    a.setSnapshot({ id: 'a', status: 'running' })
+    vi.advanceTimersByTime(1000)
+    expect(h.petState.pushed).toHaveLength(0)
+  })
+
+  it('禁用 → 启用过渡时对全部当前会话补发 create', () => {
+    h.storeState.status = { enabled: false, active_pet: 'maid', visible: false }
+    h.petState.status = { enabled: false, active_pet: 'maid', visible: false }
+    const a = makeSession('a', { id: 'a', status: 'idle' })
+    const b = makeSession('b', { id: 'b', status: 'idle' })
+    const sessions = makeSessions({ a: IDLE_SUMMARY('a'), b: IDLE_SUMMARY('b') }, [a, b])
+    cleanup = register(sessions)
+    expect(h.petState.pushed).toHaveLength(0)
+
+    // 设置页/图标把 enabled 写为 true，store 通知订阅者 → 转发引擎补发 create
+    h.storeState.status = { enabled: true, active_pet: 'maid', visible: true }
+    for (const listener of [...h.storeState.listeners])
+      listener()
+
+    expect(h.petState.pushed.map(p => p.action)).toEqual(['create', 'create'])
+    expect(h.petState.pushed.map(p => (p.session as { id: string }).id)).toEqual(['a', 'b'])
+  })
+
+  it('会话快照真实变化才转发 update（不变字段不触发）', () => {
+    const a = makeSession('a', { id: 'a', status: 'idle' })
+    const sessions = makeSessions({ a: IDLE_SUMMARY('a') }, [a])
+    cleanup = register(sessions)
+    expect(h.petState.pushed).toHaveLength(1)
+
+    // 只改一个被转发的字段：status idle→running → 100ms 合并 flush 后补发一次 update
+    a.setSnapshot({ id: 'a', status: 'running' })
+    expect(h.petState.pushed).toHaveLength(1) // 合并节流：还没到 flush 时刻
+    vi.advanceTimersByTime(100)
+    expect(h.petState.pushed).toHaveLength(2)
+    expect(h.petState.pushed[1]).toMatchObject({ action: 'update', session: { id: 'a', status: 'running' } })
+  })
+
+  it('仅非转发字段变化时不转发（投影去重）', () => {
+    const a = makeSession('a', { id: 'a', status: 'idle' })
+    const sessions = makeSessions({ a: IDLE_SUMMARY('a') }, [a])
+    cleanup = register(sessions)
+    expect(h.petState.pushed).toHaveLength(1)
+
+    // summary/快照都没有变，唯一的差异来自事件的 liveActivity 折叠（仍为 null）与一个非转发字段
+    a.setSnapshot({ id: 'a', status: 'idle', hugeUnusedField: { recursive: true } })
+    expect(h.petState.pushed).toHaveLength(1)
+    vi.advanceTimersByTime(100)
+    expect(h.petState.pushed).toHaveLength(1)
+  })
+
+  it('事件窗口折叠出 liveActivity 时随 update 转发一次', () => {
+    // 构造带 eventSource 的会话：绑定即折叠，无活动 → activity null
+    let windowEntries: unknown[] = []
+    const listeners: Array<() => void> = []
+    const snapshot = { id: 'a', status: 'running' }
+    const liveActivity: SessionLiveActivity = { kind: 'tool', name: 'pwsh', args: '{"command":"ls"}' }
+    const sessions = makeSessions({ a: IDLE_SUMMARY('a') }, [])
+    sessions.binding = (id: string) => id === 'a'
+      ? ({
+          sessionId: 'a',
+          eventSource: {
+            getSnapshot: () => ({ entries: windowEntries }),
+            subscribe: (l: () => void) => {
+              listeners.push(l)
+              return () => {}
+            },
+          },
+          session: {
+            getSnapshot: () => snapshot,
+            subscribe: () => () => {},
+          },
+        })
+      : undefined
+
+    cleanup = register(sessions)
+    // 绑定即折叠一次并发送 create
+    expect(h.petState.pushed).toHaveLength(1)
+
+    // 事件窗口填充工具调用 → 订阅触发 → 300ms trailing 节流后折叠出 liveActivity 并转发
+    windowEntries = [{ type: 'event', event: { type: 'tool/call', data: { callId: 'c1', name: 'pwsh', arguments: '{"command":"ls"}' } } }]
+    for (const listener of [...listeners])
+      listener()
+    expect(h.petState.pushed).toHaveLength(1)
+    vi.advanceTimersByTime(300)
+    expect(h.petState.pushed).toHaveLength(2)
+    const last = h.petState.pushed[1]
+    expect(last.action).toBe('update')
+    expect((last.session as { liveActivity: unknown }).liveActivity).toEqual(liveActivity)
+  })
+})

--- a/packages/dsh-tauri-pet/src/client/service/activity.ts
+++ b/packages/dsh-tauri-pet/src/client/service/activity.ts
@@ -1,10 +1,12 @@
 import type { ClientContext } from 'dsh-tauri/client'
-import type { SessionLiveActivity } from '../types'
+import type { PetStatus, SessionLiveActivity } from '../types'
 import { createLifecycleController } from 'dsh-tauri/client'
-import { PET_ACTIVITY_THROTTLE_MS } from '../constants'
+import { PET_ACTIVITY_THROTTLE_MS, PET_SESSION_UPDATE_THROTTLE_MS } from '../constants'
+import { beginPetStatusFetch, commitPetStatusFetch, getPetUiSnapshot, subscribePetUi } from '../store'
 import { foldSessionActivity } from '../utils/activity'
+import { deepEqual, projectPetPayload } from '../utils/projection'
 import { toTransferable } from '../utils/transferable'
-import { pushPetSession } from './pet'
+import { fetchPetStatus, pushPetSession } from './pet'
 
 type SessionAction = 'create' | 'update' | 'remove'
 
@@ -38,25 +40,40 @@ interface RawSessions {
   binding: (id: string) => RawSessionBinding | undefined
 }
 
-/** 每个已绑定会话的观察状态：订阅清理 + 折叠出的实时活动 + 节流定时器。 */
+/** 每个已绑定会话的观察状态：订阅清理 + 折叠出的实时活动 + 节流定时器 + 变化检测缓存。 */
 interface SessionWatch {
   disposers: Array<() => void>
   /** 事件窗口折叠结果；undefined 表示该会话无事件窗口（alpha），null 表示当前无活动 */
   activity?: SessionLiveActivity | null
   activityTimer?: ReturnType<typeof setTimeout>
+  /** 上次已推送的投影载荷（用于深比较去重，避免无变化空转发）。 */
+  lastPayload?: Record<string, unknown>
+  /** 上次计算载荷时的输入引用（summary / snapshot / activity）。引用不变 ⇒ 载荷必不变。 */
+  lastInput?: {
+    summary?: Record<string, unknown>
+    snapshot: unknown
+    activity?: SessionLiveActivity | null
+  }
 }
 
 /**
- * 将 DSH 会话原始快照按生命周期推送给桌宠窗口，不生成宠物专用 projection。
- * rc.2+ 会话额外订阅事件窗口（binding.eventSource）：流式 delta 逐 token 触发，
- * 按会话做 trailing 节流，到期时按当前窗口重算实时活动（进行中的工具调用 /
- * 思考流）并以 liveActivity 字段并入快照；alpha 缺失事件窗口时退级为纯快照转发。
+ * 把 DSH 会话原始快照投影后按建议推送给桌宠窗口，不做宠物专用 projection，但做三件事收敛：
+ *  - 门控：仅宠物启用（PetStatus.enabled）时才转发，窗口隐藏与否不改变转发；
+ *  - 变化检测：summary/snapshot/activity 引用不变则跳过；投影经白名单 + 深比较后才推送；
+ *  - 合并背压：会话订阅事件进共享节流队列，一次突发只批量 flush 一帧，避免 250ms 高频空转发。
+ * rc.2+ 会话额外订阅事件窗口（binding.eventSource）：流式 delta 逐 token 触发，按会话做
+ * trailing 节流，到期时按当前窗口重算实时活动（进行中的工具调用 / 思考流）并以
+ * liveActivity 字段并入快照；alpha 缺失事件窗口时退级为纯快照转发。
  */
 export function registerPetSessionForwarder(ctx: ClientContext): void {
   ctx.effect(() => {
     const controller = createLifecycleController()
     const watches = new Map<string, SessionWatch>()
     const known = new Set<string>()
+    // 门控：只读共享 store 里的 enabled（store 未初始化时保守关闭，转发停止而不是误发）。
+    let enabled = getPetUiSnapshot().status?.enabled ?? false
+    const pendingUpdates = new Set<string>()
+    let flushCancel: (() => void) | undefined
     let disposed = false
 
     function emit(action: SessionAction, session: Record<string, unknown>): void {
@@ -71,19 +88,54 @@ export function registerPetSessionForwarder(ctx: ClientContext): void {
 
     const sessions = ctx.sessions as unknown as RawSessions
 
-    function snapshotOf(id: string, binding: RawSessionBinding): Record<string, unknown> {
-      const list = sessions.list.getSnapshot()
-      const summary = list.byId?.[id]
-      const snapshot = binding.session.getSnapshot()
+    /** 合并 list summary 与 binding 快照，并按需附带 liveActivity。 */
+    function mergeSnapshot(
+      binding: RawSessionBinding,
+      summary: Record<string, unknown> | undefined,
+      snapshot: unknown,
+      activity: SessionLiveActivity | null | undefined,
+    ): Record<string, unknown> {
       const value = snapshot && typeof snapshot === 'object'
         ? snapshot as Record<string, unknown>
         : { value: snapshot }
       const merged: Record<string, unknown> = { id: binding.sessionId, ...(summary ?? {}), ...value }
       // 仅在探测到事件窗口的会话上附带 liveActivity；null 也是有效值（清除过期活动展示）
-      const watch = watches.get(id)
-      if (watch?.activity !== undefined)
-        merged.liveActivity = watch.activity
+      if (activity !== undefined)
+        merged.liveActivity = activity
       return merged
+    }
+
+    /**
+     * 变化检测转发：输入引用不变 ⇒ 载荷必不变，直接跳过（免 toTransferable/深比较）；
+     * 引用变了 ⇒ 投影到白名单并深比较，投影结果一致（如仅非白名单字段变化）则只更新签名
+     * 不转发，真正变化才 pushPetSession。
+     */
+    function emitIfChanged(id: string, binding: RawSessionBinding, action: SessionAction): void {
+      if (disposed || !enabled)
+        return
+      const watch = watches.get(id)
+      if (watch === undefined)
+        return
+      const list = sessions.list.getSnapshot()
+      const summary = list.byId?.[id]
+      const snapshot = binding.session.getSnapshot()
+      const activity = watch.activity
+      if (watch.lastInput !== undefined
+        && watch.lastInput.summary === summary
+        && watch.lastInput.snapshot === snapshot
+        && watch.lastInput.activity === activity) {
+        return
+      }
+      const merged = mergeSnapshot(binding, summary, snapshot, activity)
+      const projected = projectPetPayload(merged)
+      const payload = toTransferable(projected) as Record<string, unknown>
+      if (watch.lastPayload !== undefined && deepEqual(payload, watch.lastPayload)) {
+        watch.lastInput = { summary, snapshot, activity }
+        return
+      }
+      watch.lastPayload = payload
+      watch.lastInput = { summary, snapshot, activity }
+      emit(action, payload)
     }
 
     /** 订阅事件窗口：这里只做 trailing 节流，到期时按当前窗口整体重算一次，一次突发只推送一帧。 */
@@ -101,7 +153,7 @@ export function registerPetSessionForwarder(ctx: ClientContext): void {
           watch.activityTimer = undefined
           const current = source.getSnapshot()
           watch.activity = foldSessionActivity(current.entries)
-          emit('update', snapshotOf(id, binding))
+          emitIfChanged(id, binding, 'update')
         }, PET_ACTIVITY_THROTTLE_MS)
       }))
       // dsh 只在会话被选中（open）时才建立事件流；子代理等未选中会话的
@@ -130,8 +182,8 @@ export function registerPetSessionForwarder(ctx: ClientContext): void {
       const watch: SessionWatch = { disposers: [] }
       watches.set(id, watch)
       attachEventSource(id, binding, watch)
-      emit(action, snapshotOf(id, binding))
-      watch.disposers.push(binding.session.subscribe(() => emit('update', snapshotOf(id, binding))))
+      emitIfChanged(id, binding, action)
+      watch.disposers.push(binding.session.subscribe(() => scheduleUpdate(id)))
     }
 
     function unbind(id: string): void {
@@ -143,7 +195,49 @@ export function registerPetSessionForwarder(ctx: ClientContext): void {
       watches.delete(id)
     }
 
+    /** 会话订阅事件合并：进 pending 队列，由共享节流定时器一次批量 flush。 */
+    function scheduleUpdate(id: string): void {
+      if (disposed || !enabled)
+        return
+      pendingUpdates.add(id)
+      if (flushCancel !== undefined)
+        return
+      flushCancel = controller.timeout(() => {
+        flushCancel = undefined
+        for (const pendingId of pendingUpdates) {
+          const binding = sessions.binding(pendingId)
+          const watch = watches.get(pendingId)
+          if (binding !== undefined && watch !== undefined)
+            emitIfChanged(pendingId, binding, 'update')
+          pendingUpdates.delete(pendingId)
+        }
+      }, PET_SESSION_UPDATE_THROTTLE_MS)
+    }
+
+    function applyEnabled(next: boolean): void {
+      if (next === enabled)
+        return
+      enabled = next
+      pendingUpdates.clear()
+      if (enabled) {
+        // 重新启用：对当前全部会话补发 create，桌宠窗口重建状态
+        sync()
+      }
+      else {
+        // 关闭宠物：对每个已知会话（含无 binding 仅发过 {id} 的）补发 remove，清空桌宠窗口展示，再释放观察者
+        for (const id of [...known]) {
+          if (watches.has(id))
+            unbind(id)
+          emit('remove', { id })
+        }
+        known.clear()
+      }
+    }
+
     function sync(): void {
+      // 宠物未启用时不重建观察者、不转发任何会话状态（避免高频空转发）
+      if (disposed || !enabled)
+        return
       const list = sessions.list.getSnapshot()
       const ids = new Set(list.ids)
       for (const id of known) {
@@ -164,7 +258,7 @@ export function registerPetSessionForwarder(ctx: ClientContext): void {
           // activity 保持 undefined 说明事件窗口此前不可用；运行中补挂一次（成功 attach 后值为 null，不会重复订阅）
           if (watch !== undefined && watch.activity === undefined && binding.eventSource !== undefined)
             attachEventSource(id, binding, watch)
-          emit('update', snapshotOf(id, binding))
+          emitIfChanged(id, binding, 'update')
         }
         else {
           bind(id, known.has(id) ? 'update' : 'create')
@@ -175,11 +269,27 @@ export function registerPetSessionForwarder(ctx: ClientContext): void {
         known.add(id)
     }
 
+    // 门控来源：订阅共享 store 的 enabled 变化（侧栏图标 / 设置页写入）
+    controller.add(subscribePetUi(() => {
+      applyEnabled(getPetUiSnapshot().status?.enabled ?? false)
+    }))
+    // 门控兜底：共享 store 可能尚未被任何消费方初始化，主动拉取一次并入 store
+    const revision = beginPetStatusFetch()
+    void fetchPetStatus().then((status: PetStatus) => {
+      if (disposed)
+        return
+      commitPetStatusFetch(revision, status)
+      applyEnabled(status.enabled)
+    }).catch((error: unknown) => {
+      if (!disposed)
+        console.warn('[dsh-tauri-pet] fetch pet status failed:', error)
+    })
+
     controller.add(sessions.list.subscribe(sync))
-    const retryTimer = globalThis.setInterval(sync, 250)
-    controller.add(() => globalThis.clearInterval(retryTimer))
+    controller.interval(sync, 250)
     controller.add(() => {
       disposed = true
+      pendingUpdates.clear()
       for (const id of [...watches.keys()])
         unbind(id)
       known.clear()

--- a/packages/dsh-tauri-pet/src/client/utils/projection.test.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/projection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { deepEqual, PET_FORWARDED_FIELDS, projectPetPayload } from './projection'
+
+describe('projectPetPayload', () => {
+  it('只投影白名单字段，且缺省字段不补默认值', () => {
+    const merged = {
+      id: 's1',
+      sessionId: 's1',
+      title: '会话',
+      status: 'running',
+      unused: { deep: true },
+      extraField: 1,
+    }
+    expect(projectPetPayload(merged)).toEqual({
+      id: 's1',
+      sessionId: 's1',
+      title: '会话',
+      status: 'running',
+    })
+  })
+
+  it('独立附带 liveActivity（仅存在时）', () => {
+    expect(projectPetPayload({ id: 's1', liveActivity: { kind: 'tool', name: 'pwsh' } }))
+      .toEqual({ id: 's1', liveActivity: { kind: 'tool', name: 'pwsh' } })
+    // 无 liveActivity 时不制造空字段
+    expect(projectPetPayload({ id: 's1' })).toEqual({ id: 's1' })
+  })
+
+  it('白名单包含桌宠窗口消费的全部字段', () => {
+    expect([...PET_FORWARDED_FIELDS]).toEqual(expect.arrayContaining([
+      'id',
+      'sessionId',
+      'title',
+      'displayTitle',
+      'name',
+      'description',
+      'message',
+      'status',
+      'activity',
+      'phase',
+      'running',
+      'pendingInteraction',
+      'pending',
+      'lastAgentError',
+    ]))
+  })
+})
+
+describe('deepEqual', () => {
+  it('基础值与 null 比较', () => {
+    expect(deepEqual(1, 1)).toBe(true)
+    expect(deepEqual('a', 'a')).toBe(true)
+    expect(deepEqual(null, null)).toBe(true)
+    expect(deepEqual(1, 2)).toBe(false)
+    expect(deepEqual('a', 'b')).toBe(false)
+    expect(deepEqual(null, undefined)).toBe(false)
+    expect(deepEqual(1, '1')).toBe(false)
+  })
+
+  it('对象比较', () => {
+    expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(true)
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false)
+    expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false)
+  })
+
+  it('数组与嵌套比较（长度/顺序敏感）', () => {
+    expect(deepEqual([1, { x: 2 }], [1, { x: 2 }])).toBe(true)
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false)
+    expect(deepEqual([1, 2], [2, 1])).toBe(false)
+  })
+})

--- a/packages/dsh-tauri-pet/src/client/utils/projection.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/projection.ts
@@ -1,0 +1,75 @@
+/**
+ * utils/projection.ts — 桌宠转发 payload 的字段投影与变化检测。
+ *
+ * issue #396 根因之一是转发未经收敛的完整会话快照：字段数量大、嵌套深，且
+ * 高频（250ms) 重复转发未变化的会话。这里引入白名单投影 + 深比较，让转发
+ * 只携带桌宠窗口实际消费的字段，并且只在投影结果真正变化时才发出 update。
+ */
+
+/**
+ * 桌宠窗口（src/pet/hooks/use-bubble.ts）实际消费的会话字段白名单。
+ * 只在快照存在该字段时投影，缺省字段不补默认值，避免制造不存在的状态。
+ */
+export const PET_FORWARDED_FIELDS = [
+  'id',
+  'sessionId',
+  'title',
+  'displayTitle',
+  'name',
+  'description',
+  'message',
+  'status',
+  'activity',
+  'phase',
+  'running',
+  'pendingInteraction',
+  'pending',
+  'lastAgentError',
+] as const
+
+/** 桌宠窗口额外消费的实时活动字段（独立处理，仅探测到事件窗口时存在）。 */
+export const PET_FORWARDED_ACTIVITY_FIELD = 'liveActivity'
+
+/**
+ * 将合并后的会话快照投影为桌宠窗口需要的白名单载荷。
+ * 投影是纯函数：输入任何 Record，输出仅含白名单字段的浅拷贝。
+ */
+export function projectPetPayload(merged: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of PET_FORWARDED_FIELDS) {
+    if (key in merged)
+      out[key] = merged[key]
+  }
+  if (PET_FORWARDED_ACTIVITY_FIELD in merged)
+    out[PET_FORWARDED_ACTIVITY_FIELD] = merged[PET_FORWARDED_ACTIVITY_FIELD]
+  return out
+}
+
+/**
+ * 递归深比较两个 JSON 兼容值（projectPetPayload 投影结果经 toTransferable 后的
+ * payload 均为纯数据：无 function/undefined/循环引用）。用于判定投影结果是否
+ * 真正变化，以此跳过「字段变了但投影没变」的无意义 update。
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b)
+    return true
+  if (typeof a !== typeof b)
+    return false
+  if (a === null || b === null || typeof a !== 'object')
+    return false
+  const aObj = a as Record<string, unknown>
+  const bObj = b as Record<string, unknown>
+  if (Array.isArray(aObj) !== Array.isArray(bObj))
+    return false
+  const aKeys = Object.keys(aObj)
+  const bKeys = Object.keys(bObj)
+  if (aKeys.length !== bKeys.length)
+    return false
+  for (const key of aKeys) {
+    if (!(key in bObj))
+      return false
+    if (!deepEqual(aObj[key], bObj[key]))
+      return false
+  }
+  return true
+}

--- a/packages/dsh-tauri/src/client/service/invoke.test.ts
+++ b/packages/dsh-tauri/src/client/service/invoke.test.ts
@@ -1,0 +1,115 @@
+import type { InvokeBridgeReply } from '../types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  INVOKE_TIMEOUT_MS,
+  PLUGIN_ID,
+  SRC_INVOKE_REPLY,
+  TYPE_INVOKE_REPLY,
+} from '../constants'
+import { invokeBridgedTauri } from './invoke'
+
+/**
+ * 构造一个最小的 window 替身：parent 作为宿主接收 postMessage，按类型独立收集
+ * 'message' 监听器并允许测试手动分发一次宿主应答。invoke.ts 只依赖
+ * window.parent / window.addEventListener / window.removeEventListener。
+ */
+function makeWindow() {
+  const windowListeners = new Set<(event: MessageEvent<unknown>) => void>()
+  const parent = {
+    postMessage: vi.fn(),
+  }
+  const win = {
+    parent,
+    addEventListener: vi.fn((type: string, fn: (event: MessageEvent<unknown>) => void) => {
+      if (type === 'message')
+        windowListeners.add(fn)
+    }),
+    removeEventListener: vi.fn((type: string, fn: (event: MessageEvent<unknown>) => void) => {
+      if (type === 'message')
+        windowListeners.delete(fn)
+    }),
+    // 模拟宿主回传：source 必须严格 === window.parent 才能通过 onMessage 的过滤
+    dispatchReply(reply: InvokeBridgeReply) {
+      for (const listener of [...windowListeners])
+        listener({ source: parent, data: reply } as unknown as MessageEvent<unknown>)
+    },
+  }
+  return { win, parent, dispatchReply: win.dispatchReply }
+}
+
+describe('dsh-tauri invokeBridgedTauri', () => {
+  let win: ReturnType<typeof makeWindow>['win']
+  let parent: ReturnType<typeof makeWindow>['parent']
+  let dispatchReply: ReturnType<typeof makeWindow>['dispatchReply']
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    win = makeWindow().win
+    parent = win.parent
+    dispatchReply = win.dispatchReply
+    vi.stubGlobal('window', win)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  function postedRequest() {
+    expect(parent.postMessage).toHaveBeenCalledTimes(1)
+    return parent.postMessage.mock.calls[0][0] as Record<string, unknown>
+  }
+
+  it('成功应答时 resolve，并立刻清理超时计时器', async () => {
+    const promise = invokeBridgedTauri<{ enabled: boolean }>('get_pet_status', { a: 1 })
+    // postMessage 发出请求，且只留有这一个超时计时器（正是要清理的目标）
+    expect(vi.getTimerCount()).toBe(1)
+    const request = postedRequest()
+    expect(request.source).toBe('dsh-tauri-invoke')
+    expect(request.type).toBe('dsh://tauri:invoke')
+    expect(request.cmd).toBe('get_pet_status')
+    expect(typeof request.nonce).toBe('string')
+    expect(request.nonce).toMatch(new RegExp(`^${PLUGIN_ID}:\\d+$`))
+
+    dispatchReply({ source: SRC_INVOKE_REPLY, type: TYPE_INVOKE_REPLY, nonce: request.nonce as string, ok: true, value: { enabled: true } })
+
+    await expect(promise).resolves.toEqual({ enabled: true })
+    // 修复点：成功路径也必须 clearTimeout，否则计时器休眠 15s 仍存活（泄漏）
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('错误应答时 reject，并清理超时计时器与监听器', async () => {
+    const promise = invokeBridgedTauri('set_pet_enabled', { enabled: true })
+    const request = postedRequest()
+    expect(vi.getTimerCount()).toBe(1)
+
+    dispatchReply({ source: SRC_INVOKE_REPLY, type: TYPE_INVOKE_REPLY, nonce: request.nonce as string, ok: false, error: 'boom' })
+
+    await expect(promise).rejects.toThrow('boom')
+    expect(vi.getTimerCount()).toBe(0)
+    // 监听器已从 window 移除（宿主回传的 listener 不应残留）
+    dispatchReply({ source: SRC_INVOKE_REPLY, type: TYPE_INVOKE_REPLY, nonce: request.nonce as string, ok: true, value: 1 })
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('宿主 15s 未应答时超时 reject，且无残留计时器', async () => {
+    const promise = invokeBridgedTauri('get_pet_status')
+    postedRequest()
+    expect(vi.getTimerCount()).toBe(1)
+
+    vi.advanceTimersByTime(INVOKE_TIMEOUT_MS)
+
+    await expect(promise).rejects.toThrow('NODE_NOT_ANSWERED: invoke get_pet_status timed out')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('postMessage 抛错时 reject，并清理超时计时器与监听器', async () => {
+    parent.postMessage.mockImplementation(() => {
+      throw new Error('DataCloneError: stored value cannot be cloned')
+    })
+    const promise = invokeBridgedTauri('get_pet_status', { session: { loop: true } })
+    // postMessage 抛错时不应发出任何东西，计时器也必须被清除
+    await expect(promise).rejects.toThrow('DataCloneError')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/packages/dsh-tauri/src/client/service/invoke.ts
+++ b/packages/dsh-tauri/src/client/service/invoke.ts
@@ -41,6 +41,9 @@ export function invokeBridgedTauri<T>(
 
   return new Promise<T>((resolve, reject) => {
     let settled = false
+    // 定时器句柄：settle 成功/失败路径与 postMessage 抛错路径都要清理，避免高频
+    // 成功调用留下一 15s 的休眠超时闭包（见 issue #396 前端延迟根因之一）。
+    let timer: ReturnType<typeof setTimeout> | undefined
 
     function onMessage(event: MessageEvent<unknown>): void {
       // 只接受宿主（顶层）直接发回的应答，且 nonce 必须命中本次请求
@@ -58,6 +61,8 @@ export function invokeBridgedTauri<T>(
       if (settled)
         return
       settled = true
+      if (timer !== undefined)
+        clearTimeout(timer)
       window.removeEventListener('message', onMessage)
       if (reply.ok) {
         resolve(reply.value as T)
@@ -69,7 +74,7 @@ export function invokeBridgedTauri<T>(
 
     window.addEventListener('message', onMessage)
     // 超时保护：宿主未应答（监听器未挂载/iframe 非 dsh 环境等）时按失败处理
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       if (settled)
         return
       window.removeEventListener('message', onMessage)
@@ -88,7 +93,8 @@ export function invokeBridgedTauri<T>(
       window.parent.postMessage(request, '*')
     }
     catch (error) {
-      clearTimeout(timer)
+      if (timer !== undefined)
+        clearTimeout(timer)
       if (settled)
         return
       settled = true


### PR DESCRIPTION
## 问题

Fixes #396

桌宠插件（dsh-tauri-pet 0.1.0）高频转发未变化的会话状态，造成明显前端延迟。两个根因：

### 1. dsh-tauri-pet 会话转发（每 250ms 无条件重发）
- 转发器对每个已绑定会话每次都调用 `pushPetSession`，**不先判断快照是否变化**；
- 列表订阅 / 单会话订阅额外触发 update；
- 无基于宠物启用的门控（仅随窗口隐藏与否工作）。

结果是约 4×N 次调用/秒（N = 已绑定会话数），大量 payload 是未变化的重复快照。

### 2. dsh-tauri invoke 桥超时未清理
`invokeBridgedTauri()` 成功应答时只移除消息监听，**未清理 15s 的 `INVOKE_TIMEOUT_MS` 超时定时器**。高频成功调用（如每次会话转发）都会遗留一个休眠 15s 的超时闭包，累积加剧前端延迟。

## 修改

### dsh-tauri-pet `service/activity.ts`
- **门控**：仅宠物启用（`PetStatus.enabled`）时才转发，关闭即停止（不再仅依赖窗口隐藏）；
- **变化检测**：summary / snapshot / activity 引用不变即跳过；投影经白名单 + 深比较后才推送，未变化的空闲会话不再反复 update；
- **合并背压**：会话订阅事件进共享节流队列（100ms 合并 flush），一次突发只批量推一帧；
- **字段投影**：只保留桌宠窗口实际消费的字段（新增 `utils/projection.ts`），缩小跨窗口传输体积。

### dsh-tauri `service/invoke.ts`
`invokeBridgedTauri` 在成功 / 失败 / postMessage 抛错等**所有完成路径**统一清理超时计时器。

## 测试
新增回归测试：
- `projection.test.ts`：白名单投影 + 深比较；
- `activity.test.ts`：门控、未变化不转发、禁用→启用补发 create、真实变化才 update、非转发字段变化去重、事件窗口折叠 liveActivity；
- `invoke.test.ts`：成功 / 失败 / 超时 / 抛错后无残留计时器（`vi.getTimerCount() === 0`）。

本地验证：`pnpm run typecheck`、`pnpm run lint`（0 error）、`pnpm run test -- --run`（112 tests 全通过）、`pnpm build:plugins` 均通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Desktop-pet session updates are now limited to relevant information and delivered more efficiently.
  - Repeated unchanged updates are suppressed, while meaningful changes are grouped and forwarded at a controlled rate.
  - Live activity information is included when available.
  - Session forwarding now responds correctly when the desktop pet is enabled or disabled, rebuilding state when re-enabled.

- **Bug Fixes**
  - Bridged requests no longer trigger stale timeout handling after completing successfully or failing to send.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->