### PR TITLE
fix(plugin): tolerate persistent filesystem install errors

### DIFF
--- a/src-tauri/src/service/plugin/install/mod.rs
+++ b/src-tauri/src/service/plugin/install/mod.rs
@@ -88,10 +88,20 @@ const MAX_ALLOW_LIST_RETRIES: usize = 8;
 /// 一次随机失败就让整个安装放弃——`link:` 依赖没有写入 profile `package.json`，
 /// 下次启动又判定 `dep_ok=false` 而重装，形成不可恢复的启动死循环（issue #264）。
 /// 该失败是「刚重建的 reparse point 落定 / 实时杀软扫刚写入路径」的瞬时态，重跑
-/// 同一 `dsh plugin add`（间隔 [`TRANSIENT_FS_RETRY_DELAY`]）即可越过。
-const TRANSIENT_FS_RETRIES: usize = 3;
-/// 瞬时文件系统错误的重试间隔：等待 reparse point 落定、杀软结束扫描后再重试。
-const TRANSIENT_FS_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
+/// 同一 `dsh plugin add` 即可越过。首启期间杀软可能持续占用新文件，短暂的固定重试
+/// 窗口不足以覆盖扫描时间，因此使用指数退避扩大到约两分钟的恢复窗口。
+const TRANSIENT_FS_RETRIES: usize = 8;
+/// 瞬时文件系统错误的首次重试延迟；后续延迟按指数增长，最多 64 秒。
+const TRANSIENT_FS_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+
+fn transient_fs_retry_delay(retry: usize) -> std::time::Duration {
+    let seconds = TRANSIENT_FS_RETRY_DELAY
+        .as_secs()
+        .checked_shl(retry.saturating_sub(1) as u32)
+        .unwrap_or(64)
+        .min(64);
+    std::time::Duration::from_secs(seconds)
+}
 
 pub async fn install(app_handle: &AppHandle, ids: &[String]) -> Result<(), String> {
     install_with_cancel(app_handle, ids, None, new_process_owner()).await
@@ -459,9 +469,10 @@ async fn run_plugin_install_with_transient_retry(
             && is_transient_fs_install_failure(exit_code, &output)
         {
             attempt += 1;
+            let delay = transient_fs_retry_delay(attempt);
             log::warn!(
                 "dsh plugin {action} hit a transient filesystem error (exit code {exit_code}); \
-                 retrying ({attempt}/{TRANSIENT_FS_RETRIES})"
+                 retrying ({attempt}/{TRANSIENT_FS_RETRIES}) after {delay:?}"
             );
             let _ = window.emit(
                 PREINSTALL_LOG_EVENT,
@@ -471,7 +482,7 @@ async fn run_plugin_install_with_transient_retry(
                     ),
                 },
             );
-            tokio::time::sleep(TRANSIENT_FS_RETRY_DELAY).await;
+            tokio::time::sleep(delay).await;
             continue;
         }
         return Ok((exit_code, output));
@@ -529,6 +540,13 @@ mod tests {
         assert!(is_transient_fs_install_failure(1, output));
         // `[unknown]` / `unknown error` 大小写不敏感
         assert!(is_transient_fs_install_failure(1, &output.to_ascii_lowercase()));
+    }
+
+    #[test]
+    fn transient_fs_retry_delay_uses_exponential_backoff() {
+        assert_eq!(transient_fs_retry_delay(1), std::time::Duration::from_secs(1));
+        assert_eq!(transient_fs_retry_delay(2), std::time::Duration::from_secs(2));
+        assert_eq!(transient_fs_retry_delay(8), std::time::Duration::from_secs(64));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- extend transient filesystem retries from 3 fixed 200ms attempts to 8 exponential-backoff attempts\n- wait up to 64 seconds between retries to cover first-launch antivirus/IO contention\n- add regression coverage for backoff timing\n\nCloses #423\n\n## Tests\n- cargo test service::plugin::install::tests --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary filesystem errors during plugin installation by retrying with progressively longer delays.
  * Added clearer retry timing information to installation logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->