### PR TITLE
fix(panel-extension): restore shared form styles

### DIFF
--- a/packages/dsh-tauri-panel-extension/src/client/components/mcp-editor-form.cssr.ts
+++ b/packages/dsh-tauri-panel-extension/src/client/components/mcp-editor-form.cssr.ts
@@ -1,11 +1,10 @@
 import { cssr, styles as sharedStyles } from 'dsh-tauri-ui/client'
 
-const { c, bem: { b, e, m } } = cssr
-const { primary, secondary, tertiary, borderL2: border, business, layer1 } = sharedStyles
+const { c, bem: { b, e } } = cssr
+const { primary, tertiary, borderL2: border, business } = sharedStyles
 
-/** MCP 服务器编辑器（mcp-editor-form.tsx）：表单 + 编辑器页签。 */
+/** MCP 服务器编辑器（mcp-editor-form.tsx）：编辑器页签 + JSON 编辑区。 */
 export default b('extension', [
-  e('form', { display: 'flex', flexDirection: 'column', gap: '10px' }),
   e('editor-tabs', { display: 'flex', gap: '4px', borderBottom: `1px solid ${border}` }),
   e('editor-tab', {
     position: 'relative',
@@ -36,100 +35,5 @@ export default b('extension', [
       color: primary,
     }),
   ]),
-  e('label', {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '4px',
-    fontSize: '12px',
-    lineHeight: '18px',
-    color: secondary,
-  }, [
-    c('& > span:first-child', { color: tertiary }),
-  ]),
-  e('input', {
-    width: '100%',
-    boxSizing: 'border-box',
-    border: `1px solid ${border}`,
-    borderRadius: '8px',
-    padding: '7px 10px',
-    outline: 'none',
-    background: layer1,
-    color: primary,
-    font: 'inherit',
-    fontSize: '13px',
-  }, [
-    c('&:focus-visible', {
-      borderColor: business,
-      boxShadow: `0 0 0 2px color-mix(in srgb,${business} 18%,transparent)`,
-    }),
-  ]),
-  e('textarea', {
-    width: '100%',
-    boxSizing: 'border-box',
-    border: `1px solid ${border}`,
-    borderRadius: '8px',
-    padding: '7px 10px',
-    outline: 'none',
-    background: layer1,
-    color: primary,
-    font: 'inherit',
-    fontSize: '13px',
-    minHeight: '320px',
-    resize: 'vertical',
-    fontFamily: 'var(--ds-font-family-code)',
-    lineHeight: '1.5',
-  }, [
-    c('&[data-short="true"]', { minHeight: '96px' }),
-    c('&:focus-visible', {
-      borderColor: business,
-      boxShadow: `0 0 0 2px color-mix(in srgb,${business} 18%,transparent)`,
-    }),
-  ]),
-  e('select', {
-    width: '100%',
-    boxSizing: 'border-box',
-    border: `1px solid ${border}`,
-    borderRadius: '8px',
-    padding: '7px 10px',
-    outline: 'none',
-    background: layer1,
-    color: primary,
-    font: 'inherit',
-    fontSize: '13px',
-  }, [
-    c('&:focus-visible', {
-      borderColor: business,
-      boxShadow: `0 0 0 2px color-mix(in srgb,${business} 18%,transparent)`,
-    }),
-  ]),
   e('json-editor', { minHeight: '260px' }),
-  e('checks', {
-    display: 'flex',
-    gap: '16px',
-    fontSize: '13px',
-    lineHeight: '20px',
-  }, [
-    c('& label', {
-      display: 'inline-flex',
-      alignItems: 'center',
-      gap: '8px',
-      cursor: 'pointer',
-      minWidth: '0',
-    }),
-  ]),
-  e('import-choice', {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '8px',
-    cursor: 'pointer',
-    minWidth: '0',
-  }, [
-    m('disabled', { cursor: 'default' }),
-  ]),
-  e('form-error', {
-    margin: '0',
-    color: 'var(--dsw-alias-state-error-primary)',
-    fontSize: '12px',
-    lineHeight: '18px',
-  }),
 ])

