### PR TITLE
chore: release v0.10.7-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.7-beta.1",
+  "version": "0.10.7-beta.2",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.7-beta.1"
+version = "0.10.7-beta.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.7-beta.1"
+version = "0.10.7-beta.2"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.7-beta.1",
+  "version": "0.10.7-beta.2",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.10.7-beta.2` (`0.10.7-beta.1` → `0.10.7-beta.2`).

### Features

- **pet**: 会话增量改经宿主→Rust→桌宠流式下发，移除客户端轮询转发 (8e9fa7c)

### Bug Fixes

- **pet**: 不再默认选中内置鲸鱼宠物，全新安装无默认选择 (142e2a4)
- **pet**: 修复 use-bubble 的 ts/no-use-before-define lint 错误 (9d052c4)

### Styles

- prettier 统一排版并新增 sidebar 宿主/tauri 层规划文档 (2e1f4ec)

### Chores

- **plugins**: 将仅构建期内联的 css-render/bem/icons/smol-toml 移入 devDependencies (71e8d15)

### Other Changes

- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (597093c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to **0.10.7-beta.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->