### PR TITLE
fix(pet): 无可用宠物时隐藏侧栏桌宠入口图标

### DIFF
--- a/packages/dsh-tauri-pet/src/client/components/pet-settings.tsx
+++ b/packages/dsh-tauri-pet/src/client/components/pet-settings.tsx
@@ -17,7 +17,8 @@ import {
   setPetSize,
   showPet,
 } from '../service/pet'
-import { beginPetStatusFetch, commitPetStatusFetch, getPetUiSnapshot, setPetStatus, subscribePetUi } from '../store'
+import { beginPetStatusFetch, commitPetStatusFetch, getPetUiSnapshot, setPetsAvailable, setPetStatus, subscribePetUi } from '../store'
+import { hasAvailablePets } from '../utils/availability'
 import { progressPercent, resolvePresetCardAction } from '../utils/preset-card'
 import petSettingsStyle from './pet-settings.cssr'
 
@@ -152,6 +153,8 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
       const [nextPresetPets, nextStatus] = await Promise.all([fetchPresetPets(), fetchPetStatus()])
       cachedPresetPets = nextPresetPets
       setPresetPets(nextPresetPets)
+      // 下载完成会改变可用性（未安装→已安装），同步侧栏入口显隐（chat/codex 用缓存清单）。
+      setPetsAvailable(hasAvailablePets(nextPresetPets, cachedChatPets ?? [], cachedCodexPets ?? []))
       const revision = beginPetStatusFetch()
       commitPetStatusFetch(revision, nextStatus)
       setPetStatus(nextStatus)
@@ -203,6 +206,8 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
         setChatPets(nextChatPets)
         setCodexPets(nextCodexPets)
         setPresetPets(nextPresetPets)
+        // 同步侧栏入口显隐：无任何可用宠物（全新安装）时隐藏入口图标。
+        setPetsAvailable(hasAvailablePets(nextPresetPets, nextChatPets, nextCodexPets))
         // 跨挂载恢复进行中的下载：清单 phase 标记 downloading/extracting 的项重新轮询，
         // 避免「返回应用再进设置」丢失进度视图、重复点击触发 PET_PRESET_BUSY。
         // 占位进度先写入 downloads，让不确定进度条在第一次轮询返回前立即出现。
