### PR TITLE
fix(panel): 新会话按钮恢复官方白底圆角形态，移除 menu-item 类覆盖

### DIFF
--- a/packages/dsh-tauri-panel/src/client/components/sidebar.cssr.test.ts
+++ b/packages/dsh-tauri-panel/src/client/components/sidebar.cssr.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import sidebarStyle from './sidebar.cssr'
+
+// dsh-tauri-ui/client 的 dist bundle 以 `window.__ModuleLoader__.load(...)` 包裹，
+// 脱离宿主加载器后无法在 node 环境求值；把该导入 mock 到同一 cssr 实例的源文件
+// （cssr.ts），使本包的样式树能在测试里直接 render() 核对选择器形态。
+// （vitest 会提升 vi.mock，声明位置在 import 之后也无碍。）
+vi.mock('dsh-tauri-ui/client', async () => {
+  const mod = await import('../../../../dsh-tauri-ui/src/client/cssr.ts')
+  return { cssr: mod.cssr }
+})
+
+describe('sidebar.cssr new-session（回归：白底 + 圆角的官方按钮形态）', () => {
+  const sidebarCss = sidebarStyle.render()
+
+  it('基态自给自足：镜像官方 ui-sidebar New Session 按钮（elevated-fill 白底、12px 圆角、38px、500 字重、.5px l3 描边）', () => {
+    const base = /\.dshp-panel \.dshp-panel__new-session\s*\{[^}]*\}/
+    const baseBody = sidebarCss.match(base)?.[0] ?? ''
+    expect(baseBody).toContain('background: var(--dsw-alias-button-elevated-fill)')
+    expect(baseBody).toContain('border-radius: 12px')
+    expect(baseBody).toContain('height: 38px')
+    expect(baseBody).toContain('font-weight: 500')
+    expect(baseBody).toContain('border: .5px solid var(--dsw-alias-border-l3)')
+  })
+
+  it('不依赖 .dshp-panel__menu-item 提供按钮基座：display:flex 等交互基座自含，折叠态规则仍生效', () => {
+    const base = /\.dshp-panel \.dshp-panel__new-session\s*\{[^}]*\}/
+    const baseBody = sidebarCss.match(base)?.[0] ?? ''
+    expect(baseBody).toContain('display: flex')
+    expect(baseBody).toContain('cursor: pointer')
+    expect(sidebarCss).toMatch(/\.dshp-panel\.dshp-panel--collapsed \.dshp-panel__new-session\s*\{[^}]*width: 36px[^}]*\}/)
+  })
+})

--- a/packages/dsh-tauri-panel/src/client/components/sidebar.cssr.ts
+++ b/packages/dsh-tauri-panel/src/client/components/sidebar.cssr.ts
@@ -102,20 +102,42 @@ export default b('panel', {
     paddingLeft: '4px',
     paddingRight: 'calc(var(--dsh-session-list-edge-inset) - var(--dsh-session-list-scrollbar-width) - var(--dsh-session-list-scrollbar-offset))',
   }),
