### PR TITLE
chore: release v0.11.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.11.0-beta.4",
+  "version": "0.11.0-beta.5",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.11.0-beta.4"
+version = "0.11.0-beta.5"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.11.0-beta.4"
+version = "0.11.0-beta.5"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.11.0-beta.4",
+  "version": "0.11.0-beta.5",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.11.0-beta.5` (`0.11.0-beta.4` → `0.11.0-beta.5`).

### Features

- **toast-provider**: add custom attribute to support custom toast rendering (7171082)

### Bug Fixes

- **rightclick**: make context-menu paste work in contenteditable editors (84cae2c)
- **pet**: 手动取消会话静默回落空闲，不再弹「失败：aborted」toast (ba13d22)
- **pet**: 子代理会话不展示 toast（活跃追踪与已完成均静默） (b85b23f)
- **pet**: 会话状态未变化时跳过 change 重发，避免拖拽动画反复重载 (cf25d3a)
- **pet**: 会话状态动画资产缺失时降级，修复拖拽结束卡死循环 (84d627d)
- prefer official Windows process inspector (1d477ed)

### Documentation

- **pet**: add upstream sync log for dsh-tauri-pet (70096f6)

### Chores

- add github stale.yml (0ff81b0)
- add github CODEOWNERS (9378a16)

### Other Changes

- Merge branch 'fix/pet-drag-loop-stuck' (4782547)
- Merge pull request #422 from dsh-tauri-desk/fix/issue-420-rightclick-paste (c859fc1)
- Merge pull request #419 from dsh-tauri-desk/fix/issue-12-official-win-inspector (0e08451)
- Merge pull request #421 from dsh-tauri-desk/fix/pet-drag-loop-stuck (d4106f3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.11.0-beta.5**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->