### PR TITLE
chore: release v0.11.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.10.7",
+  "version": "0.11.0-beta.4",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.10.7"
+version = "0.11.0-beta.4"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.10.7"
+version = "0.11.0-beta.4"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.10.7",
+  "version": "0.11.0-beta.4",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.11.0-beta.4` (`0.10.7` → `0.11.0-beta.4`).

### Features

- **pet**: 预设宠物更新——检测 hash 更新、更新按钮、强制停用后替换安装并重新启用 (d94cfa0)
- **pet**: 工作状态动画/气泡接线对齐 dsh-dafeiyu，修复成功动画被提前掐断 (7d99ace)
- **pet**: 升级预设 ref 至 e1ff8c1，host reducer 输出工作状态细分档位 (8a517b8)
- **panel-extension**: sync MCP capabilities (60267cd)
- **pet**: 桌宠 toast 按工具展示操作明细（Grep/读取/搜索/抓取等） (811ec7b)

### Bug Fixes

- **panel-extension**: satisfy CI lint (7f4fc95)
- **scheduler**: complete schedule form fields (7c7135c)
- **panel**: 新会话按钮恢复官方白底圆角形态，移除 menu-item 类覆盖 (03908bb)

### Documentation

- **scheduler**: add automation sync log (198a8b9)
- **panel-extension**: add upstream sync log (7e09f17)

### Tests

- **scheduler**: align recurrence coverage (adcf744)

### Chores

- update docs (95d2f66)

### Other Changes

- Merge pull request #413 from dsh-tauri-desk/feat/panel-extension-mcp-updates (e46d285)
- Merge pull request #416 from dsh-tauri-desk/docs/scheduler-sync-log (f284229)
- Merge pull request #415 from dsh-tauri-desk/dsh/pet-update (4ee543a)
- Merge pull request #414 from dsh-tauri-desk/dsh/pet-work-status (db52da4)
- Merge pull request #412 from dsh-tauri-desk/feat/scheduler-form-fixes (9283290)
- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (92d4276)
- Merge pull request #411 from dsh-tauri-desk/fix/panel-new-session-style (ec99b84)
- Merge pull request #410 from dsh-tauri-desk/dsh/pet-toast-tool-info (f86b3bd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to **0.11.0-beta.4** across the release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->