### PR TITLE
chore: release v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.11.0-beta.5",
+  "version": "0.11.0",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.11.0-beta.5"
+version = "0.11.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.11.0-beta.5"
+version = "0.11.0"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.11.0-beta.5",
+  "version": "0.11.0",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.11.0` (`0.11.0-beta.5` → `0.11.0`).

### Features

- **panel**: 克隆侧栏暴露官方语义兼容锚点，供纯 Web 插件 DOM 注入 (6b611f3)

### Bug Fixes

- **panel-extension**: restore shared form styles (254ee34)
- **pet**: 聚合状态合并窗口只下发最新档位，避免多会话动画反复切回 (d252b13)
- **pet**: 默认宠物已启用时更新按钮不再继承主动作禁用态 (973e8e0)
- **plugin**: extend transient install retries (480ed57)
- preserve worktree session inheritance (d9d0b65)

### Chores

- style change (c21cbb6)

### Other Changes

- Merge pull request #430 from hairyf/fix/pet-update-button-and-bubble-coalesce (9b79391)
- Merge remote-tracking branch 'origin/main' into fix/pet-update-button-and-bubble-coalesce (d9aa046)
- Merge pull request #429 from dsh-tauri-desk/feat/panel-sidebar-compat-class (6110267)
- Merge pull request #428 from hairyf/fix/pet-update-button-and-bubble-coalesce (07f06b0)
- Merge pull request #427 from dsh-tauri-desk/fix/issue-423-plugin-retry (f747b9b)
- Merge pull request #425 from dsh-tauri-desk/fix/worktree-session-inheritance (817e2cb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Promoted the application version from 0.11.0-beta.5 to the stable 0.11.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->