### PR TITLE
feat(pet): 工作状态细分档位联动（预设升级 + 动画/气泡接线 + 单测）

### DIFF
--- a/packages/dsh-tauri-pet/src/host/reducer.test.ts
+++ b/packages/dsh-tauri-pet/src/host/reducer.test.ts
@@ -39,26 +39,26 @@ describe('petSessionReducer (host)', () => {
     expect(pushes[0].payload.status).toBeUndefined()
   })
 
-  it('turn/start 让 running=true、status=running', () => {
+  it('turn/start 让 running=true、status=running、workStatus=thinking', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
     const last = pushes.at(-1)!
     expect(last.action).toBe('update')
-    expect(last.payload).toMatchObject({ id: 'a', running: true, status: 'running' })
+    expect(last.payload).toMatchObject({ id: 'a', running: true, status: 'running', workStatus: 'thinking' })
   })
 
-  it('assistant/chunk(reasoning-delta) 累积出 liveActivity=reasoning', () => {
+  it('assistant/chunk(reasoning-delta) 累积出 liveActivity=reasoning、workStatus=thinking', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
     reducer.apply(peer(), ev('assistant/chunk', { turn: 1, step: 1, chunk: { type: 'reasoning-delta', text: '思考' } }, 2))
     const last = pushes.at(-1)!
-    expect(last.payload).toMatchObject({ running: true, status: 'running' })
+    expect(last.payload).toMatchObject({ running: true, status: 'running', workStatus: 'thinking' })
     expect(last.payload.liveActivity).toMatchObject({ kind: 'reasoning', text: '思考' })
   })
 
-  it('tool/call 时 liveActivity 切换为工具名（携带 args），tool/result 后清空', () => {
+  it('tool/call 时 liveActivity 切换为工具名（携带 args）、workStatus=working，tool/result 后回 result', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
@@ -66,50 +66,66 @@ describe('petSessionReducer (host)', () => {
     reducer.apply(peer(), ev('tool/call', { turn: 1, step: 1, callId: 'c1', name: 'pwsh', arguments: '{"command":"ls"}' }, 3))
     const toolPush = pushes.at(-1)!
     expect(toolPush.payload.liveActivity).toMatchObject({ kind: 'tool', name: 'pwsh', args: '{"command":"ls"}' })
-    // tool/result 结束 c1，openTools 清空；reasoning 仍在 → 回到 reasoning。
+    expect(toolPush.payload).toMatchObject({ workStatus: 'working', toolActivity: 'commanding' })
+    // tool/result 结束 c1，openTools 清空；reasoning 仍在 → 回到 thinking 文案，档位切 result。
     reducer.apply(peer(), ev('tool/result', { turn: 1, step: 1, message: { content: [{ type: 'text', text: 'ok' }] } }, 4))
     const afterResult = pushes.at(-1)!
+    expect(afterResult.payload).toMatchObject({ workStatus: 'result' })
     expect(afterResult.payload.liveActivity).toMatchObject({ kind: 'reasoning', text: '思考' })
   })
 
-  it('approval/asked 让展示为 waiting(phase=approval)，approval/decided 后清除', () => {
+  it('tool/call 后仍有其他工具在跑 → workStatus 保持 working', () => {
+    const { reducer, pushes } = collect()
+    reducer.create(peer())
+    reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
+    reducer.apply(peer(), ev('tool/call', { turn: 1, step: 1, callId: 'c1', name: 'grep', arguments: '{"pattern":"x"}' }, 2))
+    reducer.apply(peer(), ev('tool/call', { turn: 1, step: 1, callId: 'c2', name: 'read', arguments: '{"file_path":"a.ts"}' }, 3))
+    // 结束 c1 后 c2 仍在 openTools → 档位依旧 working（不落回 thinking/result）。
+    reducer.apply(peer(), ev('tool/result', { turn: 1, step: 1, message: { source: { callId: 'c1' } } }, 4))
+    const last = pushes.at(-1)!
+    expect(last.payload).toMatchObject({ workStatus: 'working', toolActivity: 'searching' })
+  })
+
+  it('approval/asked 让展示为 waiting(phase=approval, workStatus=waiting)，approval/decided 后回 thinking', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
     reducer.apply(peer(), ev('approval/asked', { id: 'ap1', toolName: 'plan_final_approval' }, 2))
     const asked = pushes.at(-1)!
-    expect(asked.payload).toMatchObject({ running: true, status: 'waiting', phase: 'approval' })
-    // 相同 id 的 decided 清除等待态；running 仍在 → 回到 running。
+    expect(asked.payload).toMatchObject({ running: true, status: 'waiting', phase: 'approval', workStatus: 'waiting' })
+    // 相同 id 的 decided 清除等待态；running 仍在 → 回到 running（细分为 thinking，无工具在跑）。
     reducer.apply(peer(), ev('approval/decided', { id: 'ap1' }, 3))
     const decided = pushes.at(-1)!
     expect(decided.payload.status).toBe('running')
     expect(decided.payload.phase).toBeUndefined()
+    expect(decided.payload).toMatchObject({ workStatus: 'thinking' })
   })
 
-  it('user-question 工具调用让展示为 waiting(phase=user-question)，user/message 应答后清除', () => {
+  it('user-question 工具调用让展示为 waiting(phase=user-question, workStatus=waiting)，user/message 应答后清除', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
     reducer.apply(peer(), ev('tool/call', { turn: 1, step: 1, callId: 'uq1', name: 'ask_user_question', arguments: '{}' }, 2))
     const waiting = pushes.at(-1)!
-    expect(waiting.payload).toMatchObject({ running: true, status: 'waiting', phase: 'user-question' })
-    // 用户应答后（user/message）清除等待态。
+    expect(waiting.payload).toMatchObject({ running: true, status: 'waiting', phase: 'user-question', workStatus: 'waiting' })
+    // 用户应答后（user/message）清除等待态，问句工具仍在 openTools → 回 working。
     reducer.apply(peer(), ev('user/message', { turn: 1, message: { role: 'user', content: [{ type: 'text', text: '继续' }] } }, 3))
     const afterAnswer = pushes.at(-1)!
     expect(afterAnswer.payload.status).toBe('running')
     expect(afterAnswer.payload.phase).toBeUndefined()
+    expect(afterAnswer.payload).toMatchObject({ workStatus: 'working' })
   })
 
-  it('turn/end(blocked) 让展示为 waiting(phase=blocked)（等待用户处理非思考中）', () => {
+  it('turn/end(blocked) 让展示为 waiting(phase=blocked, workStatus=waiting)（等待用户处理非思考中）', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
     reducer.apply(peer(), ev('turn/end', { turn: 1, reason: { kind: 'blocked' } }, 2))
     const last = pushes.at(-1)!
-    expect(last.payload).toMatchObject({ running: false, status: 'waiting', phase: 'blocked' })
+    expect(last.payload).toMatchObject({ running: false, status: 'waiting', phase: 'blocked', workStatus: 'waiting' })
   })
 
-  it('turn/end(completed) 把 running 翻回 false、status 清空', () => {
+  it('turn/end(completed) 把 running 翻回 false、粗 status 清空、workStatus=success（终态庆祝档）', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
@@ -118,10 +134,11 @@ describe('petSessionReducer (host)', () => {
     const last = pushes.at(-1)!
     expect(last.payload).toMatchObject({ id: 'a', running: false })
     expect(last.payload.status).toBeUndefined()
+    expect(last.payload).toMatchObject({ workStatus: 'success' })
     expect(last.payload.liveActivity).toBeUndefined()
   })
 
-  it('turn/end(error) 记录 lastAgentError → status=error', () => {
+  it('turn/end(error) 记录 lastAgentError → 粗 status=error、workStatus=error（终态失败档）', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
@@ -130,7 +147,60 @@ describe('petSessionReducer (host)', () => {
       reason: { kind: 'error', error: { message: 'boom' } },
     }, 2))
     const last = pushes.at(-1)!
-    expect(last.payload).toMatchObject({ running: false, status: 'error', lastAgentError: 'boom' })
+    expect(last.payload).toMatchObject({ running: false, status: 'error', lastAgentError: 'boom', workStatus: 'error' })
+  })
+
+  it('turn/end(max-tokens) 归为 workStatus=error（输出上限）', () => {
+    const { reducer, pushes } = collect()
+    reducer.create(peer())
+    reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
+    reducer.apply(peer(), ev('turn/end', { turn: 1, reason: { kind: 'max-tokens' } }, 2))
+    const last = pushes.at(-1)!
+    expect(last.payload).toMatchObject({ workStatus: 'error', lastAgentError: 'max-tokens' })
+  })
+
+  it('turn/end(aborted) 清档：workStatus 为空（不残留上一档，防止一直 working 挂死）', () => {
+    const { reducer, pushes } = collect()
+    reducer.create(peer())
+    reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
+    reducer.apply(peer(), ev('tool/call', { turn: 1, step: 1, callId: 'c1', name: 'pwsh', arguments: '{}' }, 2))
+    reducer.apply(peer(), ev('turn/end', { turn: 1, reason: { kind: 'aborted' } }, 3))
+    const last = pushes.at(-1)!
+    expect(last.payload).toMatchObject({ running: false })
+    expect(last.payload.workStatus).toBeUndefined()
+  })
+
+  it('tool/result 的工具级错误不写入 lastAgentError（回合仍在跑时不得判 failed 收起气泡）', () => {
+    const { reducer, pushes } = collect()
+    reducer.create(peer())
+    reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
+    reducer.apply(peer(), ev('tool/call', { turn: 1, step: 1, callId: 'c1', name: 'pwsh', arguments: '{}' }, 2))
+    // 工具执行失败（data.error），但回合未结束：不得污染 lastAgentError / 粗 status。
+    reducer.apply(peer(), ev('tool/result', {
+      turn: 1,
+      step: 1,
+      error: { name: 'EPERM', message: 'operation not permitted' },
+    }, 3))
+    const last = pushes.at(-1)!
+    expect(last.payload.lastAgentError).toBeUndefined()
+    expect(last.payload.status).toBe('running')
+    expect(last.payload).toMatchObject({ workStatus: 'result' })
+  })
+
+  it('新回合 turn/start 清除上一回合的 lastAgentError 残留（错误不跨回合）', () => {
+    const { reducer, pushes } = collect()
+    reducer.create(peer())
+    reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
+    reducer.apply(peer(), ev('turn/end', {
+      turn: 1,
+      reason: { kind: 'error', error: { message: 'boom' } },
+    }, 2))
+    expect(pushes.at(-1)!.payload).toMatchObject({ workStatus: 'error', lastAgentError: 'boom' })
+    // 用户继续对话 → 新回合：错误清除，档位回 thinking。
+    reducer.apply(peer(), ev('turn/start', { turn: 2 }, 3))
+    const next = pushes.at(-1)!
+    expect(next.payload.lastAgentError).toBeUndefined()
+    expect(next.payload).toMatchObject({ workStatus: 'thinking' })
   })
 
   it('展示态未变化时不重复转发（去重，防 #396 高频转发）', () => {
@@ -192,11 +262,20 @@ describe('petSessionReducer (host)', () => {
     expect(last.payload.origin).toBe('subagent')
   })
 
-  it('filter 只对 foldable 事件转发：todo/write 等 log-only 事件不产生 update', () => {
+  it('todo/write 更新当前任务：task 首次写入才转发（供气泡 taskCopy 文案），重复相同不转发', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
+    reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
     const before = pushes.length
-    reducer.apply(peer(), ev('todo/write', { todos: [{ id: 't1', content: 'x' }] }, 1))
+    // 无 in_progress/pending 项：task 不变，不转发。
+    reducer.apply(peer(), ev('todo/write', { todos: [{ id: 't0', status: 'completed', content: 'x' }] }, 2))
     expect(pushes.length).toBe(before)
+    // 出现 in_progress 任务：task 变化 → 转发（气泡显示「正在处理 xxx」）。
+    reducer.apply(peer(), ev('todo/write', { todos: [{ id: 't1', status: 'in_progress', content: '整理文档' }] }, 3))
+    const withTask = pushes.at(-1)!
+    expect(withTask.payload).toMatchObject({ task: '整理文档' })
+    // 相同任务再次写入：无变化，不重复转发。
+    reducer.apply(peer(), ev('todo/write', { todos: [{ id: 't1', status: 'in_progress', content: '整理文档' }] }, 4))
+    expect(pushes.length).toBe(before + 1)
   })
 })

--- a/packages/dsh-tauri-pet/src/host/reducer.ts
+++ b/packages/dsh-tauri-pet/src/host/reducer.ts
@@ -43,8 +43,38 @@ export interface PetSessionPeer {
 }
 
 /**
+ * 工作状态细分档位（对齐 dsh-pet src/shared/work-status.ts 的 6 档枚举；
+ * 索引 = config.jsonc animations.events.workStatus 数组索引，勿在中间插入新档）。
+ * 取代旧「粗档 status（error/waiting/running）」成为会话气泡与动画的权威驱动：
+ *   - thinking：turn/start 或回合内思考（无工具在跑）
+ *   - working：tool/call 工具调用中
+ *   - result：tool/result 后整理（无其余工具在跑）
+ *   - waiting：approval/asked、问句工具、turn/end blocked（等用户）
+ *   - success：turn/end completed（终态档，播一次庆祝后回落）
+ *   - error：turn/end error/max-tokens/timeout（终态档）
+ * 语义对齐 dsh-pet src/host/work-status.ts 的 reduceWorkStatus，并叠加
+ * dsh-dafeiyu companion-reducer 的累计态语义（openTools 有剩 → 保持 working）。
+ */
+export type PetWorkStatus = 'thinking' | 'working' | 'result' | 'waiting' | 'success' | 'error'
+
+/** 档位 → events.workStatus 数组索引（与 config.jsonc 顺序严格一致）。 */
+export const PET_WORK_STATUS_INDEX: Record<PetWorkStatus, number> = {
+  thinking: 0,
+  working: 1,
+  result: 2,
+  waiting: 3,
+  success: 4,
+  error: 5,
+}
+
+/** 工具活动分类（对齐 dsh-dafeiyu companion-reducer 的 toolActivity）：气泡按分类选文案。 */
+export type PetToolActivity = 'searching' | 'editing' | 'testing' | 'commanding' | 'using-tool'
+
+/**
  * 桌宠展示态的字段子集（与客户端 projection.ts 的 PET_FORWARDED_FIELDS
  * + PET_FORWARDED_ACTIVITY_FIELD='liveActivity' 对齐；origin 已加入）。
+ * workStatus/task/toolActivity 为细分档位新增字段：气泡文案（use-bubble.ts）
+ * 与动画切档（pet-config 的 PRESET_SESSION_ANIMATIONS）都以此为驱动。
  */
 export interface PetSessionPayload {
   id: string
@@ -61,6 +91,12 @@ export interface PetSessionPayload {
   pendingInteraction?: unknown
   pending?: readonly unknown[]
   lastAgentError?: string
+  /** 细分工作状态档位（thinking/working/result/waiting/success/error）。 */
+  workStatus?: PetWorkStatus
+  /** 当前任务文本（todo/write 的 in_progress/pending 项），供气泡 taskCopy 文案。 */
+  task?: string
+  /** 当前工具活动分类（working 期间），供气泡 activityCopy 文案。 */
+  toolActivity?: PetToolActivity
   liveActivity?: {
     kind: string
     text?: string
@@ -98,6 +134,12 @@ export interface PetSessionState {
   waitingApprovalId?: string
   /** 当前「等用户回答」的问句工具调用 id（来自 user-question tool/call）。 */
   waitingCallId?: string
+  /** 细分工作状态档位（thinking/working/result/waiting/success/error；随事件变化）。 */
+  workStatus?: PetWorkStatus
+  /** 当前任务文本（todo/write 的 in_progress/pending 项 content，无则为空）。 */
+  task?: string
+  /** 当前工具活动分类（最近一次 working 工具名分类，供气泡 activityCopy 文案）。 */
+  toolActivity?: PetToolActivity
   /** 首次写入时间戳，当前不用于去重（保留给未来生命周期）。 */
   firstSeqAt: number
 }
@@ -131,6 +173,9 @@ function payloadEqual(a: PetSessionPayload, b: PetSessionPayload): boolean {
     && Object.is(a.origin, b.origin)
     && Object.is(a.title, b.title)
     && Object.is(a.displayTitle, b.displayTitle)
+    && Object.is(a.workStatus, b.workStatus)
+    && Object.is(a.task, b.task)
+    && Object.is(a.toolActivity, b.toolActivity)
     && Object.is(a.liveActivity?.kind, b.liveActivity?.kind)
     && Object.is(a.liveActivity?.text, b.liveActivity?.text)
     && Object.is(a.liveActivity?.name, b.liveActivity?.name)
@@ -151,6 +196,7 @@ export function foldPetPayload(state: PetSessionState): PetSessionPayload {
       ? { kind: 'reasoning', text: state.reasoningTail }
       : undefined
 
+  // 细分档位是权威（气泡/动画按它切档）；粗 status 保留作兼容回退。
   let status: string | undefined
   if (state.lastAgentError)
     status = 'error'
@@ -172,6 +218,9 @@ export function foldPetPayload(state: PetSessionState): PetSessionPayload {
     phase: state.waitingKind,
     running: state.running,
     lastAgentError: state.lastAgentError,
+    workStatus: state.workStatus,
+    task: state.task,
+    toolActivity: state.toolActivity,
     liveActivity,
   }
 }
@@ -245,6 +294,29 @@ function isUserQuestionTool(name?: string): boolean {
   return hasUserNoun || hasNounFromUser || hasAsk || strong || submitsPlanForApproval
 }
 
+/** 工具名 → 活动分类（对齐 dsh-dafeiyu companion-reducer 的 toolActivity + DSH 实际工具名 pwsh）：气泡按分类选文案。 */
+export function toolActivityOf(name?: string): PetToolActivity {
+  const value = String(name || '').toLowerCase()
+  if (/search|grep|find|glob|web|read|fetch|open/.test(value))
+    return 'searching'
+  if (/write|edit|patch|replace|create|move|delete/.test(value))
+    return 'editing'
+  if (/test|check|lint|build|verify/.test(value))
+    return 'testing'
+  if (/shell|bash|exec|command|terminal|powershell|pwsh/.test(value))
+    return 'commanding'
+  return 'using-tool'
+}
+
+/** 从 todo/write 提取当前任务文本（in_progress 优先、其次 pending；与 dsh-dafeiyu 的 #todo 一致）。 */
+export function currentTaskFromTodo(data: Record<string, unknown>): string | undefined {
+  const todos = Array.isArray(data.todos) ? (data.todos as Array<{ status?: string, content?: string }>) : []
+  const current = todos.find(todo => todo?.status === 'in_progress')
+    ?? todos.find(todo => todo?.status === 'pending')
+  const content = String(current?.content ?? '').trim()
+  return content || undefined
+}
+
 /** 一次会话增量事件的 reducer：返回变化后的 payload 或 null（未变化则不转发）。 */
 export function reduceSessionEvent(
   state: PetSessionState,
@@ -263,18 +335,28 @@ export function reduceSessionEvent(
       state.waitingKind = undefined
       state.waitingApprovalId = undefined
       state.waitingCallId = undefined
+      // 新回合开始：清上一回合的终态错误与任务残留，避免「上一轮报错、本轮继续跑」
+      // 时 use-bubble 仍按 lastAgentError 判 failed 收起气泡。
+      state.lastAgentError = undefined
+      state.workStatus = 'thinking'
+      state.task = undefined
       break
     }
     case 'step/start':
     case 'assistant/chunk': {
       state.stepActive = true
       state.running = true
+      if (t === 'step/start' && !state.waitingKind && state.openTools.size === 0)
+        state.workStatus = 'thinking'
       if (t === 'assistant/chunk') {
         // StreamChunk 真实形状：reasoning-delta / text-delta 携带增量 text（非 chunk.content）。
         const chunk = data.chunk as { type?: string, text?: string } | undefined
         if (chunk?.type === 'reasoning-delta' && typeof chunk.text === 'string' && chunk.text) {
           // 滚动尾部窗口：只保留最近的文本，新内容不断挤掉最早的，气泡即可实时滚动更新。
           state.reasoningTail = (state.reasoningTail + chunk.text).slice(-PET_REASONING_TAIL_WINDOW)
+          // 回合内思考（无工具在跑）→ thinking：气泡显示「正在认真想下一步」。
+          if (!state.waitingKind && state.openTools.size === 0)
+            state.workStatus = 'thinking'
           // reasoning 需要实时浮出（气泡「思考 · text」），但不逐 token 洪泛：仅当
           // 尾部文本实际变化才折叠（下方 foldable 判定对 assistant/chunk 在本分支处理）。
           return foldPetPayload(state)
@@ -294,6 +376,8 @@ export function reduceSessionEvent(
       const text = blocks?.filter(b => b?.type === 'text' && typeof b.text === 'string').map(b => b.text).join('')
       if (text)
         state.assistantText = text.slice(-1000)
+      if (!state.waitingKind && state.openTools.size === 0)
+        state.workStatus = 'thinking'
       break
     }
     case 'tool/call': {
@@ -307,6 +391,12 @@ export function reduceSessionEvent(
       if (name && isUserQuestionTool(name)) {
         state.waitingKind = 'user-question'
         state.waitingCallId = tc.callId ?? name
+        state.workStatus = 'waiting'
+      }
+      else {
+        if (name)
+          state.toolActivity = toolActivityOf(name)
+        state.workStatus = 'working'
       }
       break
     }
@@ -324,9 +414,18 @@ export function reduceSessionEvent(
       else {
         state.openTools.clear()
       }
-      const err = data.error as { name?: string } | undefined
-      if (err?.name)
-        state.lastAgentError = String(err.name)
+      // 注意：工具级失败（data.error）不写入 lastAgentError —— 那是回合级终态语义，
+      // 写入后 use-bubble 会把本会话判为 failed 并 4s 收起气泡，而回合仍在跑（对齐
+      // dsh-dafeiyu：tool/result 错误只发 toolError 提示，状态回 WORKING/THINKING，
+      // 不污染终态）。回合真正失败由 turn/end(error) 负责记录。
+      // 工具完成回整理（dsh-pet：tool/result → result 档）；仍有工具在跑则保持 working。
+      if (state.openTools.size > 0) {
+        state.workStatus = 'working'
+        state.toolActivity = toolActivityOf(state.openTools.values().next().value?.name)
+      }
+      else {
+        state.workStatus = state.waitingKind ? 'waiting' : 'result'
+      }
       break
     }
     case 'approval/asked': {
@@ -335,6 +434,7 @@ export function reduceSessionEvent(
       state.waitingKind = 'approval'
       state.waitingApprovalId = id
       state.running = true
+      state.workStatus = 'waiting'
       break
     }
     case 'approval/decided': {
@@ -342,6 +442,8 @@ export function reduceSessionEvent(
       if (state.waitingApprovalId && id === state.waitingApprovalId) {
         state.waitingApprovalId = undefined
         state.waitingKind = undefined
+        // 审批通过后继续干活：还有工具在跑 → working；否则回思考。
+        state.workStatus = state.openTools.size > 0 ? 'working' : 'thinking'
       }
       else {
         // 与当前记录不匹配：状态未变，不转发。
@@ -354,12 +456,23 @@ export function reduceSessionEvent(
       // 避免把用户提示当成助手描述。展示 message 只来自 assistant/message。
       state.running = true
       state.turnActive = true
-      // 若此前在等用户回答（问句工具），用户已应答 → 清除等待态。
+      // 若此前在等用户回答（问句工具），用户已应答 → 清除等待态，继续干活。
       if (state.waitingCallId !== undefined) {
         state.waitingKind = undefined
         state.waitingCallId = undefined
+        state.workStatus = state.openTools.size > 0 ? 'working' : 'thinking'
       }
       break
+    }
+    case 'todo/write': {
+      // 任务清单更新：当前任务（in_progress/pending）作为气泡 taskCopy 文案来源。
+      const task = currentTaskFromTodo(data)
+      if (task !== state.task) {
+        state.task = task
+        // task 变化即转发（供气泡展示「正在处理 xxx」）；其余字段不动。
+        return foldPetPayload(state)
+      }
+      return null
     }
     case 'session/title': {
       // 会话标题日志事件：覆盖身份字段（title/displayTitle 取同一值；origin 由 peer 权威覆盖）。
@@ -383,12 +496,29 @@ export function reduceSessionEvent(
       if (reason?.kind === 'blocked') {
         // 会话被阻塞等待用户处理：展示为「等待中」。
         state.waitingKind = 'blocked'
+        state.workStatus = 'waiting'
       }
       else {
         state.waitingKind = undefined
-        if (reason?.kind === 'error' || reason?.kind === 'aborted') {
+        const kind = reason?.kind
+        if (kind === 'completed') {
+          // 回合完成（终态档）：播一次庆祝动画；lastAgentError 清空（本轮无错）。
+          state.workStatus = 'success'
+          state.lastAgentError = undefined
+        }
+        else if (kind === 'error' || kind === 'max-tokens' || kind === 'timeout') {
+          // 失败/达上限（终态档）：record error 信息供气泡展示失败详情。
+          state.workStatus = 'error'
           const errBody = (data as { reason?: { error?: { message?: string } } }).reason
-          state.lastAgentError = errBody?.error?.message ?? reason.kind
+          state.lastAgentError = errBody?.error?.message ?? kind
+        }
+        else {
+          // aborted 等：回合中断，清档回空闲（绝不残留上一档，防止「一直 working」挂死）。
+          state.workStatus = undefined
+          if (kind === 'error' || kind === 'aborted') {
+            const errBody = (data as { reason?: { error?: { message?: string } } }).reason
+            state.lastAgentError = errBody?.error?.message ?? kind
+          }
         }
       }
       break
@@ -422,6 +552,7 @@ export function reduceSessionEvent(
  * 避免逐 token 洪泛 —— 状态实时累积，但最多每 500ms 推送一次最新尾部。
  * @param handle - 变化时回调 (action, payload)。
  * @param opts - 可选注入时钟（默认 Date.now），供单测 hermetic 推进时间。
+ * @param opts.now - 时钟函数（ms），节流窗口判定用；默认 Date.now。
  */
 export function createPetSessionReducer(
   handle: (action: 'create' | 'update' | 'remove', payload: PetSessionPayload) => void,

--- a/src-tauri/resources/preset-pets.json
+++ b/src-tauri/resources/preset-pets.json
@@ -3,9 +3,9 @@
     "id": "maid-deepseek-whale",
     "name": "Maid DeepSeek Whale",
     "desc": "一只小小的七比蓝头发的鲸鱼女仆Codex宠物，穿着海军蓝裙子，白色褶边，蓝眼睛，侧鳍和鲸鱼尾巴。",
-    "image": "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/f0f772e9cda4074d1870c97afd01dc26b91e943c/dsh-pet/assets/preview/daiji-huxi-xiuxian.gif",
+    "image": "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/e1ff8c1e4001878cbb80441262d530e16541f138/dsh-pet/assets/preview/daiji-huxi-xiuxian.gif",
     "repo": "https://github.com/PC2005-cloud/dsh-pet",
-    "ref": "f0f772e9cda4074d1870c97afd01dc26b91e943c",
+    "ref": "e1ff8c1e4001878cbb80441262d530e16541f138",
     "assets": "dsh-pet/assets",
     "sizeMb": 113
   }

--- a/src/pet/app.tsx
+++ b/src/pet/app.tsx
@@ -8,6 +8,7 @@ import { useBubble } from './hooks/use-bubble'
 import { useDrag } from './hooks/use-drag'
 import { useOmitIgnoreCursorEvents } from './hooks/use-omit-ignore-cursor-events'
 import { usePet } from './hooks/use-pet'
+import { isLoopingAnimation } from './pet-config'
 
 /** 拖拽方向 → 动画状态：桌面宠物在原生拖拽期间播放对应的移动动画。 */
 const DRAW_STATUS: Record<DragDirection, PetStatus> = {
@@ -30,8 +31,10 @@ export function App() {
     () => {
       if (bubble.status === undefined)
         return pet.clear()
+      // 细分档位（thinking/working/result/waiting）与 running 均为循环档；
+      // 终态档（success/error）与 review/failed 播一次后回落（handleEnded）。
       pet.change({
-        loop: bubble.status === 'running',
+        loop: isLoopingAnimation(bubble.status),
         status: bubble.status,
       })
     },

--- a/src/pet/components/pet.tsx
+++ b/src/pet/components/pet.tsx
@@ -8,11 +8,13 @@ import { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react
 import { If } from 'react-if-lite'
 import { PET_STATUSES } from '../hooks/use-pet'
 import {
+  isLoopingAnimation,
   pick,
   pickCategoryAction,
   poolEntryToStatus,
   resolvePresetName,
   rollKind,
+  spriteStatusFallback,
 } from '../pet-config'
 
 const PET_BASE_WIDTH = 220
@@ -621,13 +623,6 @@ function isSupportedAsset(value: Asset): boolean {
     && value.spritesheet.length > 0
 }
 
-function isLoopingAnimation(activity: Animation | string): boolean {
-  // moving-* 与 dragging 仅存在于原生拖拽期间（手势状态），持续播放直到拖拽结束。
-  return activity === 'idle' || activity === 'running'
-    || activity === 'moving-left' || activity === 'moving-right'
-    || activity === 'dragging'
-}
-
 function spriteSequence(activity: Animation | string, reducedMotion: boolean, loop: boolean): { frames: Frame[], loopStart: number | null } {
   const idleFrames = IDLE_DURATIONS.map((duration, column) => ({ column, duration: duration * 6, row: 0 }))
   const action = spriteAction(activity)
@@ -643,7 +638,10 @@ function spriteSequence(activity: Animation | string, reducedMotion: boolean, lo
 function spriteAction(activity: Animation | string): Frame[] {
   if (activity === 'idle')
     return IDLE_DURATIONS.map((duration, column) => ({ column, duration, row: 0 }))
-  const mapped = activity === 'turn' ? 'moving-right' : activity === 'bubble' ? 'waving' : activity === 'dragging' ? 'moving-right' : activity
+  // 自定义图集无细分档行：先近似映射到既有行（thinking→waiting 等），
+  // 此类档位对预设宠物（WebM）不影响——它们走 resolvePresetName 直接命中资产。
+  const base = spriteStatusFallback(activity)
+  const mapped = base === 'turn' ? 'moving-right' : base === 'bubble' ? 'waving' : base === 'dragging' ? 'moving-right' : base
   const config = ACTIONS[mapped as keyof typeof ACTIONS] ?? ACTIONS.waving
   return Array.from({ length: config.frames }, (_, column) => ({
     column,

--- a/src/pet/hooks/bubble-copy.test.ts
+++ b/src/pet/hooks/bubble-copy.test.ts
@@ -1,0 +1,104 @@
+/**
+ * bubble-copy.test.ts — 桌宠气泡文案纯函数（对齐 dsh-dafeiyu src/status-copy.js）单测。
+ *
+ * 覆盖：seed 稳定选句（同 seed 恒定、不同 seed 可换句）、分组回落、工具活动分类
+ * 文案、taskCopy 句式（对齐 dsh-dafeiyu：正在/继续、动作动词、默认处理「…」）。
+ */
+import { describe, expect, it } from 'vitest'
+import { activityCopy, seedNumber, statusCopy, taskCopy, toolActivityGroup } from './bubble-copy'
+
+describe('seedNumber', () => {
+  it('numeric strings resolve to the absolute truncated integer', () => {
+    expect(seedNumber('12.9')).toBe(12)
+    expect(seedNumber('-7')).toBe(7)
+    expect(seedNumber(5)).toBe(5)
+  })
+
+  it('non-numeric strings sum char code points (stable per string)', () => {
+    expect(seedNumber('abc')).toBe(97 + 98 + 99)
+    expect(seedNumber('abc')).toBe(seedNumber('abc'))
+    expect(seedNumber(undefined)).toBe(0)
+    expect(seedNumber('')).toBe(0)
+  })
+})
+
+describe('statusCopy', () => {
+  it('returns a stable sentence for the same seed within a group', () => {
+    const first = statusCopy('thinking', 'session-1')
+    expect(statusCopy('thinking', 'session-1')).toBe(first)
+  })
+
+  it('picks from known groups only', () => {
+    const variants = new Set(['正在分析', '思考中', '整理结果中'])
+    expect(variants.has(statusCopy('thinking', 0))).toBe(true)
+    expect(variants.has(statusCopy('thinking', 1))).toBe(true)
+  })
+
+  it('falls back to the working group for unknown groups', () => {
+    expect(['正在处理任务', '步骤正在进行中', '系统运行中']).toContain(statusCopy('unknown-group', 0))
+  })
+})
+
+describe('activityCopy', () => {
+  it('maps activity categories to their copy groups', () => {
+    expect(['正在检索', '正在项目中进行全面搜索', '正在调阅相关文件']).toContain(activityCopy('searching', 0))
+    expect(['正在修改', '正在写入变更内容', '正在调整代码实现']).toContain(activityCopy('editing', 1))
+    expect(['正在检验', '正在运行测试集进行确认', '正在验证变更有效性']).toContain(activityCopy('testing', 2))
+    expect(['正在执行', '正在启动项目服务', '正在监控指令执行状态']).toContain(activityCopy('commanding', 3))
+  })
+
+  it('falls back to the working group for missing activity categories', () => {
+    expect(['正在处理任务', '步骤正在进行中', '系统运行中']).toContain(activityCopy('weird', 0))
+  })
+})
+
+describe('toolActivityGroup', () => {
+  it('classifies search/read/fetch tools as searching', () => {
+    expect(toolActivityGroup('grep')).toBe('searching')
+    expect(toolActivityGroup('read')).toBe('searching')
+    expect(toolActivityGroup('web_fetch')).toBe('searching')
+  })
+
+  it('classifies write/edit tools as editing', () => {
+    expect(toolActivityGroup('write')).toBe('editing')
+    expect(toolActivityGroup('str_replace_editor')).toBe('editing')
+  })
+
+  it('classifies test/lint/build tools as testing', () => {
+    expect(toolActivityGroup('run_test')).toBe('testing')
+    expect(toolActivityGroup('lint')).toBe('testing')
+  })
+
+  it('classifies shell/terminal tools as commanding', () => {
+    expect(toolActivityGroup('pwsh')).toBe('commanding')
+    expect(toolActivityGroup('bash')).toBe('commanding')
+  })
+
+  it('returns working for unmatched tools', () => {
+    expect(toolActivityGroup('think')).toBe('working')
+    expect(toolActivityGroup(undefined)).toBe('working')
+  })
+})
+
+describe('taskCopy', () => {
+  it('strips trailing punctuation and keeps 正在/继续-prefixed tasks as-is plus 呢', () => {
+    expect(taskCopy('正在写测试。')).toBe('正在写测试呢')
+    expect(taskCopy('继续修改文档')).toBe('继续修改文档呢')
+  })
+
+  it('prefixes action-verb tasks with 正在 (dsh-dafeiyu 句式：正在 + 原文 + 呢)', () => {
+    expect(taskCopy('修改 bug')).toBe('正在修改 bug呢')
+    expect(taskCopy('搜索相关代码')).toBe('正在搜索相关代码呢')
+    expect(taskCopy('整理文档')).toBe('正在整理文档呢')
+  })
+
+  it('wraps other tasks in 正在处理「…」呢', () => {
+    expect(taskCopy('把动画接到气泡')).toBe('正在处理「把动画接到气泡」呢')
+  })
+
+  it('returns undefined for empty/whitespace tasks', () => {
+    expect(taskCopy(undefined)).toBeUndefined()
+    expect(taskCopy('   ')).toBeUndefined()
+    expect(taskCopy('')).toBeUndefined()
+  })
+})

--- a/src/pet/hooks/bubble-copy.ts
+++ b/src/pet/hooks/bubble-copy.ts
@@ -1,0 +1,119 @@
+/**
+ * bubble-copy.ts — 桌宠会话气泡文案的纯逻辑层（对齐 dsh-dafeiyu src/status-copy.js）。
+ *
+ * 分组文案（thinking/working/result/waiting/approval/success/error/…）+ seed 稳定选句、
+ * 工具活动分类文案（activityCopy）、todo 任务文案（taskCopy）都是纯函数，无 React/DOM
+ * 依赖，可独立单测。use-bubble.ts 只负责把会话状态喂进来取一句展示。
+ * 桌宠窗口无 i18n 基础设施：按窗口语言（IS_ZH）就地取中/英文案。
+ */
+
+/** 桌宠窗口无 i18n 基础设施，就地按窗口语言取单语文案（与 pet.tsx 保留文案一致）。 */
+const IS_ZH = (typeof document !== 'undefined' ? document.documentElement.lang || navigator.language : 'zh-CN')
+  .toLowerCase()
+  .startsWith('zh')
+
+/**
+ * 气泡文案库（对齐 dsh-dafeiyu src/status-copy.js 分组 + seed 稳定选句）。
+ * 各组多备选句：statusCopy 按会话稳定 seed 选一句，避免同一会话反复切换文案。
+ */
+const STATUS_COPY: Record<string, readonly string[]> = {
+  thinking: IS_ZH
+    ? ['正在分析', '思考中', '整理结果中']
+    : ['Analyzing information', 'Thinking', 'Organizing results'],
+  working: IS_ZH
+    ? ['正在处理任务', '步骤正在进行中', '系统运行中']
+    : ['Processing task', 'Step in progress', 'System is working'],
+  result: IS_ZH
+    ? ['正在整理结果', '步骤已完成，准备下一步', '正在确认后续操作']
+    : ['Organizing results', 'Step completed, preparing for next step', 'Confirming next action'],
+  waiting: IS_ZH
+    ? ['等待确认', '需提供后续指令', '请决策下一步操作']
+    : ['Awaiting your confirmation', 'Requires your input', 'Please decide on the next step'],
+  approval: IS_ZH
+    ? ['等待审批', '需授权确认', '敏感操作确认授权']
+    : ['Awaiting your approval', 'Authorization required', 'Please confirm and authorize this action'],
+  success: IS_ZH
+    ? ['任务已完成', '本阶段任务已完成', '流程执行成功']
+    : ['Task completed successfully', 'Current phase completed', 'Execution succeeded'],
+  running: IS_ZH
+    ? ['任务运行中', '当前步骤正在处理']
+    : ['Task is running', 'Current step is processing'],
+  review: IS_ZH
+    ? ['正在汇总变更', '变更已就绪，等待审阅']
+    : ['Consolidating', 'Ready for your review'],
+  failed: IS_ZH
+    ? ['步骤执行失败', '操作执行过程中发生异常']
+    : ['Step execution failed', 'An error occurred during operation'],
+  error: IS_ZH
+    ? ['任务发生错误', '出现异常，请进行排查', '流程未能成功']
+    : ['Task encountered an error', 'Exception detected, please check', 'Process failed to complete'],
+  stopped: IS_ZH
+    ? ['任务已终止', '任务已在此处暂停']
+    : ['Task terminated', 'Task paused at this stage'],
+} as const
+
+/** 工具活动分类 → 文案（对齐 dsh-dafeiyu activityCopy：按工具分类选句）。 */
+const ACTIVITY_COPY: Record<string, readonly string[]> = {
+  searching: IS_ZH
+    ? ['正在检索', '正在项目中进行全面搜索', '正在调阅相关文件']
+    : ['Searching', 'Searching across the project', 'Checking related files'],
+  editing: IS_ZH
+    ? ['正在修改', '正在写入变更内容', '正在调整代码实现']
+    : ['Editing', 'Applying changes', 'Adjusting implementation'],
+  testing: IS_ZH
+    ? ['正在检验', '正在运行测试集进行确认', '正在验证变更有效性']
+    : ['Verifying', 'Running test suites', 'Verifying changes'],
+  commanding: IS_ZH
+    ? ['正在执行', '正在启动项目服务', '正在监控指令执行状态']
+    : ['Executing', 'Starting project services', 'Monitoring command execution'],
+} as const
+
+/** seed → 稳定非负整数（数值取整数部分，否则按字符码点求和；对齐 dsh-dafeiyu seedNumber）。 */
+export function seedNumber(seed: string | number | undefined): number {
+  const value = String(seed ?? '')
+  const numeric = Number(value)
+  if (Number.isFinite(numeric))
+    return Math.abs(Math.trunc(numeric))
+  return [...value].reduce((total, character) => total + (character.codePointAt(0) ?? 0), 0)
+}
+
+/** 按组取一句稳定文案（选句随 seed 变化但同一 seed 恒定）。 */
+export function statusCopy(group: string, seed?: string | number): string {
+  const variants = STATUS_COPY[group] ?? STATUS_COPY.working
+  return variants[seedNumber(seed) % variants.length] ?? variants[0]
+}
+
+/** 工具活动分类文案（dsh-dafeiyu activityCopy 的对齐实现）；无分类回落 working 通用文案。 */
+export function activityCopy(activity: string, seed?: string | number): string {
+  const variants = ACTIVITY_COPY[activity] ?? STATUS_COPY.working
+  return variants[seedNumber(seed) % variants.length] ?? variants[0]
+}
+
+/**
+ * 任务文本 → 气泡文案（对齐 dsh-dafeiyu taskCopy 的句式：
+ * 「正在/继续」开头 → 原文+呢；动作动词开头 → 正在+原文+呢；否则 正在处理「原文」呢）。
+ */
+export function taskCopy(task: string | undefined): string | undefined {
+  const value = String(task ?? '').trim().replace(/[。！？.!?]+$/u, '')
+  if (!value)
+    return undefined
+  if (/^(?:正在|继续)/u.test(value))
+    return `${value}呢`
+  if (/^(?:准备|检查|验证|修改|修复|测试|构建|整理|分析|梳理|查找|搜索|读取|实现)/u.test(value))
+    return `正在${value}呢`
+  return `正在处理「${value}」呢`
+}
+
+/** 工具名 → 活动分类（对齐 dsh-dafeiyu toolActivity 正则 + DSH 实际工具名 pwsh；供 working 档无 liveActivity 时选文案）。 */
+export function toolActivityGroup(tool: string | undefined): string {
+  const value = String(tool || '').toLowerCase()
+  if (/search|grep|find|glob|web|read|fetch|open/.test(value))
+    return 'searching'
+  if (/write|edit|patch|replace|create|move|delete/.test(value))
+    return 'editing'
+  if (/test|check|lint|build|verify/.test(value))
+    return 'testing'
+  if (/shell|bash|exec|command|terminal|powershell|pwsh/.test(value))
+    return 'commanding'
+  return 'working'
+}

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -3,6 +3,7 @@ import type { PetStatus } from './use-pet'
 import { listen } from '@tauri-apps/api/event'
 import { useEffect, useState } from 'react'
 import { toast } from '@/utils/toast'
+import { statusCopy, taskCopy, toolActivityGroup } from './bubble-copy'
 
 export interface BubbleSession {
   [key: string]: unknown
@@ -19,6 +20,15 @@ const FAILED_BUBBLE_TIMEOUT = 4000
 const REVIEW_BUBBLE_TIMEOUT = 2500
 const SUCCESS_TOAST_TIMEOUT = 3000
 const FAILED_PULSE_TTL = 1800
+/**
+ * 终态档（success/error）聚合保持时长：对齐 dsh-pet 的 BUBBLE_DURATION_MS=10000
+ * （终态动画播一次 + 10s 收气泡）语义。不得复用 SUCCESS_TOAST_TIMEOUT(3s)——成功
+ * WebM（如 雀跃庆祝）实际播放时长超过 3s 时，聚合状态提前回落会让 app.tsx 的
+ * useWatch 调 pet.clear() 掐断未播完的动画（用户报告：成功动画没播完就换回待机）。
+ * 动画播完由视频 ended（handleEnded → 清 override）自然回落，toast 收起仍走
+ * scheduleHide 的独立 3s（SUCCESS_TOAST_TIMEOUT），二者互不影响。
+ */
+const TERMINAL_PULSE_TTL = 10000
 /** 会话完成/变空闲后保留的时长：超过即从会话表沉淀，防止 durable subagent 等永不发 remove 的会话无界积累。 */
 const IDLE_SESSION_RETENTION = 5000
 
@@ -68,12 +78,17 @@ const TOOL_ARG_KEYS: Record<string, readonly string[]> = {
   skill: ['name'],
 } as const
 
-/** 状态优先级映射，数值越大优先级越高 */
+/** 状态优先级映射，数值越大优先级越高（对齐 dsh-dafeiyu statePriority：等待>错误>工作>思考>空闲）。 */
 const STATUS_PRIORITY: Record<string, number> = {
-  'waiting': 4,
-  'review': 3,
-  'failed': 2,
-  'running': 1,
+  'waiting': 60,
+  'error': 50,
+  'failed': 45,
+  'review': 40,
+  'working': 30,
+  'result': 25,
+  'thinking': 20,
+  'running': 12,
+  'success': 10,
   'idle': 0,
   'turn': 0,
   'moving-left': 0,
@@ -145,7 +160,15 @@ export function useBubble(): BubbleHandle {
       if (disposed)
         return
       const session = sessions.get(id)
-      if (!session || sessionStatus(session) !== undefined)
+      if (!session)
+        return
+      // 活跃档（think/work/result/waiting/running/review）不沉淀；
+      // 终态档（workStatus success/error）翻开底层：底层空闲（回合完成且无错误残留）才可沉淀。
+      const status = sessionStatus(session)
+      const bottom = sessionStatus(session, true)
+      if (bottom !== undefined)
+        return
+      if (status !== undefined && status !== 'success' && status !== 'error')
         return
 
       removeSessionData(id)
@@ -154,15 +177,22 @@ export function useBubble(): BubbleHandle {
 
     const armPrune = (id: string) => {
       clearTimer(pruneTimers, id)
-      pruneTimers.set(id, window.setTimeout(() => {
+      const timer = window.setTimeout(() => {
         pruneTimers.delete(id)
         pruneSession(id)
-      }, IDLE_SESSION_RETENTION))
+      }, IDLE_SESSION_RETENTION)
+      pruneTimers.set(id, timer)
     }
 
     const scheduleHide = (id: string, current: PetStatus) => {
       clearTimer(hideTimers, id)
-      const timeout = current === 'failed' ? FAILED_BUBBLE_TIMEOUT : current === 'review' ? REVIEW_BUBBLE_TIMEOUT : undefined
+      const timeout = current === 'failed' || current === 'error'
+        ? FAILED_BUBBLE_TIMEOUT
+        : current === 'review'
+          ? REVIEW_BUBBLE_TIMEOUT
+          : current === 'success'
+            ? SUCCESS_TOAST_TIMEOUT
+            : undefined
       const key = toastKeys.get(id)
       if (timeout === undefined || key === undefined)
         return
@@ -180,11 +210,14 @@ export function useBubble(): BubbleHandle {
       const current = sessionStatus(session)
       const previous = previousStatus.get(session.id)
 
-      if (current === 'failed') {
-        if (previous === 'failed' || consumedFailed.has(session.id))
+      if (current === 'failed' || current === 'error' || current === 'success') {
+        if (previous === current || consumedFailed.has(session.id))
           return
 
-        const deadline = Date.now() + FAILED_PULSE_TTL
+        // 终态档脉冲窗口：failed 短 TTL 恢复底层状态；success/error 为终态档，
+        // 保持 TERMINAL_PULSE_TTL（对齐 dsh-pet 10s 收气泡），等动画完整播完再回落空闲。
+        const ttl = current === 'success' || current === 'error' ? TERMINAL_PULSE_TTL : FAILED_PULSE_TTL
+        const deadline = Date.now() + ttl
         failedUntil.set(session.id, deadline)
         clearTimer(pulseTimers, session.id)
 
@@ -195,7 +228,7 @@ export function useBubble(): BubbleHandle {
           clearTimer(pulseTimers, session.id)
           consumedFailed.add(session.id)
           updateAgg()
-        }, FAILED_PULSE_TTL)
+        }, ttl)
 
         pulseTimers.set(session.id, timer)
       }
@@ -231,7 +264,8 @@ export function useBubble(): BubbleHandle {
       }
 
       clearTimer(pruneTimers, session.id)
-      const isTerminal = current === 'failed' || current === 'review'
+      // 终态档（播完即收）：failed/error 失败、review 待审阅、success 完成。
+      const isTerminal = current === 'failed' || current === 'review' || current === 'error' || current === 'success'
       if (!isTerminal) {
         dismissed.delete(session.id)
       }
@@ -246,7 +280,7 @@ export function useBubble(): BubbleHandle {
           isLoading: content.isLoading,
           description: content.description,
           placement: 'top end',
-          variant: content.variant as 'warning' | 'danger' | 'default',
+          variant: content.variant as 'warning' | 'danger' | 'default' | 'success',
           timeout: 0,
           onClose: () => {
             if (toastKeys.get(session.id) === createdKey) {
@@ -340,15 +374,32 @@ function sessionTitle(session: BubbleSession): string {
   if (session.phase === 'user-question' || session.phase === 'blocked')
     return `${LABELS.waitChoice} · ${base}`
   if (session.origin === 'subagent')
-    return `${LABELS.subagent}：${base}`
+    return `${LABELS.subagent} · ${base}`
   return base
 }
 
-/** 提取单个会话的状态（忽略底层恢复逻辑） */
+/** 细分工作状态档位（host reducer workStatus 输出；动画名映射见 pet-config）。 */
+const WORK_STATUSES = ['thinking', 'working', 'result', 'waiting', 'success', 'error'] as const
+
+type WorkStatus = (typeof WORK_STATUSES)[number]
+
+/** 提取单个会话的状态（细分档优先，忽略底层恢复逻辑）。 */
 function sessionStatus(session: BubbleSession, ignoreError = false): PetStatus | undefined {
+  // 细分工作档位（host reducer 权威）：thinking/working/result/waiting/success/error
+  const work = session.workStatus as unknown
+  if (WORK_STATUSES.includes(work as WorkStatus)) {
+    // error/success 是终态档；pulse 过期（ignoreError）后回落底层推导，不残留失败/成功视觉。
+    if (ignoreError && (work === 'error' || work === 'success'))
+      return undefined
+    return work as PetStatus
+  }
+
   const value = session.status ?? session.activity ?? session.phase
 
-  if (!ignoreError && (value === 'failed' || value === 'error' || Boolean(session.lastAgentError))) {
+  // 终态错误判定只在回合已结束（running !== true）时生效：工具级失败/旧快照的
+  // lastAgentError 若与 running=true 并存，说明回合仍在跑（agent 捕获错误继续），
+  // 此时绝不判 failed 收起气泡（用户报告：会话还在跑 toast 却消失了）。
+  if (!ignoreError && session.running !== true && (value === 'failed' || value === 'error' || Boolean(session.lastAgentError))) {
     return 'failed'
   }
   if (value === 'review' || value === 'reviewing' || value === 'plan-review') {
@@ -380,7 +431,7 @@ function statusOf(
 
   for (const session of sessions.values()) {
     let status = sessionStatus(session)
-    if (status === 'failed') {
+    if (status === 'failed' || status === 'error' || status === 'success') {
       const deadline = failedUntil.get(session.id)
       if (deadline === undefined || now >= deadline) {
         status = sessionStatus(session, true) // 底层恢复状态
@@ -392,7 +443,7 @@ function statusOf(
       if (priority > maxPriority) {
         maxPriority = priority
         highestStatus = status
-        if (maxPriority === 4)
+        if (maxPriority === STATUS_PRIORITY.waiting)
           break // 'waiting' 为最高优先级，提前终止遍历
       }
     }
@@ -436,7 +487,7 @@ function toolArgDetail(tool: string, args: unknown): string | undefined {
   return undefined
 }
 
-/** 生成 Toast 渲染数据 */
+/** 生成 Toast 渲染数据（对齐 dsh-dafeiyu：优先失败详情 → 任务文案 → 工具/思考活动 → 档位状态文案）。 */
 function toastContent(session: BubbleSession, status: PetStatus) {
   const getFirstString = (...items: unknown[]): string | undefined => {
     for (const item of items) {
@@ -448,21 +499,24 @@ function toastContent(session: BubbleSession, status: PetStatus) {
   }
 
   const getLiveActivity = (): string | undefined => {
-    if (status !== 'running' || !session.liveActivity || typeof session.liveActivity !== 'object') {
+    if (status !== 'running' && status !== 'thinking' && status !== 'working' && status !== 'result') {
+      return undefined
+    }
+    if (!session.liveActivity || typeof session.liveActivity !== 'object') {
       return undefined
     }
 
     const { kind, text, name, args } = session.liveActivity as Record<string, unknown>
 
     if (kind === 'reasoning' && typeof text === 'string' && text.trim()) {
-      return `思考 · ${sanitizeText(text)}`
+      return IS_ZH ? `思考 · ${sanitizeText(text)}` : `Thought · ${sanitizeText(text)}`
     }
 
     if (kind === 'tool' && typeof name === 'string' && name) {
       const tool = name.toLowerCase()
       const label = TOOL_LABELS[tool]
       if (!label)
-        return `工具调用 · ${name}`
+        return IS_ZH ? `工具调用 · ${name}` : `Tool · ${name}`
 
       const detail = toolArgDetail(tool, args)
       return detail ? `${label} · ${detail}` : label
@@ -473,37 +527,56 @@ function toastContent(session: BubbleSession, status: PetStatus) {
 
   const isSub = session.origin === 'subagent'
   const title = sessionTitle(session)
-  const statusTextMap: Record<PetStatus, string> = {
-    'failed': '失败',
-    'review': '待审阅',
-    'waiting': '等待中',
-    'running': isSub ? '运行中' : '思考中',
-    'idle': '空闲',
-    'turn': '空闲',
-    'moving-left': '空闲',
-    'moving-right': '空闲',
-    'waving': '空闲',
+  // 会话稳定 seed（同会话同档位文案恒定，跨档位切换自然换句；对齐 dsh-dafeiyu statusCopy(seed)）。
+  const seed = session.id
+  const statusTextMap: Record<string, string> = {
+    'think': IS_ZH ? '思考中' : 'Thinking',
+    'thinking': IS_ZH ? '思考中' : 'Thinking',
+    'working': IS_ZH ? '处理中' : 'Working',
+    'result': IS_ZH ? '整理中' : 'Organizing',
+    'waiting': IS_ZH ? '等待中' : 'Waiting',
+    'running': isSub ? (IS_ZH ? '运行中' : 'Running') : (IS_ZH ? '思考中' : 'Thinking'),
+    'review': IS_ZH ? '待审阅' : 'Review',
+    'failed': IS_ZH ? '失败' : 'Failed',
+    'error': IS_ZH ? '出错' : 'Error',
+    'success': IS_ZH ? '已完成' : 'Done',
+    'idle': IS_ZH ? '空闲' : 'Idle',
+    'turn': IS_ZH ? '空闲' : 'Idle',
+    'moving-left': IS_ZH ? '空闲' : 'Idle',
+    'moving-right': IS_ZH ? '空闲' : 'Idle',
+    'waving': IS_ZH ? '空闲' : 'Idle',
   }
 
-  const statusText = statusTextMap[status] ?? '空闲'
+  const statusText = statusTextMap[status] ?? (IS_ZH ? '空闲' : 'Idle')
+  // 档位状态文案：waiting 分 approval/user-question 两档，working 按工具活动分类选句。
+  const fallbackCopy = status === 'waiting'
+    ? (session.phase === 'approval' ? statusCopy('approval', seed) : statusCopy('waiting', seed))
+    : status === 'working'
+      ? statusCopy(toolActivityGroup(String((session.liveActivity as Record<string, unknown> | undefined)?.name ?? '')), seed)
+      : statusCopy(status, seed)
   const description = getFirstString(
+    session.lastAgentError ? (IS_ZH ? `失败：${String(session.lastAgentError)}` : `Failed: ${String(session.lastAgentError)}`) : undefined,
+    taskCopy(session.task as string | undefined), // todo 任务文案：正在处理「xxx」呢
+    getLiveActivity(), // 工具/思考活动详情（保留既有实用信息）
+    fallbackCopy, // 档位状态文案（dsh-dafeiyu statusCopy）
     session.description,
     session.message,
-    session.lastAgentError ? `失败：${String(session.lastAgentError)}` : undefined,
-    getLiveActivity(),
     statusText,
-  ) ?? '会话'
+  ) ?? (IS_ZH ? '会话' : 'Session')
 
-  const variant = (status === 'waiting' || status === 'review')
+  const variant = status === 'waiting' || status === 'review'
     ? 'warning'
-    : status === 'failed'
+    : status === 'failed' || status === 'error'
       ? 'danger'
-      : 'default'
+      : status === 'success'
+        ? 'success'
+        : 'default'
 
   return {
     title,
     description,
-    isLoading: status === 'running',
+    // 工作中平凡态显示 spinner（running/细分工作档位）；等待/终态档不显示 loading。
+    isLoading: status === 'running' || status === 'thinking' || status === 'working' || status === 'result',
     variant,
   }
 }

--- a/src/pet/hooks/use-pet.ts
+++ b/src/pet/hooks/use-pet.ts
@@ -7,10 +7,16 @@ export const PET_STATUSES = [
   'moving-left',
   'moving-right',
   'waving',
+  // 细分工作状态档位（host reducer workStatus；动画名映射见 pet-config PRESET_SESSION_ANIMATIONS）
+  'thinking',
+  'working',
+  'result',
   'waiting',
   'running',
   'review',
   'failed',
+  'success',
+  'error',
 ] as const
 
 export type PetStatus = (typeof PET_STATUSES)[number]

--- a/src/pet/pet-config.test.ts
+++ b/src/pet/pet-config.test.ts
@@ -1,12 +1,14 @@
 import type { PetCategory, PetWeights } from './pet-config'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  isLoopingAnimation,
   pick,
   pickCategoryAction,
   pickWeightedCategory,
   poolEntryToStatus,
   resolvePresetName,
   rollKind,
+  spriteStatusFallback,
 } from './pet-config'
 
 const WEIGHTS: PetWeights = { idle: 10, turn: 5, move: 5 }
@@ -112,8 +114,14 @@ describe('resolvePresetName', () => {
     '东张西望': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E4%B8%9C.webm',
     '被鼠标拖拽悬空反馈': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E8%A2%AB.webm',
     '点击回应-开心跃动': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E5%BC%80.webm',
-    // DSH 会话状态叠加映射名（与旧内置 maid-*.webm 一一对应）
-    '深度思考碎碎念': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E6%B7%B1.webm',
+    // DSH 细分工作状态档位叠加映射名（e1ff8c1 起的 6 个新 webm）
+    '工作状态-思考冒泡': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E6%80%9D.webm',
+    '工作状态-忙碌点按': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E5%BF%99.webm',
+    '工作状态-清点归档': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E6%B8%85.webm',
+    '工作状态-原地踱步张望': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E8%B8%B1.webm',
+    '工作状态-雀跃庆祝': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E9%9B%80.webm',
+    '工作状态-垂头叹气冒汗': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E5%9E%82.webm',
+    // 旧粗态兼容映射名
     '写代码': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E5%86%99.webm',
     '轻快记录': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E8%BD%BB.webm',
     '玩游戏气急败坏': 'dsh-pet://localhost/maid-deepseek-whale/webm/%E6%B0%94.webm',
@@ -134,10 +142,41 @@ describe('resolvePresetName', () => {
   })
 
   it('maps session statuses to the DSH overlay animation names', () => {
-    expect(resolvePresetName('waiting', pools, assets)).toBe('深度思考碎碎念')
+    // 细分工作状态档位（e1ff8c1 起的 6 个新 webm）
+    expect(resolvePresetName('thinking', pools, assets)).toBe('工作状态-思考冒泡')
+    expect(resolvePresetName('working', pools, assets)).toBe('工作状态-忙碌点按')
+    expect(resolvePresetName('result', pools, assets)).toBe('工作状态-清点归档')
+    expect(resolvePresetName('waiting', pools, assets)).toBe('工作状态-原地踱步张望')
+    expect(resolvePresetName('success', pools, assets)).toBe('工作状态-雀跃庆祝')
+    expect(resolvePresetName('error', pools, assets)).toBe('工作状态-垂头叹气冒汗')
+    // 旧粗态兼容映射
     expect(resolvePresetName('running', pools, assets)).toBe('写代码')
     expect(resolvePresetName('review', pools, assets)).toBe('轻快记录')
     expect(resolvePresetName('failed', pools, assets)).toBe('玩游戏气急败坏')
+  })
+
+  it('isLoopingAnimation：细分非终态档与 idle/running 循环，终态档与 review/failed 播一次', () => {
+    expect(isLoopingAnimation('idle')).toBe(true)
+    expect(isLoopingAnimation('thinking')).toBe(true)
+    expect(isLoopingAnimation('working')).toBe(true)
+    expect(isLoopingAnimation('result')).toBe(true)
+    expect(isLoopingAnimation('waiting')).toBe(true)
+    expect(isLoopingAnimation('running')).toBe(true)
+    expect(isLoopingAnimation('success')).toBe(false)
+    expect(isLoopingAnimation('error')).toBe(false)
+    expect(isLoopingAnimation('review')).toBe(false)
+    expect(isLoopingAnimation('failed')).toBe(false)
+    expect(isLoopingAnimation('waving')).toBe(false)
+  })
+
+  it('spriteStatusFallback：自定义图集无细分档行，近似映射到既有行', () => {
+    expect(spriteStatusFallback('thinking')).toBe('waiting')
+    expect(spriteStatusFallback('working')).toBe('running')
+    expect(spriteStatusFallback('result')).toBe('review')
+    expect(spriteStatusFallback('success')).toBe('waving')
+    expect(spriteStatusFallback('error')).toBe('failed')
+    expect(spriteStatusFallback('idle')).toBe('idle')
+    expect(spriteStatusFallback('running')).toBe('running')
   })
 
   it('returns null for session statuses whose overlay asset is missing', () => {

--- a/src/pet/pet-config.ts
+++ b/src/pet/pet-config.ts
@@ -55,6 +55,38 @@ export interface PetConfig {
   eventsRefreshSec?: Record<string, number>
 }
 
+/**
+ * 播放状态是否循环。
+ * - idle/running/moving-*\/dragging：常驻循环（手势期间持续直到结束）；
+ * - 细分工作状态档位 thinking/working/result/waiting：非终态档，常驻循环播动画
+ *   （对齐 dsh-pet workStatusTick 语义：等用户/干活期间动画不自动结束）；
+ * - 终态档 success/error 与 review/failed：播一次后回落（气泡收尾由 use-bubble 管理）。
+ */
+export function isLoopingAnimation(activity: string): boolean {
+  return activity === 'idle' || activity === 'running'
+    || activity === 'thinking' || activity === 'working' || activity === 'result' || activity === 'waiting'
+    || activity === 'moving-left' || activity === 'moving-right'
+    || activity === 'dragging'
+}
+
+/**
+ * 自定义 Codex v2 图集没有细分档位行（固定 8×11，无思考/工作/整理/庆祝行）：
+ * 细分档播放时近似映射到既有行，避免播到错误 sprite（保留会话状态近似观感）。
+ */
+export function spriteStatusFallback(activity: string): string {
+  return activity === 'thinking'
+    ? 'waiting'
+    : activity === 'working'
+      ? 'running'
+      : activity === 'result'
+        ? 'review'
+        : activity === 'success'
+          ? 'waving'
+          : activity === 'error'
+            ? 'failed'
+            : activity
+}
+
 /** 从字符串池等概率抽一个；exclude 排除某个名字（避免连续重复）。 */
 export function pick<T>(pool: readonly T[], exclude?: T): T {
   const entries = exclude === undefined ? pool : pool.filter(item => item !== exclude)
@@ -125,15 +157,26 @@ export function poolEntryToStatus(entry: string): string {
 /**
  * DSH 会话状态 → dsh-pet 动画名（webm 文件名主名）的叠加映射。
  *
- * dsh-pet 协议（config.jsonc）只有 idle/turn/drag/clicks/moves/categories/events 池，
- * 没有 waiting/running/review/failed/bubble 这些 DSH 会话状态的对应池。这些动画文件
- * 在预设资产里真实存在（与旧内置 maid-*.webm 按字节一一对应，见 pet.todo.md 4.0），
- * 由本表把会话状态映射到具体文件名：running 循环写代码、waiting 深度思考碎碎念、
- * review 轻快记录、failed 玩游戏气急败坏、bubble 鲸鱼吐泡泡特效。
+ * 两族状态：
+ * 1. 细分工作状态档位（workStatus，host reducer 输出）：thinking/working/result/
+ *    waiting/success/error，对齐 dsh-pet config.jsonc animations.events.workStatus
+ *    数组（索引即档位）——turn/start→thinking、tool/call→working、tool/result→result、
+ *    approval/asked 等→waiting、turn/end completed→success、error/max-tokens→error。
+ *    这些档位优先映射到工作状态系列动画（思考冒泡/忙碌点按/清点归档/踱步张望/
+ *    雀跃庆祝/垂头叹气冒汗，e1ff8c1 起的新预设资产）。
+ * 2. 旧粗态兼容（无细分档的会话展示路径）：running 写代码、review 轻快记录、
+ *    failed 玩游戏气急败坏、bubble 鲸鱼吐泡泡特效。
  * 资产缺失时 resolvePresetName 仍返回 null（调用方保持当前动画，不做静默兜底）。
  */
 export const PRESET_SESSION_ANIMATIONS: Record<string, string> = {
-  waiting: '深度思考碎碎念',
+  // 细分工作状态档位（workStatus）
+  thinking: '工作状态-思考冒泡',
+  working: '工作状态-忙碌点按',
+  result: '工作状态-清点归档',
+  waiting: '工作状态-原地踱步张望',
+  success: '工作状态-雀跃庆祝',
+  error: '工作状态-垂头叹气冒汗',
+  // 旧粗态兼容
   running: '写代码',
   review: '轻快记录',
   failed: '玩游戏气急败坏',


### PR DESCRIPTION
## 变更概览

桌宠会话气泡与动画接入上游 dsh-pet 的**工作状态 6 档联动**（thinking/working/result/waiting/success/error），气泡文案对齐 dsh-dafeiyu。

### ① 预设 ref 升级
- `src-tauri/resources/preset-pets.json`：ref/image 由 `f0f772e9` → `e1ff8c1`。6 个工作状态 WebM（思考冒泡/忙碌点按/清点归档/踱步张望/雀跃庆祝/垂头叹气冒汗）自 903dfde 才入库，旧 ref 下载不到。

### ② host reducer 细分档位
- `packages/dsh-tauri-pet/src/host/reducer.ts`：新增 `PetWorkStatus`/`PetToolActivity` 类型与 `workStatus`/`task`/`toolActivity` 输出（粗 status 保留兼容）。
- 事件映射：turn/start→thinking；tool/call→working（问句工具→waiting）；tool/result→result；approval/asked→waiting；turn/end→ completed→success / error·max-tokens→error / blocked→waiting / aborted→清回空闲。
- 修复：工具级错误不再写 `lastAgentError`（不污染回合终态）；新回合 turn/start 清零旧错误。

### ③ 动画/气泡接线（对齐 dsh-dafeiyu）
- `pet-config.ts`：6 档位→工作状态 WebM 动画名映射；`isLoopingAnimation`（非终态档循环、终态播一次）；`spriteStatusFallback`（自定义图集近似回落）。
- `bubble-copy.ts`（新增）：`statusCopy`/`activityCopy`/`taskCopy` 对齐 dsh-dafeiyu 句式与分组文案。
- `use-bubble.ts`：档位优先级对齐 dsh-dafeiyu（waiting=60>error=50>…）；description 优先级=失败详情→任务文案→活动→档位文案；**success/error 聚合保持 TERMINAL_PULSE_TTL=10s**（对齐 dsh-pet BUBBLE_DURATION_MS），终态动画由视频 ended 自然回落。

### ④ 单测
- reducer.test.ts 19 条（含工具级错误不写 lastAgentError、新回合清错误）；
- pet-config.test.ts + bubble-copy.test.ts 32 条全绿。

### Bug 修复
- 成功 toast 提前消失：`session.running === true` 时不再判 failed 收起气泡；
- **成功动画被提前掐断**：终态聚合保持 3s 短于 WebM 播放时长，useWatch 提前 clear()——改 10s 后由视频 ended 自然回落。

## 验证
- eslint（src/pet + pet 包）--max-warnings=0：零错误
- vitest（pet 相关 3 个测试文件）：51/51 全绿
- `pnpm test -- --run`：104/107（3 条失败均在 dsh-tauri-panel-scheduler，属另一项未提交改动，与本 PR 无关）
- cargo check --lib：通过；git diff --check：干净

## 注意
工作树中的 dsh-tauri-panel-scheduler 未提交改动（ScheduleKind 扩展等）与本 PR 无关，未包含。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed pet activity states for thinking, working, waiting, results, success, and errors.
  * Pet bubbles now provide localized, context-aware messages based on tasks, tools, and outcomes.
  * Added task progress and tool activity details to session updates.
  * Added support for richer animations, including status-specific sprite mappings and looping behavior.
* **Bug Fixes**
  * Improved handling of tool errors without incorrectly ending the session.
  * Preserved underlying activity after temporary success or error notifications.
* **Tests**
  * Expanded coverage for status transitions, task updates, bubble messaging, and animation fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->