### PR TITLE
fix(rightclick): 右键菜单「粘贴」对 contenteditable 输入框生效 (issue #420)

### DIFF
--- a/packages/dsh-tauri-rightclick/src/client/service/menu.ts
+++ b/packages/dsh-tauri-rightclick/src/client/service/menu.ts
@@ -25,7 +25,7 @@ import { createMenuItem, createMenuRoot, createSeparator, positionMenu } from '.
 import { text } from '../locales'
 import { copyText, readClipboard } from '../utils/clipboard'
 import { toast } from '../utils/dialog'
-import { replaceSelection, selectAll, selectionSurface, selectSurface } from '../utils/editable'
+import { pasteInto, replaceSelection, selectAll, selectionSurface, selectSurface } from '../utils/editable'
 import {
   archiveSession,
   archiveUngroupedSessions,
@@ -191,7 +191,7 @@ export function registerContextMenu(ctx: ClientContext): () => void {
         replaceSelection(editable, '')
       }, 'Ctrl+X')
       add(root, text('copy'), () => copyText(selection, 'copied'), 'Ctrl+C')
-      add(root, text('paste'), async () => replaceSelection(editable, await readClipboard()), 'Ctrl+V')
+      add(root, text('paste'), async () => pasteInto(editable, await readClipboard()), 'Ctrl+V')
       split(root)
       add(root, text('selectAll'), () => selectAll(editable), 'Ctrl+A')
       split(root)

--- a/packages/dsh-tauri-rightclick/src/client/utils/editable.test.ts
+++ b/packages/dsh-tauri-rightclick/src/client/utils/editable.test.ts
@@ -1,0 +1,185 @@
+/**
+ * editable.test.ts — editable.ts 粘贴/选区工具的 DOM 逻辑单测。
+ *
+ * 默认 node 环境（无 jsdom），用轻量替身 stub DOM 全局（DataTransfer /
+ * ClipboardEvent / InputEvent / document / getSelection）模拟三态元素与
+ * contenteditable 编辑器接管行为，验证 pasteInto 的逐级回退阶梯：
+ * 合成 paste 事件 → execCommand('insertText') → 原 DOM 写入。
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// 与实现文件同源：import 引用即验证导出面，避免未导出被遗漏。
+import { pasteInto } from './editable'
+
+class FakeDataTransfer {
+  private data = new Map<string, string>()
+  setData(type: string, value: string): void {
+    this.data.set(type, value)
+  }
+
+  getData(type: string): string {
+    return this.data.get(type) ?? ''
+  }
+}
+
+interface FakeClipboardEventInit {
+  bubbles?: boolean
+  cancelable?: boolean
+  clipboardData?: FakeDataTransfer | null
+}
+
+class FakeClipboardEvent extends Event {
+  clipboardData: FakeDataTransfer | null
+  constructor(type: string, init: FakeClipboardEventInit = {}) {
+    super(type, init)
+    // Chromium（WebView2）构造器支持 clipboardData init；node 替身手工回填。
+    this.clipboardData = init.clipboardData ?? null
+  }
+}
+
+interface FakeInputEventInit {
+  bubbles?: boolean
+  inputType?: string
+  data?: string | null
+}
+
+class FakeInputEvent extends Event {
+  inputType: string
+  data: string | null
+  constructor(type: string, init: FakeInputEventInit = {}) {
+    super(type, init)
+    this.inputType = init.inputType ?? ''
+    this.data = init.data ?? null
+  }
+}
+
+class StubInputElement {}
+
+interface EditableLike {
+  focus: ReturnType<typeof vi.fn>
+  textContent: string | null
+  contains: (node: unknown) => boolean
+  dispatchEvent: ReturnType<typeof vi.fn>
+  value: string
+  selectionStart: number | null
+  selectionEnd: number | null
+  setRangeText: ReturnType<typeof vi.fn>
+}
+
+/** 构造 contenteditable 风格替身（非 HTMLInputElement 实例），记录派发的事件。 */
+function contentEditableStub(initial: string): EditableLike & { received: unknown[] } {
+  const stub: EditableLike & { received: unknown[] } = {
+    textContent: initial,
+    focus: vi.fn(),
+    contains: () => false,
+    dispatchEvent: vi.fn(),
+    value: '',
+    selectionStart: null,
+    selectionEnd: null,
+    setRangeText: vi.fn(),
+    received: [],
+  }
+  stub.dispatchEvent = vi.fn((event: Event) => {
+    stub.received.push(event)
+    return true
+  })
+  return stub
+}
+
+/** 构造 HTMLInputElement 替身（走 replaceSelection 路径）。 */
+function inputStub(initial: string): EditableLike {
+  return Object.assign(Object.create(StubInputElement.prototype), {
+    value: initial,
+    selectionStart: null,
+    selectionEnd: null,
+    setRangeText: vi.fn(),
+    focus: vi.fn(),
+    contains: () => false,
+    dispatchEvent: vi.fn(),
+  })
+}
+
+/** contenteditable 场景的公共全局 stub。 */
+function stubContentEditableGlobals(): void {
+  vi.stubGlobal('HTMLInputElement', class {})
+  vi.stubGlobal('HTMLTextAreaElement', class {})
+  vi.stubGlobal('DataTransfer', FakeDataTransfer)
+  vi.stubGlobal('ClipboardEvent', FakeClipboardEvent)
+}
+
+/** input 场景的公共全局 stub（HTMLInputElement 命中 + 粘贴路径所需全局齐备）。 */
+function stubInputGlobals(): void {
+  vi.stubGlobal('HTMLInputElement', StubInputElement)
+  vi.stubGlobal('HTMLTextAreaElement', class {})
+  vi.stubGlobal('InputEvent', FakeInputEvent)
+  vi.stubGlobal('DataTransfer', FakeDataTransfer)
+  vi.stubGlobal('ClipboardEvent', FakeClipboardEvent)
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('pasteInto — input/textarea', () => {
+  it('委托 replaceSelection：setRangeText + 合成 input 事件', () => {
+    stubInputGlobals()
+    const input = inputStub('abc')
+
+    pasteInto(input as unknown as HTMLElement, 'X')
+
+    // 无选区时取 value.length：start/end = 3，追加在末尾。
+    expect(input.setRangeText).toHaveBeenCalledWith('X', 3, 3, 'end')
+    const event = input.dispatchEvent.mock.calls[0]?.[0] as FakeInputEvent
+    expect(event).toBeInstanceOf(FakeInputEvent)
+    expect(event.type).toBe('input')
+    expect(event.inputType).toBe('insertText')
+    expect(event.data).toBe('X')
+  })
+})
+
+describe('pasteInto — contenteditable', () => {
+  it('编辑器接管合成 paste 事件时写入并短路（不再 execCommand / DOM 写入）', () => {
+    stubContentEditableGlobals()
+    const execCommand = vi.fn(() => true)
+    vi.stubGlobal('document', { execCommand })
+    const stub = contentEditableStub('ab')
+    // 模拟 Lexical 式编辑器：读取 clipboardData 纯文本并同步写入 + preventDefault。
+    stub.dispatchEvent = vi.fn((event: FakeClipboardEvent) => {
+      stub.received.push(event)
+      stub.textContent = `${stub.textContent}${event.clipboardData?.getData('text/plain') ?? ''}`
+      event.preventDefault()
+      return false
+    })
+
+    pasteInto(stub as unknown as HTMLElement, 'X')
+
+    expect(stub.textContent).toBe('abX')
+    const event = stub.received[0] as FakeClipboardEvent
+    expect(event.type).toBe('paste')
+    expect(event.bubbles).toBe(true)
+    expect(event.cancelable).toBe(true)
+    expect(event.clipboardData?.getData('text/plain')).toBe('X')
+    expect(execCommand).not.toHaveBeenCalled()
+  })
+
+  it('编辑器未接管（内容未变化）时回退 execCommand(\'insertText\')', () => {
+    stubContentEditableGlobals()
+    const execCommand = vi.fn(() => true)
+    vi.stubGlobal('document', { execCommand })
+    const stub = contentEditableStub('ab')
+
+    pasteInto(stub as unknown as HTMLElement, 'X')
+
+    expect(stub.textContent).toBe('ab')
+    expect(execCommand).toHaveBeenCalledWith('insertText', false, 'X')
+  })
+
+  it('execCommand 也失败时退回原 DOM 写入（选区未知则抛 editPositionUnknown）', () => {
+    stubContentEditableGlobals()
+    vi.stubGlobal('document', { execCommand: vi.fn(() => false) })
+    vi.stubGlobal('getSelection', () => ({ rangeCount: 0 }))
+    const stub = contentEditableStub('ab')
+
+    expect(() => pasteInto(stub as unknown as HTMLElement, 'X')).toThrow('Could not determine the editing position')
+  })
+})

--- a/packages/dsh-tauri-rightclick/src/client/utils/editable.ts
+++ b/packages/dsh-tauri-rightclick/src/client/utils/editable.ts
@@ -7,6 +7,39 @@
  */
 import { text } from '../locales'
 
+/**
+ * 将文本粘贴进可编辑元素（input/textarea 走 replaceSelection，contenteditable
+ * 走编辑器自身粘贴管线）。
+ *
+ * contenteditable（Lexical 系富文本编辑器，如 dsh 聊天输入框 `data-composer-input`）
+ * 只接受自身编辑管线：外部直接改 DOM 再派发合成 `input` 事件会被编辑器模型
+ * reconcile 静默丢弃（表现为右键「粘贴」点了没反应、无报错、无 toast）。因此
+ * 优先派发携带纯文本 DataTransfer 的合成 paste 事件交给编辑器自身 beforeinput/
+ * paste 管线；若编辑器未接管（内容未变化）再回退 `document.execCommand('insertText')`，
+ * 最后才退回原 DOM 写入。input/textarea 行为与旧实现一致。
+ */
+export function pasteInto(editable: HTMLElement, value: string): void {
+  if (editable instanceof HTMLInputElement || editable instanceof HTMLTextAreaElement) {
+    replaceSelection(editable, value)
+    return
+  }
+  editable.focus()
+  const before = editable.textContent ?? ''
+  // 合成 paste 事件不带默认行为，须由监听器（编辑器管线）接管并 preventDefault + 写入。
+  const dataTransfer = new DataTransfer()
+  dataTransfer.setData('text/plain', value)
+  editable.dispatchEvent(new ClipboardEvent('paste', {
+    bubbles: true,
+    cancelable: true,
+    clipboardData: dataTransfer,
+  }))
+  if ((editable.textContent ?? '') !== before)
+    return
+  if (document.execCommand('insertText', false, value))
+    return
+  replaceSelection(editable, value)
+}
+
 /** 替换可编辑元素中的当前选区（输入/文本域/可编辑区三态）。 */
 export function replaceSelection(editable: HTMLElement, value: string): void {
   editable.focus()


### PR DESCRIPTION
Fixes #420

## 问题

聊天输入框（Lexical 系 contenteditable，`data-composer-input`）只接受自身编辑管线（原生 paste/beforeinput）。
原「粘贴」实现为 `navigator.clipboard.readText()` + 直接修改 DOM 选区 + 派发合成 `input` 事件，
这类外部 DOM 改动会被 Lexical 模型 reconcile 静默丢弃 —— 表现为点了没反应、无报错、无 toast，而 Ctrl+V 正常。

## 修复

- `packages/dsh-tauri-rightclick/src/client/utils/editable.ts`：新增 `pasteInto()`
  - input/textarea：行为不变，仍走 `replaceSelection`
  - contenteditable：优先派发携带纯文本 `DataTransfer` 的合成 `paste` 事件（bubbles + cancelable），交给编辑器自身 beforeinput/paste 管线；
    校验内容未变化（编辑器未接管）再回退 `document.execCommand('insertText')`；最后才退回原 DOM 写入
- `packages/dsh-tauri-rightclick/src/client/service/menu.ts`：「粘贴」菜单项改调 `pasteInto(editable, await readClipboard())`

## 验证

- 新增 `editable.test.ts` 4 个单测覆盖回退阶梯（input 委托 / 合成 paste 接管短路 / execCommand 回退 / DOM 写入兜底抛错）
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅（2 files changed，0 errors）
- `pnpm run test -- --run` ✅（18 files / 113 tests）
- `pnpm --filter dsh-tauri-rightclick build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the paste action for text inputs, text areas, and content-editable fields.
  * Pasted content now inserts more reliably at the active cursor or selection, including when editors handle paste events directly.
  * Added fallback handling for editors with limited paste support.

* **Tests**
  * Added coverage for paste behavior across supported editable field types and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->