+  // 新会话按钮是独立控件，不再挂 .dshp-panel__menu-item（那是面板区第三方功能项
+  // 的行样式，51c0195 拆分样式后 action-item.cssr 后挂载，同特异性下会把本块的
+  // 白底/圆角/描边全部覆盖成透明菜单行）。这里自给自足地镜像官方 ui-sidebar 的
+  // New Session 按钮（.hHd-Xa_newSession：elevated-fill 白底、12px 圆角、
+  // .5px l3 描边、38px 高、500 字重），并补上按钮交互基座
+  // （appearance/cursor/focus-visible/transition）。
   e('new-session', {
+    boxSizing: 'border-box',
+    appearance: 'none',
+    cursor: 'pointer',
+    userSelect: 'none',
     width: '100%',
+    minWidth: 0,
     height: '38px',
+    flex: 'none',
     margin: '0 0 4px',
     padding: '8px 16px',
-    border: '1px solid var(--dsw-alias-border-l2)',
+    border: '.5px solid var(--dsw-alias-border-l3)',
     borderRadius: '12px',
     background: 'var(--dsw-alias-button-elevated-fill)',
+    color: 'var(--dsw-alias-label-primary)',
+    display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     gap: '6px',
+    fontFamily: 'inherit',
+    fontSize: '14px',
     fontWeight: 500,
+    lineHeight: '22px',
+    textAlign: 'left',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    transition: 'background-color .12s var(--ds-ease-in-out), color .12s var(--ds-ease-in-out)',
   }, [
     c('&:hover', { background: 'var(--dsw-alias-button-floating-hover)' }),
+    c('&:focus-visible', { outline: '2px solid var(--dsw-alias-border-focus)', outlineOffset: '-2px' }),
   ]),
   e('region-area', {
     minHeight: 0,

--- a/packages/dsh-tauri-panel/src/client/components/sidebar.tsx
+++ b/packages/dsh-tauri-panel/src/client/components/sidebar.tsx
@@ -12,8 +12,9 @@ import sidebarStyle from './sidebar.cssr'
  *
  * 结构为官方 SidebarRoot（dsh-client-ui-sidebar 0.1.1-rc.2）的克隆，改动点：
  *   - logoRow 高度 60px → 32px、底部间距 8px → 4px（需求①②）；
- *   - 「新会话」按钮从 logoRow 下方移入**面板区**（需求③），样式改为
- *     workspace 菜单项行样式（需求④，镜像官方 Rows.module.css .sessionRow）；
+ *   - 「新会话」按钮从 logoRow 下方移入**面板区**（需求③），样式镜像官方
+ *     ui-sidebar 的 New Session 按钮（elevated-fill 白底 + 12px 圆角；
+ *     独立类自给自足，不挂 menu-item，避免与面板区条目样式互相覆盖）；
  *   - 面板区 = 新会话菜单项 + 第三方功能项（槽 `sidebar.panel.action`，
  *     list/root，本条目 children 声明，协议⑤，见 PROTOCOL.md）。
  *
@@ -144,7 +145,7 @@ export function SidebarRootClone({ collapsed, width, startSession, toggleSidebar
       <div className="dshp-panel__panel-area">
         <button
           type="button"
-          className={`${'dshp-panel__menu-item'} ${'dshp-panel__new-session'}`}
+          className="dshp-panel__new-session"
           title={t('session.new.label')}
           onClick={() => {
             console.warn('[dsh-tauri-panel] new session requested', { source: 'menu' })


### PR DESCRIPTION
## 背景

b2ac295 修复系列（PR #400 客户端样式回归）的后续回归：面板侧栏「新会话」按钮丢失了白色背景与圆角，变成透明菜单行。

## 根因

- 按钮同时挂 \dshp-panel__menu-item\（action-item.cssr）与 \dshp-panel__new-session\（sidebar.cssr）。
- plugin-bem 的 e() 在块内渲染为后代选择器（\.dshp-panel .dshp-panel__new-session\），与 menu-item 同为 (0,2,0) 特异性。
- 51c0195 拆分样式后，action-item.cssr 由面板区子组件（React 子 effect 先执行 + css-render head:true 插到已有 style 之前）挂载在 sidebar.cssr **之后**，同特异性下后挂载者胜出：
  menu-item 的 \ackground: transparent / border: 0 / border-radius: 8px / height: 34px / font-weight: 400\ 覆盖了新会话按钮的白底/圆角/描边。
- 官方 ui-sidebar 的 New Session 按钮是独立单类 \.hHd-Xa_newSession\，不存在该冲突。

## 修复

- sidebar.tsx：新会话按钮去掉 \dshp-panel__menu-item\，只保留独立类 \dshp-panel__new-session\（对齐官方单类设计）。
- sidebar.cssr.ts：\('new-session')\ 自给自足镜像官方 \.hHd-Xa_newSession\ —— elevated-fill 白底、12px 圆角、.5px l3 描边、38px 高、500 字重，并补齐 display:flex / cursor / appearance / focus-visible / transition 交互基座。
- 新增回归测试 sidebar.cssr.test.ts：render cssr 树断言白底/圆角/38px/500/.5px l3 描边自含、折叠态规则仍生效。

## 验证

- 根 \pnpm typecheck\、\pnpm test\（17 文件 102 用例全绿）、\pnpm build\、lint 通过。
- 已部署到运行中应用并实测：\getComputedStyle\ → \ackgroundColor: rgb(255, 255, 255)\、\orderRadius: 12px\、\height: 38px\、\ontWeight: 500\、\display: flex\。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the sidebar’s **New Session** button with a standalone elevated-fill appearance.
  - Improved button sizing, typography, spacing, borders, colors, transitions, and focus-visible behavior.
  - Preserved existing hover behavior and adjusted the button’s border styling.
  - Ensured the button maintains appropriate sizing when the sidebar is collapsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->