### PR TITLE
feat(pet): 桌宠 toast 按工具展示操作明细

### DIFF
--- a/packages/dsh-tauri-pet/src/host/reducer.ts
+++ b/packages/dsh-tauri-pet/src/host/reducer.ts
@@ -176,16 +176,9 @@ export function foldPetPayload(state: PetSessionState): PetSessionPayload {
   }
 }
 
-/** 工具名 → liveActivity 展示对象（与 use-bubble.ts getLiveActivity 对齐：携带 args 供其解析 command/path）。 */
+/** 工具名 → liveActivity 展示对象（所有工具统一携带 name+args，展示标签由 use-bubble.ts 侧映射）。 */
 function toolActivity(name?: string, args?: string): PetSessionPayload['liveActivity'] {
-  if (!name)
-    return { kind: 'tool' }
-  const lower = name.toLowerCase()
-  if (lower === 'pwsh' || lower === 'bash')
-    return { kind: 'tool', name, args }
-  if (lower === 'str_replace_editor' || lower === 'edit' || lower === 'write')
-    return { kind: 'tool', name, args }
-  return { kind: 'tool', name, args }
+  return name ? { kind: 'tool', name, args } : { kind: 'tool' }
 }
 
 /**

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -34,6 +34,40 @@ const LABELS = {
   waitChoice: IS_ZH ? '需选择' : 'Needs your input',
 } as const
 
+/** 工具名 → toast 展示标签（沿用既有风格：英文工具名大写 / 中文动词）。 */
+const TOOL_LABELS: Record<string, string> = {
+  pwsh: 'Pwsh',
+  bash: 'Bash',
+  grep: 'Grep',
+  glob: 'Glob',
+  read: '读取',
+  read_image: '看图',
+  write: '写入',
+  edit: '编辑',
+  str_replace_editor: '编辑',
+  web_search: '搜索',
+  web_fetch: '抓取',
+  think: '思考',
+  skill: '技能',
+} as const
+
+/** 工具名 → 从 args（JSON 字符串）提取展示明细的键，按优先级取第一个非空值。 */
+const TOOL_ARG_KEYS: Record<string, readonly string[]> = {
+  pwsh: ['command'],
+  bash: ['command'],
+  grep: ['pattern'],
+  glob: ['pattern'],
+  read: ['file_path', 'path'],
+  read_image: ['file_path', 'path'],
+  write: ['file_path', 'path'],
+  edit: ['file_path', 'path'],
+  str_replace_editor: ['file_path', 'path'],
+  web_search: ['queries', 'query'],
+  web_fetch: ['url'],
+  think: ['thought'],
+  skill: ['name'],
+} as const
+
 /** 状态优先级映射，数值越大优先级越高 */
 const STATUS_PRIORITY: Record<string, number> = {
   'waiting': 4,
@@ -371,6 +405,37 @@ function sanitizeText(str: string): string {
   return str.replace(/\s+/g, ' ').trim()
 }
 
+/** 从工具 args（JSON 字符串）按优先级提取展示明细；解析失败或无匹配键时返回 undefined。 */
+function toolArgDetail(tool: string, args: unknown): string | undefined {
+  if (typeof args !== 'string' || !args)
+    return undefined
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(args)
+  }
+  catch {
+    return undefined
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+    return undefined
+
+  const record = parsed as Record<string, unknown>
+  for (const key of TOOL_ARG_KEYS[tool] ?? ['file_path', 'path']) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) {
+      return sanitizeText(value)
+    }
+    if (Array.isArray(value)) {
+      const first = value.find(item => typeof item === 'string' && item.trim())
+      if (typeof first === 'string' && first.trim()) {
+        return sanitizeText(first)
+      }
+    }
+  }
+  return undefined
+}
+
 /** 生成 Toast 渲染数据 */
 function toastContent(session: BubbleSession, status: PetStatus) {
   const getFirstString = (...items: unknown[]): string | undefined => {
@@ -394,37 +459,13 @@ function toastContent(session: BubbleSession, status: PetStatus) {
     }
 
     if (kind === 'tool' && typeof name === 'string' && name) {
-      let detail: string | undefined
-      if (typeof args === 'string' && args) {
-        try {
-          const parsed = JSON.parse(args)
-          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-            const keys = name === 'pwsh' || name === 'bash'
-              ? ['command']
-              : name === 'str_replace_editor'
-                ? ['path']
-                : ['file_path', 'path']
+      const tool = name.toLowerCase()
+      const label = TOOL_LABELS[tool]
+      if (!label)
+        return `工具调用 · ${name}`
 
-            for (const k of keys) {
-              if (typeof parsed[k] === 'string' && parsed[k].trim()) {
-                detail = sanitizeText(parsed[k])
-                break
-              }
-            }
-          }
-        }
-        catch {
-          // JSON 校验失败时容错
-        }
-      }
-
-      if (name === 'pwsh' || name === 'bash') {
-        return `${name === 'pwsh' ? 'Pwsh' : 'Bash'} · ${detail ?? '命令执行'}`
-      }
-      if (name === 'str_replace_editor' || name === 'edit' || name === 'write') {
-        return `编辑 · ${detail ?? name}`
-      }
-      return `工具调用 · ${name}`
+      const detail = toolArgDetail(tool, args)
+      return detail ? `${label} · ${detail}` : label
     }
 
     return undefined


### PR DESCRIPTION
## 背景

桌宠会话气泡（toast）的工具信息目前只有少数工具有专属展示（Pwsh/Bash/编辑），其余工具一律退化为「工具调用 · name」，且不携带任何操作明细，例如 grep/read 只显示 工具调用 · grep。

## 改动

**src/pet/hooks/use-bubble.ts（展示层）**

- 新增表驱动映射 TOOL_LABELS / TOOL_ARG_KEYS，覆盖 13 个常用工具：

  | 工具 | Toast |
  |---|---|
  | pwsh / bash | \Pwsh/Bash · command\ |
  | grep / glob | \Grep/Glob · pattern\ |
  | read | \读取 · file_path\ |
  | read_image | \看图 · file_path\ |
  | write | \写入 · file_path\ |
  | edit / str_replace_editor | \编辑 · file_path\ |
  | web_search | \搜索 · query\（queries 数组取首项） |
  | web_fetch | \抓取 · url\ |
  | think | \思考 · thought\ |
  | skill | \技能 · name\ |

- 新增 	oolArgDetail()：按优先级从 args JSON 提取首个非空明细（解析失败容错、支持数组字段）。
- 未命中的工具保持原回退「工具调用 · name」；思考（reasoning）路径不变。

**packages/dsh-tauri-pet/src/host/reducer.ts**

- 清理 	oolActivity() 死分支：三个分支返回完全相同，统一为单行（所有工具本就透传 name+args，展示映射全在 use-bubble 侧）。

## 验证

- \pnpm typecheck\ 通过
- \pnpm test\ 100/100 通过（含 dsh-tauri-pet reducer 14 项，确认工具 name+args 透传不变）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Experience**
  - Improved tool activity messages with clearer display labels and relevant argument details.
  - Added safer handling for tool arguments, including readable text and list values.
  - Unknown tools continue to display a generic activity message, while known tools without details show their label only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->