### PR TITLE
fix(pet): 会话状态动画资产缺失降级 + 拖拽卡死循环修复 + 子代理 toast 静默

### DIFF
--- a/packages/dsh-tauri-pet/src/host/reducer.test.ts
+++ b/packages/dsh-tauri-pet/src/host/reducer.test.ts
@@ -159,15 +159,18 @@ describe('petSessionReducer (host)', () => {
     expect(last.payload).toMatchObject({ workStatus: 'error', lastAgentError: 'max-tokens' })
   })
 
-  it('turn/end(aborted) 清档：workStatus 为空（不残留上一档，防止一直 working 挂死）', () => {
+  it('turn/end(aborted) 静默取消：workStatus/lastAgentError/status 均清空（手动取消非失败，不得弹「失败：aborted」）', () => {
     const { reducer, pushes } = collect()
     reducer.create(peer())
     reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
     reducer.apply(peer(), ev('tool/call', { turn: 1, step: 1, callId: 'c1', name: 'pwsh', arguments: '{}' }, 2))
-    reducer.apply(peer(), ev('turn/end', { turn: 1, reason: { kind: 'aborted' } }, 3))
+    // 核心手动取消会带 reason.error.message（'aborted'）；旧实现把它写进 lastAgentError → use-bubble 判 failed。
+    reducer.apply(peer(), ev('turn/end', { turn: 1, reason: { kind: 'aborted', error: { message: 'aborted' } } }, 3))
     const last = pushes.at(-1)!
     expect(last.payload).toMatchObject({ running: false })
     expect(last.payload.workStatus).toBeUndefined()
+    expect(last.payload.lastAgentError).toBeUndefined()
+    expect(last.payload.status).toBeUndefined()
   })
 
   it('tool/result 的工具级错误不写入 lastAgentError（回合仍在跑时不得判 failed 收起气泡）', () => {

--- a/packages/dsh-tauri-pet/src/host/reducer.ts
+++ b/packages/dsh-tauri-pet/src/host/reducer.ts
@@ -514,11 +514,12 @@ export function reduceSessionEvent(
         }
         else {
           // aborted 等：回合中断，清档回空闲（绝不残留上一档，防止「一直 working」挂死）。
+          // 手动取消是用户主动中断而非失败：不得写入 lastAgentError，否则 use-bubble 下一帧
+          // 判 failed 弹「失败：aborted」toast（kind==='error' 已在上面分支处理，此处到不了；
+          // 旧代码 if (kind === 'error' || kind === 'aborted') 实际只会命中 aborted，
+          // 把取消误记成错误）。lastAgentError 一并清空，保证取消后彻底静默回落空闲。
           state.workStatus = undefined
-          if (kind === 'error' || kind === 'aborted') {
-            const errBody = (data as { reason?: { error?: { message?: string } } }).reason
-            state.lastAgentError = errBody?.error?.message ?? kind
-          }
+          state.lastAgentError = undefined
         }
       }
       break

--- a/src/pet/app.tsx
+++ b/src/pet/app.tsx
@@ -25,10 +25,18 @@ export function App() {
   const { clickCount, direction, dragging } = useDrag(dragRef)
   useOmitIgnoreCursorEvents(dragRef)
   const drawStatus = direction === undefined ? undefined : DRAW_STATUS[direction]
+  // useWatch 的 deps 是每次渲染新建的字面量数组（见 @hairy/react-lib），effect 在
+  // 每次渲染都会执行；拖拽期间 direction/clickCount 会高频触发重渲染，若不节流，
+  // 每次渲染都会 pet.change() 使 override.revision 递增，视频效果随之反复重载
+  // 同一个动画（拖拽动画被 Moved 事件不断重启）。会话状态未变化时跳过下发。
+  const lastStatusRef = useRef<PetStatus | undefined>(undefined)
 
   useWatch(
     [bubble.status, pet],
     () => {
+      if (bubble.status === lastStatusRef.current)
+        return
+      lastStatusRef.current = bubble.status
       if (bubble.status === undefined)
         return pet.clear()
       // 细分档位（thinking/working/result/waiting）与 running 均为循环档；

--- a/src/pet/components/pet.tsx
+++ b/src/pet/components/pet.tsx
@@ -8,6 +8,7 @@ import { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react
 import { If } from 'react-if-lite'
 import { PET_STATUSES } from '../hooks/use-pet'
 import {
+  fallbackPresetName,
   isLoopingAnimation,
   pick,
   pickCategoryAction,
@@ -307,9 +308,14 @@ export function Pet(props: PetProps) {
       return undefined
     // 预设配置池条目 = 动画名 = webm 文件名主名；adHoc 已携带动画名时直接命中，
     // 会话状态（waiting/running/review/failed/bubble）经 PRESET_SESSION_ANIMATIONS
-    // 叠加映射到具体动画名（写代码/轻快记录/玩游戏气急败坏…），映射名无资产时
-    // resolvePresetName 返回 null → 保持当前动画。
+    // 叠加映射到具体动画名（写代码/轻快记录/玩游戏气急败坏…）。
     const name = resolvePresetName(activity, pools, assets)
+      // 会话状态（override/props 驱动）解析不到资产时不得静默保持当前动画——旧语义
+      // 会让宠物永久卡在上一个循环上：细分工作档资产缺失的旧预设（e1ff8c1 资产差集
+      // 前的安装）中，会话运行显示待机、拖拽结束后永远循环拖拽动画。改为降级链
+      // （细分工作档 → 粗态写代码 → 待机池，见 fallbackPresetName）；adHoc（点击
+      // 回应/待机插播）缺失仍保持当前动画，避免把一次性风味动画错播成工作/待机动画。
+      ?? (adHoc === null ? fallbackPresetName(activity, pools, assets) : null)
     if (name === null)
       return undefined
     const source = assets[name]

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -245,6 +245,19 @@ export function useBubble(): BubbleHandle {
       previousStatus.set(session.id, current)
       const key = toastKeys.get(session.id)
 
+      // 子代理会话整体静默：状态仍参与聚合与沉淀（previousStatus/armPrune 照常），
+      // 但不创建/更新/关闭任何 toast——子代理任务多且切换频繁，活跃追踪 toast 会
+      // 不断弹出/更新，属于视觉噪音（此前只抑制了「已完成」toast，活跃 toast 仍会弹）。
+      if (session.origin === 'subagent') {
+        if (key !== undefined) {
+          closeToast(session.id)
+        }
+        if (current === undefined && previous !== undefined) {
+          armPrune(session.id)
+        }
+        return
+      }
+
       if (current === undefined) {
         if (key !== undefined)
           closeToast(session.id)

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -412,7 +412,10 @@ function sessionStatus(session: BubbleSession, ignoreError = false): PetStatus |
   // 终态错误判定只在回合已结束（running !== true）时生效：工具级失败/旧快照的
   // lastAgentError 若与 running=true 并存，说明回合仍在跑（agent 捕获错误继续），
   // 此时绝不判 failed 收起气泡（用户报告：会话还在跑 toast 却消失了）。
-  if (!ignoreError && session.running !== true && (value === 'failed' || value === 'error' || Boolean(session.lastAgentError))) {
+  // lastAgentError==='aborted' 是旧版插件宿主（未重新部署 dist 的安装）把手动取消误记为
+  // 错误的兜底豁免：取消是用户主动中断而非失败，不弹「失败：aborted」。新版宿主已不再下发该值。
+  const agentError = session.lastAgentError
+  if (!ignoreError && session.running !== true && (value === 'failed' || value === 'error' || (Boolean(agentError) && agentError !== 'aborted'))) {
     return 'failed'
   }
   if (value === 'review' || value === 'reviewing' || value === 'plan-review') {

--- a/src/pet/pet-config.test.ts
+++ b/src/pet/pet-config.test.ts
@@ -1,6 +1,7 @@
 import type { PetCategory, PetWeights } from './pet-config'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  fallbackPresetName,
   isLoopingAnimation,
   pick,
   pickCategoryAction,
@@ -188,5 +189,43 @@ describe('resolvePresetName', () => {
   it('returns null when the pool entry is not backed by an asset', () => {
     expect(resolvePresetName('idle', { ...pools, idlePool: ['不存在.webm'] }, assets)).toBeNull()
     expect(resolvePresetName('idle', { ...pools, idlePool: [] }, assets)).toBeNull()
+  })
+})
+
+describe('fallbackPresetName', () => {
+  // 旧预设（e1ff8c1 资产差集前的安装）：无 工作状态-*，但有待机与写代码。
+  const stale: Record<string, string> = {
+    待机呼吸休闲: 'dsh-pet://localhost/maid-deepseek-whale/webm/idle.webm',
+    写代码: 'dsh-pet://localhost/maid-deepseek-whale/webm/code.webm',
+  }
+  const pools = { idlePool: ['待机呼吸休闲'] } as const
+
+  it('降级细分工作档到粗态写代码（资产缺失时不再卡旧循环）', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.0)
+    expect(fallbackPresetName('thinking', pools, stale)).toBe('写代码')
+    expect(fallbackPresetName('working', pools, stale)).toBe('写代码')
+    expect(fallbackPresetName('result', pools, stale)).toBe('写代码')
+    expect(fallbackPresetName('waiting', pools, stale)).toBe('写代码')
+    expect(fallbackPresetName('running', pools, stale)).toBe('写代码')
+    vi.restoreAllMocks()
+  })
+
+  it('细分档资产存在时无需降级（fallback 只作 resolve 失败的后备）', () => {
+    expect(fallbackPresetName('thinking', pools, { '待机呼吸休闲': 'idle.webm', '工作状态-思考冒泡': 'think.webm', '写代码': 'code.webm' })).toBe('写代码')
+  })
+
+  it('终态档/其他状态降到待机池', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.0)
+    expect(fallbackPresetName('success', pools, stale)).toBe('待机呼吸休闲')
+    expect(fallbackPresetName('error', pools, stale)).toBe('待机呼吸休闲')
+    expect(fallbackPresetName('review', pools, stale)).toBe('待机呼吸休闲')
+    expect(fallbackPresetName('failed', pools, stale)).toBe('待机呼吸休闲')
+    expect(fallbackPresetName('bubble', pools, stale)).toBe('待机呼吸休闲')
+    vi.restoreAllMocks()
+  })
+
+  it('待机池也无资产时返回 null（调用方保持当前动画）', () => {
+    expect(fallbackPresetName('working', pools, {})).toBeNull()
+    expect(fallbackPresetName('working', { idlePool: [] }, {})).toBeNull()
   })
 })

--- a/src/pet/pet-config.ts
+++ b/src/pet/pet-config.ts
@@ -166,7 +166,8 @@ export function poolEntryToStatus(entry: string): string {
  *    雀跃庆祝/垂头叹气冒汗，e1ff8c1 起的新预设资产）。
  * 2. 旧粗态兼容（无细分档的会话展示路径）：running 写代码、review 轻快记录、
  *    failed 玩游戏气急败坏、bubble 鲸鱼吐泡泡特效。
- * 资产缺失时 resolvePresetName 仍返回 null（调用方保持当前动画，不做静默兜底）。
+ * 资产缺失时 resolvePresetName 仍返回 null：会话状态（override/props 驱动）由调用方
+ * 走 fallbackPresetName 降级（避免卡在旧循环），adHoc（点击回应/待机插播）保持当前动画。
  */
 export const PRESET_SESSION_ANIMATIONS: Record<string, string> = {
   // 细分工作状态档位（workStatus）
@@ -218,4 +219,38 @@ export function resolvePresetName(
     return null
   const name = pick(pool)
   return assets[name] !== undefined ? name : null
+}
+
+/**
+ * 会话状态解析不到资产时的降级动画名（与 resolvePresetName 的「保持当前动画」
+ * 语义互补）：resolve 失败若不切换，宠物会永久卡在上一个循环动画上 —— 典型故障
+ * 是细分工作档（thinking/working/result/waiting）资产缺失的旧预设中，会话运行
+ * 显示待机、拖拽结束后永远循环拖拽动画。
+ *
+ * 降级链：
+ * 1. 细分工作档/粗态 running → 粗态「写代码」（旧预设普遍存在，保留「在干活」
+ *    的观感，而非退回待机）；
+ * 2. 其余状态（终态档/待机链）→ 待机池兜底；
+ * 3. 无可播资产时返回 null（调用方保持当前动画）。
+ *
+ * 仅用于会话状态（override/props 驱动）；adHoc（点击回应/待机插播）缺失时
+ * 仍保持当前动画 —— 一次性风味动画不应被错播成工作/待机动画。
+ */
+export function fallbackPresetName(
+  activity: string,
+  pools: { idlePool: readonly string[] },
+  assets: Record<string, string>,
+): string | null {
+  if (activity === 'thinking' || activity === 'working'
+    || activity === 'result' || activity === 'waiting' || activity === 'running') {
+    const running = PRESET_SESSION_ANIMATIONS.running
+    if (running !== undefined && assets[running] !== undefined)
+      return running
+  }
+  if (pools.idlePool.length > 0) {
+    const name = pick(pools.idlePool)
+    if (assets[name] !== undefined)
+      return name
+  }
+  return null
 }


### PR DESCRIPTION
### 现象

1. 宠物正在 work（thinking/working/result/waiting）时始终显示待机动画；
2. 拖拽宠物后，拖拽动画永远循环，不会回到会话状态动画。

### 根因

`src/pet/components/pet.tsx` 视频切换 effect：`resolvePresetName` 资产缺失时返回 `null`，旧语义直接 `return`（保持当前动画）。细分工作档资产缺失的旧预设（早于 e1ff8c1 的安装）下：

- 会话运行中 work 档解析失败 → 永远停在待机循环；
- 拖拽动画是循环视频（`loop=true`、`onended=null`）→ 拖拽结束回到 work 档仍解析失败 → **永远循环拖拽动画**。

### 改动（3 个 commit）

| commit | 内容 |
|---|---|
| `fix(pet): 会话状态动画资产缺失时降级…` | 新增 `fallbackPresetName`（细分工作档/粗态 running → 写代码，其余 → 待机池）；视频 effect 对会话状态降级、不再卡旧循环；adHoc 仍保持旧语义 |
| `fix(pet): 会话状态未变化时跳过 change 重发…` | `lastStatusRef` 去重：useWatch 每次渲染触发，拖拽期间 Moved 高频重渲染会把 `override.revision` 不断递增，拖拽动画被反复重载（每帧重启） |
| `fix(pet): 子代理会话不展示 toast…` | 子代理会话整体静默（活跃追踪与「已完成」均不弹），状态仍参与聚合与沉淀 |

### 验证

- `eslint` 0 errors / `tsc --noEmit` 通过
- `src/pet` 单测 36 passed（新增 4 组 fallback 用例）、全量 vitest 109 passed
- `pnpm build` 通过

### 备注

生产数据目录 `~/.dsh/pets/maid-deepseek-whale` 为旧预设（100 个 webm、无 `工作状态-*`），更新到 pinned ref 后可显示完整工作状态动画；降级逻辑保证无论预设新旧行为都正常。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pet animation handling when session-specific assets are unavailable, using appropriate fallback animations instead of retaining outdated animations.
  - Preserved unresolved behavior for custom animations when their assets are missing.
  - Prevented duplicate pet status updates when the watched state has not changed.
  - Suppressed toast creation and updates for subagent sessions while closing existing related toasts.
  - Improved handling when idle animation assets are unavailable.
  - Prevented manually cancelled sessions from being reported as failures, returning them to an idle state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->