### PR TITLE
fix: preserve worktree session inheritance

### DIFF
--- a/packages/dsh-tauri-worktree/src/host/service/handoff.ts
+++ b/packages/dsh-tauri-worktree/src/host/service/handoff.ts
@@ -66,9 +66,12 @@ export async function createInheritedSession(
       meta: {
         cwd,
         parentSession: options.parentSession ?? sourceSession.id,
+        // DSH 0.1.2-rc.1 requires seeded sessions to declare the inherited prefix.
+        isSeeded: true,
         seedLength: seed.length,
         ...(parentPreset ? { agentPreset: parentPreset } : {}),
       },
+      inheritedEventCount: seed.length,
       agentOptions: agent?.options ?? {},
     }
     if (agent && presets && parentPreset) {
@@ -156,9 +159,11 @@ export async function handbackWorktreeSession(
       meta: {
         cwd: projectPath,
         parentSession: sourceSession.id,
+        isSeeded: true,
         seedLength: seed.length,
         ...(parentPreset ? { agentPreset: parentPreset } : {}),
       },
+      inheritedEventCount: seed.length,
       agentOptions: agent?.options ?? {},
     }
     if (agent && presets && parentPreset) {
@@ -240,9 +245,11 @@ export async function completeWorktreeHandoff(
       meta: {
         cwd: binding.worktreePath,
         parentSession: sourceSession.id,
+        isSeeded: true,
         seedLength: seed.length,
         ...(parentPreset ? { agentPreset: parentPreset } : {}),
       },
+      inheritedEventCount: seed.length,
       agentOptions: sourceAgent.options ?? {},
       setup: (agentCtx: any) => {
         if (presets && parentPreset)


### PR DESCRIPTION
## Summary\n- mark inherited worktree sessions as seeded for DSH 0.1.2-rc.1\n- pass inheritedEventCount when creating seeded sessions\n- cover new worktree, checkout handback, and tool handoff flows\n\n## Validation\n- git diff --check\n- pnpm typecheck (not run: dependencies are not installed in the isolated worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Inherited sessions now retain seeded-session status across handoff workflows.
  - Session handoffs now record the number of inherited events for improved continuity and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->