@@ -353,7 +358,11 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
     setError(null)
     try {
       await importPet(file.name, await readAsBase64(file))
-      setCodexPets(await fetchPetList('codex'))
+      const nextCodexPets = await fetchPetList('codex')
+      cachedCodexPets = nextCodexPets
+      setCodexPets(nextCodexPets)
+      // 导入成功后本地宠物集合变化，同步侧栏入口显隐。
+      setPetsAvailable(hasAvailablePets(cachedPresetPets ?? [], cachedChatPets ?? [], nextCodexPets))
     }
     catch (importError) {
       console.error('[dsh-tauri-pet] import failed:', importError)

--- a/packages/dsh-tauri-pet/src/client/dom/sidebar-icon.ts
+++ b/packages/dsh-tauri-pet/src/client/dom/sidebar-icon.ts
@@ -12,11 +12,17 @@
  * 挂载策略参照 dsh-tauri-session 的 workspace-patch：MutationObserver 监听
  * document.body，侧栏就绪后插入并持续看护（React 重渲染容器后自动补插）；
  * guard 属性 + 位置校验防止重复插入与死循环。
+ *
+ * 可用性：无任何可用宠物（已安装预设或本地 chat/codex 均无）时入口隐藏，避免
+ * 展示一个点了没意义的按钮；快照由本模块挂载时拉取一次，设置页在清单变化
+ * （下载完成/导入）后写回。桌宠仍启用（如宠物数据被外部清理）时保留入口，
+ * 让用户还能从侧栏关闭桌宠。
  */
 import { PET_ICON_ATTRIBUTE, PET_ICON_RETRY_MAX, PET_ICON_RETRY_MS, PET_SETTINGS_ROW_CLASS, SETTINGS_TRIGGER_SELECTOR, SIDEBAR_SELECTOR } from '../constants'
 import { text } from '../locales'
-import { fetchPetStatus, hidePet, setPetEnabled, showPet } from '../service/pet'
-import { beginPetStatusFetch, commitPetStatusFetch, getPetUiSnapshot, setPetStatus, subscribePetUi } from '../store'
+import { fetchPetList, fetchPetStatus, fetchPresetPets, hidePet, setPetEnabled, showPet } from '../service/pet'
+import { beginPetStatusFetch, commitPetStatusFetch, getPetUiSnapshot, setPetsAvailable, setPetStatus, subscribePetUi } from '../store'
+import { hasAvailablePets } from '../utils/availability'
 
 /** 入口图标（爪印，currentColor 跟随官方 iconButton 悬停变色）。 */
 const PET_ICON_SVG = '<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 13.5c-2.7 0-5.5 2-5.5 4.3 0 1.4 1 2.2 2.3 2.2 1 0 1.9-.6 3.2-.6s2.2.6 3.2.6c1.3 0 2.3-.8 2.3-2.2 0-2.3-2.8-4.3-5.5-4.3z"/><path d="M7.3 8.1c-1 .1-1.8 1.2-1.7 2.5.1 1.2 1 2.1 2 2 .9-.1 1.7-1.2 1.6-2.4-.1-1.2-1-2.2-1.9-2.1z"/><path d="M12 4.5c-1.1 0-2 1.1-2 2.5s.9 2.5 2 2.5 2-1.1 2-2.5-.9-2.5-2-2.5z"/><path d="M16.7 8.1c-.9-.1-1.8.9-1.9 2.1-.1 1.2.7 2.3 1.6 2.4 1 .1 1.9-.8 2-2 .1-1.3-.7-2.4-1.7-2.5z"/><path d="M4.8 12.3c-.8.3-1.2 1.4-.9 2.4.3 1 1.2 1.6 2 1.3.8-.3 1.1-1.4.8-2.4-.3-1-1.1-1.6-1.9-1.3z"/><path d="M19.2 12.3c-.8-.3-1.6.3-1.9 1.3-.3 1 0 2.1.8 2.4.8.3 1.7-.3 2-1.3.3-1-.1-2.1-.9-2.4z"/></svg>'
@@ -81,12 +87,36 @@ function createPetIconButton(): HTMLButtonElement {
   return button
 }
 
-/** 按共享状态缓存同步按钮两态（绿点显隐 + aria-pressed）。 */
+/** 按共享状态缓存同步按钮显隐与两态（绿点显隐 + aria-pressed）。 */
 function syncIconState(button: HTMLButtonElement): void {
-  const status = getPetUiSnapshot().status
+  const shared = getPetUiSnapshot()
+  const status = shared.status
+  // 无任何可用宠物时隐藏入口；桌宠仍启用（如宠物数据被外部清理）时保留入口以便关闭。
+  const keep = shared.petsAvailable || Boolean(status?.enabled)
+  button.style.display = keep ? '' : 'none'
   const active = Boolean(status?.enabled && status?.visible)
   button.classList.toggle('dshp-pet__icon--on', active)
   button.setAttribute('aria-pressed', String(active))
+}
+
+/**
+ * 拉取全部宠物清单并写入「是否有可用宠物」快照（侧栏入口显隐用）。失败时按
+ * 有宠物处理（fail-open），避免桥接瞬时错误把入口藏掉；此后清单变化（下载
+ * 完成/导入）由设置页写回同一快照。
+ */
+async function refreshPetsAvailability(): Promise<void> {
+  try {
+    const [presets, chatPets, codexPets] = await Promise.all([
+      fetchPresetPets(),
+      fetchPetList('chat'),
+      fetchPetList('codex'),
+    ])
+    setPetsAvailable(hasAvailablePets(presets, chatPets, codexPets))
+  }
+  catch (error) {
+    console.error('[dsh-tauri-pet] refresh pets availability failed:', error)
+    setPetsAvailable(true)
+  }
 }
 
 /**
@@ -113,6 +143,9 @@ export function registerSidebarPetIcon(): () => void {
         commitPetStatusFetch(revision, status)
     })
     .catch(error => console.error('[dsh-tauri-pet] fetchPetStatus failed:', error))
+  // 初始可用性：无任何可用宠物时隐藏入口（按钮按默认快照先隐藏，拉取成功后才
+  // 决定是否显示；fail-open 策略见 refreshPetsAvailability）。
+  void refreshPetsAvailability()
   syncIconState(button)
 
   /**

--- a/packages/dsh-tauri-pet/src/client/store/index.ts
+++ b/packages/dsh-tauri-pet/src/client/store/index.ts
@@ -13,10 +13,12 @@ import { createExternalStore } from 'dsh-tauri/client'
 export interface PetShared {
   /** 最近一次从桌面端读回的桌宠状态缓存（图标绿点与设置页共用）。 */
   status: PetStatus | null
+  /** 是否存在可用宠物（已安装预设或本地 chat/codex）；无可用宠物时侧栏入口图标隐藏。 */
+  petsAvailable: boolean
 }
 
 /** dsh-tauri 外部 store（getSnapshot 稳定，uSES 安全）。 */