--- a/packages/dsh-tauri-panel-extension/src/client/components/mcp-import-dialog.cssr.ts
+++ b/packages/dsh-tauri-panel-extension/src/client/components/mcp-import-dialog.cssr.ts
@@ -1,14 +1,10 @@
 import { cssr, styles as sharedStyles } from 'dsh-tauri-ui/client'
 
-const { c, bem: { b, e } } = cssr
+const { bem: { b, e, m } } = cssr
 const { secondary, tertiary } = sharedStyles
 
-/** MCP 批量导入弹窗（mcp-import-dialog.tsx）：分组滚动列表。 */
+/** MCP 批量导入弹窗（mcp-import-dialog.tsx）：分组滚动列表 + 勾选行。 */
 export default b('extension', [
-  // Modal className 需高于官方 Modal 内部宽度的特异性，保持双重类。
-  c('.dshp-extension__modal-wide.dshp-extension__modal-wide', { width: 'min(680px,100%)' }),
-  c('.dshp-extension__modal-form.dshp-extension__modal-form', { width: 'min(760px,100%)' }),
-  c('.dshp-extension__modal-scroll.dshp-extension__modal-scroll', { maxHeight: 'calc(100vh - 160px)', overflowY: 'auto' }),
   e('import-scroll', {
     display: 'flex',
     flexDirection: 'column',
@@ -29,4 +25,13 @@ export default b('extension', [
     color: secondary,
     cursor: 'pointer',
   }),
+  e('import-choice', {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '8px',
+    cursor: 'pointer',
+    minWidth: '0',
+  }, [
+    m('disabled', { cursor: 'default' }),
+  ]),
 ])

--- a/packages/dsh-tauri-panel-extension/src/client/components/mcp-tab.cssr.ts
+++ b/packages/dsh-tauri-panel-extension/src/client/components/mcp-tab.cssr.ts
@@ -1,37 +1,25 @@
 import { cssr, styles as sharedStyles } from 'dsh-tauri-ui/client'
 
 const { c, bem: { b, e } } = cssr
-const { primary, secondary, tertiary, borderL2: border, layer1, hover } = sharedStyles
+const { primary, borderL2: border, business, layer1 } = sharedStyles
 
-/** MCP 列表（mcp-tab.tsx）：格式分段 + 标签 chips + 开关 + 链接。 */
+/** MCP 列表（mcp-tab.tsx）：list-head 内的范围筛选下拉。 */
 export default b('extension', [
-  e('segments', {
-    display: 'inline-flex',
-    gap: '4px',
+  e('scope', {
+    boxSizing: 'border-box',
     border: `1px solid ${border}`,
     borderRadius: '8px',
-    padding: '3px',
+    padding: '4px 10px',
+    outline: 'none',
     background: layer1,
-  }),
-  e('segment', {
-    border: '0',
-    borderRadius: '6px',
-    padding: '4px 14px',
-    background: 'transparent',
-    color: secondary,
+    color: primary,
     font: 'inherit',
     fontSize: '12px',
-    cursor: 'pointer',
+    lineHeight: '18px',
   }, [
-    c('&[data-active="true"]', { background: hover, color: primary, fontWeight: '600' }),
+    c('&:focus-visible', {
+      borderColor: business,
+      boxShadow: `0 0 0 2px color-mix(in srgb,${business} 18%,transparent)`,
+    }),
   ]),
-  e('format', {
-    border: `1px solid ${border}`,
-    borderRadius: '8px',
-    padding: '8px 12px',
-    background: layer1,
-  }, [
-    c('& summary', { fontSize: '12px', color: secondary, cursor: 'pointer' }),
-  ]),
-  e('format-hint', { margin: '2px 0 0', fontSize: '12px', color: tertiary }),
 ])

--- a/packages/dsh-tauri-panel-extension/src/client/components/mcp-tab.tsx
+++ b/packages/dsh-tauri-panel-extension/src/client/components/mcp-tab.tsx
@@ -334,7 +334,7 @@ export function McpTab({ t }: McpTabProps): ReactElement {
       <div className="dshp-extension__list-head">
         <h3>{t('mcpTab')}</h3>
         {servers !== null && <span className="dshp-extension__count">{servers.length}</span>}
-        <select aria-label={t('scope')} value={scope} onChange={event => setScope(event.target.value as typeof scope)}>
+        <select className="dshp-extension__scope" aria-label={t('scope')} value={scope} onChange={event => setScope(event.target.value as typeof scope)}>
           <option value="all">{t('scopeAll')}</option>
           <option value="global">{t('global')}</option>
           <option value="profile">{t('profile')}</option>

--- a/packages/dsh-tauri-panel-extension/src/client/components/skills-tab.cssr.ts
+++ b/packages/dsh-tauri-panel-extension/src/client/components/skills-tab.cssr.ts
@@ -16,7 +16,7 @@ export default b('extension', [
   ]),
   e('list-head', {
     display: 'flex',
-    alignItems: 'baseline',
+    alignItems: 'center',
     gap: '7px',
     padding: '0 2px',
     marginTop: '2px',

--- a/packages/dsh-tauri-panel-extension/src/client/components/skills-tab.cssr.ts
+++ b/packages/dsh-tauri-panel-extension/src/client/components/skills-tab.cssr.ts
@@ -143,4 +143,25 @@ export default b('extension', [
   }, [
     c('&:hover', { textDecoration: 'underline' }),
   ]),
+  // 技能编辑器弹窗的「预览 / 编辑」分段切换（skills-tab.tsx editor modal）。
+  e('segments', {
+    display: 'inline-flex',
+    gap: '4px',
+    border: `1px solid ${border}`,
+    borderRadius: '8px',
+    padding: '3px',
+    background: layer1,
+  }),
+  e('segment', {
+    border: '0',
+    borderRadius: '6px',
+    padding: '4px 14px',
+    background: 'transparent',
+    color: secondary,
+    font: 'inherit',
+    fontSize: '12px',
+    cursor: 'pointer',
+  }, [
+    c('&[data-active="true"]', { background: hover, color: primary, fontWeight: '600' }),
+  ]),
 ])

--- a/packages/dsh-tauri-panel-extension/src/client/styles/index.cssr.ts
+++ b/packages/dsh-tauri-panel-extension/src/client/styles/index.cssr.ts
@@ -26,6 +26,100 @@ export default b('extension', [
       boxShadow: `0 0 0 2px color-mix(in srgb,${business} 18%,transparent)`,
     }),
   ]),
+  // 表单字段：技能编辑器 / MCP 编辑器 / 导入弹窗共享，挂载于 apply 全局生效。
+  e('form', { display: 'flex', flexDirection: 'column', gap: '10px' }),
+  e('label', {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+    fontSize: '12px',
+    lineHeight: '18px',
+    color: secondary,
+  }, [
+    c('& > span:first-child', { color: tertiary }),
+  ]),
+  e('input', {
+    width: '100%',
+    boxSizing: 'border-box',
+    border: `1px solid ${border}`,
+    borderRadius: '8px',
+    padding: '7px 10px',
+    outline: 'none',
+    background: layer1,
+    color: primary,
+    font: 'inherit',
+    fontSize: '13px',
+  }, [
+    c('&:focus-visible', {
+      borderColor: business,
+      boxShadow: `0 0 0 2px color-mix(in srgb,${business} 18%,transparent)`,
+    }),
+  ]),
+  e('textarea', {
+    width: '100%',
+    boxSizing: 'border-box',
+    border: `1px solid ${border}`,
+    borderRadius: '8px',
+    padding: '7px 10px',
+    outline: 'none',
+    background: layer1,
+    color: primary,
+    font: 'inherit',
+    fontSize: '13px',
+    minHeight: '320px',
+    resize: 'vertical',
+    fontFamily: 'var(--ds-font-family-code)',
+    lineHeight: '1.5',
+  }, [
+    c('&[data-short="true"]', { minHeight: '96px' }),
+    c('&:focus-visible', {
+      borderColor: business,
+      boxShadow: `0 0 0 2px color-mix(in srgb,${business} 18%,transparent)`,
+    }),
+  ]),
+  e('select', {
+    width: '100%',
+    boxSizing: 'border-box',
+    border: `1px solid ${border}`,
+    borderRadius: '8px',
+    padding: '7px 10px',
+    outline: 'none',
+    background: layer1,
+    color: primary,
+    font: 'inherit',
+    fontSize: '13px',
+  }, [
+    c('&:focus-visible', {
+      borderColor: business,
+      boxShadow: `0 0 0 2px color-mix(in srgb,${business} 18%,transparent)`,
+    }),
+  ]),
+  e('checks', {
+    display: 'flex',
+    gap: '16px',
+    fontSize: '13px',
+    lineHeight: '20px',
+  }, [
+    c('& label', {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '8px',
+      cursor: 'pointer',
+      minWidth: '0',
+    }),
+  ]),
+  e('form-error', {
+    margin: '0',
+    color: 'var(--dsw-alias-state-error-primary)',
+    fontSize: '12px',
+    lineHeight: '18px',
+  }),
+  // Modal 根元素自身同时携带 .dshp-extension 与 __modal-wide/__modal-form：
+  // 必须用 & 复合选择器命中同一元素（后代选择器永远不中）。
+  c('&.dshp-extension__modal-wide.dshp-extension__modal-wide', { width: 'min(680px,100%)' }),
+  c('&.dshp-extension__modal-form.dshp-extension__modal-form', { width: 'min(760px,100%)' }),
+  // contentClassName 落在 Modal 内容层（dialog 根的后代），保持后代选择器。
+  c('.dshp-extension__modal-scroll.dshp-extension__modal-scroll', { maxHeight: 'calc(100vh - 160px)', overflowY: 'auto' }),
   e('cards', {
     display: 'grid',
     gridTemplateColumns: 'repeat(2,minmax(0,1fr))',


### PR DESCRIPTION
## Summary\n- make shared extension form/control styles globally available so Skills and MCP import/editor surfaces receive them\n- move Skills editor segment styles to the Skills stylesheet and keep MCP scope filter styling on its component\n- add the scope select class and repair modal root selectors\n\n## Validation\n- pnpm --filter dsh-tauri-panel-extension typecheck\n- pnpm exec eslint packages/dsh-tauri-panel-extension/src/client/components/mcp-editor-form.cssr.ts packages/dsh-tauri-panel-extension/src/client/components/mcp-import-dialog.cssr.ts packages/dsh-tauri-panel-extension/src/client/components/mcp-tab.cssr.ts packages/dsh-tauri-panel-extension/src/client/components/mcp-tab.tsx packages/dsh-tauri-panel-extension/src/client/components/skills-tab.cssr.ts packages/dsh-tauri-panel-extension/src/client/styles/index.cssr.ts\n- pnpm --filter dsh-tauri-panel-extension build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved shared form layouts and validation styling across skill, MCP, and import-modal editors.
  * Added clearer focus states, responsive text areas, modal sizing, and scrollable modal content.
  * Enhanced import dialogs with selectable rows and improved interaction cues.
  * Refined the MCP scope filter dropdown, including focus and visual states.
  * Added preview/edit segmented controls and improved header alignment in the skills editor.
  * Preserved a minimum height for the JSON editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->