### PR TITLE
feat(panel): 克隆侧栏暴露官方语义兼容锚点，供纯 Web 插件（dsh-task-board/dsh-ssh）DOM 注入

### DIFF
--- a/packages/dsh-tauri-panel/PROTOCOL.md
+++ b/packages/dsh-tauri-panel/PROTOCOL.md
@@ -120,3 +120,31 @@ return ctx.slots.register(
   手柄不渲染、宽度固定（`--dsh-chat-content-width` 回退 `780px`），仅 console.warn 一次；
 - **renderer 补丁缺失**：`<SlotOutlet>` 为 `undefined` → 侧栏面板整体不注册
   （官方侧栏原样工作），但 `panel.protocol`（内容区替换）仍可用。
+
+## 5. 纯 Web 插件的 DOM 兼容锚点（`PANEL_SIDEBAR_COMPAT_CLASS`）
+
+桌面端以 `priority: -1` 整槽替换官方 `ui-sidebar`，官方 `SidebarRoot`（含
+`logoRow` / `newSession` 等 CSS module camelCase class）不再渲染。纯 Web 生态插件
+（dsh-web 的 `dsh-task-board` / `dsh-ssh` 等）**不接入**本协议的
+`sidebar.panel.action` 槽，而是按官方 class 的 camelCase 子串做纯 DOM 注入：
+
+- `[class*="sidebarCol"]`（官方 layout 列；桌面仍在）定位侧栏列；
+- 列内 `[class*="logoRow"]` 元素的 `parentElement` 作为注入 root；
+- root 内 `button[class*="newSession"]` 作为「新会话块」定位；
+- 入口行插入该块与 workspace 浏览器之间（`closest('[class*="logoRow"]')`
+  命中块 → 块是 root 直接子级 → 插到块之后）。
+
+克隆侧栏 class 为 kebab 命名（`dshp-panel__logo-row` 等），与 camelCase 子串
+不匹配 → 这类插件的入口行永不挂载（静默，仅 console.error）。为此克隆 DOM 在
+**语义等价**元素上携带带官方 camelCase 子串的 token class（无任何样式）：
+
+| token | 值 | 位置（语义） |
+| --- | --- | --- |
+| `PANEL_SIDEBAR_COMPAT_CLASS.logoRow` | `dshp-panel-compat-logoRow` | 面板区容器 `dshp-panel__panel-area`（充当「新会话所在块」） |
+| `PANEL_SIDEBAR_COMPAT_CLASS.newSession` | `dshp-panel-compat-newSession` | 面板区内新会话菜单项（`dshp-panel__new-session`） |
+
+效果：注入行落入 panel-area（新会话 + 第三方条目）与 region-area（workspace
+浏览器）之间，与官方侧栏语义等价；`sidebar.panel.action` 协议仍是推荐接入方式，
+DOM 锚点仅为无法改造的纯 Web 插件提供回退。未来若克隆侧栏结构调整，须保持
+panel-area 为 root 直接子级且 newSession token 位于 logoRow token 容器内
+（`closest` 链依赖此几何）。

--- a/packages/dsh-tauri-panel/src/client/components/sidebar.tsx
+++ b/packages/dsh-tauri-panel/src/client/components/sidebar.tsx
@@ -3,7 +3,7 @@ import type { SidebarRootProps } from '../types'
 import { SlotOutlet } from '@deepseek-ai/dsh-client-ui-renderer'
 import { CommentPlus, FishMark, Icon, useMountStyle } from 'dsh-tauri-ui/client'
 import { useEffect, useRef, useState } from 'react'
-import { COLLAPSE_SETTLE_MS, PANEL_DATA_ATTRIBUTES, SCROLLBAR_LINGER_MS, SIDEBAR_STYLE_ID } from '../constants'
+import { COLLAPSE_SETTLE_MS, PANEL_DATA_ATTRIBUTES, PANEL_SIDEBAR_COMPAT_CLASS, SCROLLBAR_LINGER_MS, SIDEBAR_STYLE_ID } from '../constants'
 import sidebarStyle from './sidebar.cssr'
 
 /**
@@ -142,10 +142,10 @@ export function SidebarRootClone({ collapsed, width, startSession, toggleSidebar
           )}
         </button>
       </div>
-      <div className="dshp-panel__panel-area">
+      <div className={`${'dshp-panel__panel-area'} ${PANEL_SIDEBAR_COMPAT_CLASS.logoRow}`}>
         <button
           type="button"
-          className="dshp-panel__new-session"
+          className={`${'dshp-panel__new-session'} ${PANEL_SIDEBAR_COMPAT_CLASS.newSession}`}
           title={t('session.new.label')}
           onClick={() => {
             console.warn('[dsh-tauri-panel] new session requested', { source: 'menu' })

--- a/packages/dsh-tauri-panel/src/client/constants/index.ts
+++ b/packages/dsh-tauri-panel/src/client/constants/index.ts
@@ -27,3 +27,19 @@ export const PANEL_DATA_ATTRIBUTES = {
   view: 'data-dshp-panel-view',
   widthHandle: 'data-width-handle',
 } as const
+
+/**
+ * 官方侧栏语义的兼容 class 锚点。桌面端用 priority -1 整槽替换了官方 ui-sidebar，
+ * 而纯 Web 生态插件（dsh-web 的 dsh-task-board / dsh-ssh 等）不接 sidebar.panel.action
+ * 协议，改为按官方 CSS module class 的 **camelCase 子串** 做纯 DOM 注入：
+ *   - `[class*="logoRow"]`（取 logoRow 块的 parentElement 作为注入 root）
+ *   - `button[class*="newSession"]`（入口行插到新会话块与 workspace 浏览器之间）
+ * 克隆侧栏的 class 是 kebab 命名（dshp-panel__logo-row 等），子串不匹配 → 入口永不挂载。
+ * 因此在「等价语义」的克隆元素上追加携带官方 camelCase 子串的 token（不参与任何样式），
+ * 让这类插件的选择器能命中：panel-area 充当新会话所在块（logoRow token），其内的新会话
+ * 菜单项携带 newSession token，注入行落入 panel-area 与 region-area 之间。
+ */
+export const PANEL_SIDEBAR_COMPAT_CLASS = {
+  logoRow: 'dshp-panel-compat-logoRow',
+  newSession: 'dshp-panel-compat-newSession',
+} as const


### PR DESCRIPTION
## 背景

调研结论：`dsh-task-board`（@linxin666/dsh-client-ui-task-board，dsh-web 生态）等纯 Web 插件**不接入** `sidebar.panel.action` 协议，而是按官方 `ui-sidebar` CSS module class 的 **camelCase 子串**做纯 DOM 注入（`[class*="logoRow"]` 定位注入 root、`button[class*="newSession"]` 作新会话块锚点，入口行插到该块与 workspace 浏览器之间）。桌面端 `priority: -1` 整槽替换官方 ui-sidebar 后，克隆侧栏 class 全为 kebab 命名（`dshp-panel__logo-row` 等），camelCase 子串不匹配 → 这类插件的入口行**静默不挂载**（仅 console.error，不白屏）。

## 改动

在克隆侧栏的**语义等价**元素上追加携带官方 camelCase 子串的 token class（纯锚点、不参与任何样式）：

- `packages/dsh-tauri-panel/src/client/constants/index.ts`：新增 `PANEL_SIDEBAR_COMPAT_CLASS = { logoRow: 'dshp-panel-compat-logoRow', newSession: 'dshp-panel-compat-newSession' }`（含机制注释）
- `packages/dsh-tauri-panel/src/client/components/sidebar.tsx`：panel-area（新会话所在块）补 `logoRow` token；面板区内新会话按钮补 `newSession` token
- `packages/dsh-tauri-panel/PROTOCOL.md`：新增 §5 记录 DOM 兼容契约与几何约束

注入行落入 panel-area（新会话 + 第三方条目）与 region-area（workspace 浏览器）**之间**，与官方语义位置等价。dsh-ssh 同源共享注入核心，一并受益。

## 反向误伤排查

- 仓库内无其它 `[class*="logoRow"]` / `[class*="newSession"]` 子串选择器；
- dsh-web 皮肤 CSS 的同类选择器带 `[data-pane="sidebar"]` 前缀，而官方 bundle 不发射 `data-pane` → 不误伤克隆 panel-area；
- 克隆根 flex column 无 nth-child 依赖，注入行安全插入。

## 验证

- `pnpm --filter dsh-tauri-panel typecheck` / `build`（tsdown + publint clean）✅
- eslint 改动文件 0 error ✅
- vitest：width.test.ts（8）+ sidebar.cssr.test.ts（2，上游新增）全过 ✅

> 注：本分支基于 `07f06b0`（拉取最新后合并），已与上游同期改动（新会话按钮独立类拆分 51c0195 线）协调。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility markers to the desktop sidebar, enabling web-only plugins to locate the logo area and new-session control through standard DOM class names.
  - Documented the sidebar DOM compatibility anchors and their expected placement for plugin integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->