-export const petUiStore = createExternalStore<PetShared>({ status: null })
+export const petUiStore = createExternalStore<PetShared>({ status: null, petsAvailable: false })
 let fetchRevision = 0
 /** Start a status fetch; only its latest revision may write the initial snapshot. */
 export function beginPetStatusFetch(): number {
@@ -44,4 +46,9 @@ export function getPetUiSnapshot(): PetShared {
 export function setPetStatus(status: PetStatus | null): void {
   fetchRevision += 1
   petUiStore.set(state => (state.status === status ? state : { ...state, status }))
+}
+
+/** 写入「是否有可用宠物」快照（侧栏入口图标显隐用）。 */
+export function setPetsAvailable(available: boolean): void {
+  petUiStore.set(state => (state.petsAvailable === available ? state : { ...state, petsAvailable: available }))
 }

--- a/packages/dsh-tauri-pet/src/client/utils/availability.test.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/availability.test.ts
@@ -1,0 +1,32 @@
+import type { PetListItem, PresetPetItem } from '../types'
+import { describe, expect, it } from 'vitest'
+import { hasAvailablePets } from './availability'
+
+function preset(installed: boolean): PresetPetItem {
+  return { id: 'maid-deepseek-whale', installed, name: 'Maid DeepSeek Whale' }
+}
+
+function listItem(id: string, source: PetListItem['source']): PetListItem {
+  return { id, name: id, source }
+}
+
+describe('hasAvailablePets', () => {
+  it('空清单 → false', () => {
+    expect(hasAvailablePets([], [], [])).toBe(false)
+  })
+
+  it('仅有未安装的预设宠物（可下载但不可用）→ false', () => {
+    expect(hasAvailablePets([preset(false)], [], [])).toBe(false)
+  })
+
+  it('已安装的预设宠物 → true', () => {
+    expect(hasAvailablePets([preset(true)], [], [])).toBe(true)
+    expect(hasAvailablePets([preset(false), preset(true)], [], [])).toBe(true)
+  })
+
+  it('任意本地 chat/codex 宠物 → true', () => {
+    expect(hasAvailablePets([], [listItem('chat-pet', 'chat')], [])).toBe(true)
+    expect(hasAvailablePets([], [], [listItem('codex-pet', 'codex')])).toBe(true)
+    expect(hasAvailablePets([preset(false)], [listItem('a', 'chat')], [])).toBe(true)
+  })
+})

--- a/packages/dsh-tauri-pet/src/client/utils/availability.ts
+++ b/packages/dsh-tauri-pet/src/client/utils/availability.ts
@@ -1,0 +1,14 @@
+import type { PetListItem, PresetPetItem } from '../types'
+
+/**
+ * 是否存在可直接使用的宠物：已安装的预设宠物（installed）或任意本地 chat/codex
+ * 宠物。未安装的预设（仅可下载）不算可用——启用后没有可播放资产，侧栏切换
+ * 入口对用户没有意义；无任何可用宠物时侧栏入口图标隐藏。
+ */
+export function hasAvailablePets(
+  presets: readonly PresetPetItem[],
+  chatPets: readonly PetListItem[],
+  codexPets: readonly PetListItem[],
+): boolean {
+  return presets.some(item => item.installed) || chatPets.length > 0 || codexPets.length > 0
+}


### PR DESCRIPTION
### 背景

#402 修复了「默认预设宠物未安装」的入口状态（已合并），但其衍生场景是：全新安装时**没有任何可用宠物**（无已安装预设、无本地 chat/codex 宠物），侧栏的桌宠切换图标是一个点了没意义的按钮——点击只会提示「未选择宠物」。

### 改动

- `store/index.ts`：共享快照新增 `petsAvailable: boolean`（默认 `false`）与写入函数 `setPetsAvailable`。
- 新增 `utils/availability.ts`：纯函数 `hasAvailablePets(presets, chatPets, codexPets)` —— 已安装预设或任意本地 chat/codex 宠物即视为可用；**未安装的预设（仅可下载）不算可用**。
- `dom/sidebar-icon.ts`：`syncIconState` 增加显隐逻辑——`!petsAvailable && !enabled` 时隐藏入口按钮；挂载时拉取全部清单写入快照（fail-open：拉取失败按有宠物处理，避免桥接瞬时错误藏掉入口）；桌宠仍启用（如宠物数据被外部清理）时保留入口，让用户还能从侧栏关闭。
- `components/pet-settings.tsx`：初始加载、预设下载完成（`refreshPresets`）、本地宠物导入成功后写回可用性快照，保证侧栏图标实时同步；顺带修正导入成功后未写 `cachedCodexPets` 缓存的小缺口。
- 新增 `utils/availability.test.ts` 覆盖四种判定场景。

### 验证

- vitest：116/116 通过（含新增 4 个用例）
- `tsc` typecheck 通过；eslint 0 错误；`tsdown` 构建通过

### 无可用宠物时的预期效果

侧栏不再显示桌宠入口图标；下载/导入首个宠物后图标自动出现。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The pet sidebar entry now appears only when at least one usable pet is available.
  - Availability includes installed preset pets and local chat or Codex pets.
  - The sidebar updates automatically when pet data refreshes, initial data loads, or a Codex pet is imported.
  - An active pet remains accessible so it can still be disabled, even if no other pets are available.

- **Bug Fixes**
  - Improved synchronization between pet availability and sidebar visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->