### PR TITLE
chore: release v0.10.7-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.6",
+  "version": "0.10.7-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.6"
+version = "0.10.7-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.6"
+version = "0.10.7-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.6",
+  "version": "0.10.7-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.7-beta.1` (`0.10.6` → `0.10.7-beta.1`).

### Features

- **plugins**: centralize css-render with bem and unify style mounting (db2aa00)
- **navbar**: 设置/帮助改为图标按钮并移除前进后退（#331 部分实现） (f5425f7)

### Bug Fixes

- **pet**: 收敛会话转发并修复子代理状态展示，移除调试打点 (b4b840f)
- **extension**: 统一 dshp-extension__ 类名为 kebab，对齐 cssr 元素名 (7bcf62a)
- **plugins**: 保留 bem 修复 PR #400 客户端样式回归（块祖先/挂载/错位） (b2ac295)
- **plugins**: 修复 PR #400 客户端样式回归（选择器/挂载/样式错位） (a280bb5)
- **pet**: 无可用宠物时隐藏侧栏桌宠入口图标 (94080c9)
- **plugin**: 插件页如实展示 cordis.patch.yml 配置覆盖禁用状态（issue #399） (0b9479c)
- **pet**: 延后桌宠点击穿透，规避 Linux/Wayland 启动崩溃 (#394) (18da4b7)
- **pet**: 未安装的默认预设宠物显示下载入口与可见提示 (7b7e3e0)
- **pet-mouse**: macOS callback 处理 drag 事件，更新光标位置 (5a7b864)
- **pet-mouse**: macOS CGEventTap 直监听，绕开 rdev 0.5.3 的 SIGTRAP (0407de7)
- remove duplicate shared icon alias (a6d55bb)
- normalize shared UI consumer compatibility (76cd103)
- clean desktop lint regressions (87cd1d4)
- align plugin consumers with shared UI exports (7148dd3)
- **pet**: open session event stream for unselected subagent sessions (927915c)
- **navbar**: 按 reviewer 反馈撤回设置/帮助图标改动，保留移除前进后退 (5c040e5)

### Refactors

- **host**: storage/index.ts exposes storage only, domain primitives in service/*.ts (6779347)
- unify tsconfig, tsdown as ts source, upstream type stubs (21aad41)
- **plugins**: unify register/* prefix across client plugins (81fc78f)
- **panel**: drop drag-handle mirror, keep width sync only (b608f80)
- **storage**: createStorage/localStorageDriver only, plugin-scoped storage (15a3851)
- **dsh-tauri**: apis/index.ts exports only fetch with built-in error normalization (688f1ed)
- **scheduler**: merge session-icon patch styles into index.cssr (3bfcc4b)
- **extension**: per-component cssr + shared index (562649d)
- **plugins**: converge styles to index.cssr + per-component cssr (980cdc7)
- **worktree**: per-component cssr + shared index (10cd33d)
- **scheduler**: per-component cssr files + shared index (eca7ba2)
- **panel**: split styles into per-component cssr + shared index (51c0195)
- **plugins**: inline className bem strings, drop class constants (90dc75c)
- **plugins**: migrate all remaining plugins to shared bem cssr (e457ab0)
- **plugins**: migrate rightclick and panel styles to bem cssr (ded649c)
- **plugins**: converge client apis to index.ts + index.type.ts (41f00fe)
- centralize official plugin types (a3670b2)
- centralize shared plugin UI (f407844)

### Documentation

- update AGENTS.plugins.md for fetch/storage/register* protocols (f345b13)
- update plugin optimization plans (c76f357)

### CI

- 在CI类型检查前构建核心共享包 (0605f94)

### Chores

- css-render 内联配置与 pet/UI 图标微调 (9f2b7df)
- remove packages .js extname (a41b216)

### Other Changes

- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (23e9fb6)
- Merge pull request #406 from hairyf/fix/pet-hide-sidebar-icon (b099ad8)
- Merge pull request #404 from dsh-tauri-desk/fix/issue-399-plugin-config-override (bab16fd)
- Merge pull request #405 from dsh-tauri-desk/fix/issue-396-pet-session-forwarding (16c683a)
- Merge pull request #402 from hairyf/fix/pet-default-preset-not-installed (7f082e1)
- Merge pull request #403 from dsh-tauri-desk/fix/pet-linux-clickthrough-defer-394 (7170ee4)
- fix(pet (9de86d3)
- Merge pull request #400 from dsh-tauri-desk/refactor/plugins-optimize (57bd6a0)
- Merge pull request #388 from X-SCI-TECH/codex/navbar-icon-buttons-drop-nav (2d973e1)
- refactor(host (f27f942)
- Merge pull request #398 from coderstory/fix/pet-mouse-macos-tsm-crash (3633929)
- refactor(extension (3d5bcda)
- Merge pull request #395 from dsh-tauri-desk/feat/pet-bubble-live-activity (031a946)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application version to **0.10.7-beta.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->