### PR TITLE
fix(pet): macOS preset pet black background via stacked-alpha on WebKit

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-if-lite": "catalog:runtime",
     "react-use": "catalog:runtime",
     "semver": "catalog:runtime",
+    "stacked-alpha-video": "catalog:runtime",
     "tailwind-variants": "catalog:runtime",
     "valtio-define": "catalog:runtime"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ catalogs:
     semver:
       specifier: ^7.8.0
       version: 7.8.5
+    stacked-alpha-video:
+      specifier: ^1.0.10
+      version: 1.0.10
     tailwind-variants:
       specifier: ^3.3.1
       version: 3.3.1
@@ -314,6 +317,9 @@ importers:
       semver:
         specifier: catalog:runtime
         version: 7.8.5
+      stacked-alpha-video:
+        specifier: catalog:runtime
+        version: 1.0.10
       tailwind-variants:
         specifier: catalog:runtime
         version: 3.3.1(tailwind-merge@3.4.0)(tailwindcss@4.1.11)
@@ -5231,6 +5237,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stacked-alpha-video@1.0.10:
+    resolution: {integrity: sha512-FdBFKJu/+kinUMTkpELYwvx2ARXDi9GOfvN7KEMajIiNmkBJzEK2h37QSTTPzee1QXBiYssoDW7NdfTxHXYygA==}
 
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
@@ -11214,6 +11223,8 @@ snapshots:
       stackframe: 1.3.4
 
   stackback@0.0.2: {}
+
+  stacked-alpha-video@1.0.10: {}
 
   stackframe@1.3.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,6 +88,7 @@ catalogs:
     react-if-lite: ^0.1.0
     react-use: ^17.6.1
     semver: ^7.8.0
+    stacked-alpha-video: ^1.0.10
     tailwind-variants: ^3.3.1
     valtio-define: ^1.4.1
   # Tauri 相关

--- a/scripts/encode-stacked-alpha.ts
+++ b/scripts/encode-stacked-alpha.ts
@@ -1,0 +1,102 @@
+/**
+ * encode-stacked-alpha.ts — 把预设宠物的 VP9-alpha WebM 批量转码为 stacked-alpha 堆叠视频。
+ *
+ * 背景（issue #434）：macOS WKWebView / Linux WebKitGTK 不支持 VP9-alpha 透明 WebM
+ * （解码丢 alpha 平面 → 黑底）。stacked-alpha 方案把透明信息搬进 luma 平面：视频高度
+ * 翻倍，上半像素 = 颜色，下半像素 = alpha 亮度，前端 WebGL shader 在运行时合成透明。
+ * 产物是「普通不透明编码」（hvc1/av01/avc1 均可），无需 HEVC-with-Alpha 专属 API——
+ * 这正是本脚本与上游 source/dsh-pet/scripts/encode_hevc_alpha.sh 的差异：上游走
+ * macOS 原生 AVAssetWriter + hevcWithAlpha（仅 macOS 可用），stacked 版任何能解码
+ * WebM + 编码 hvc1/av01 的工具链都能产出，ffmpeg 只是默认实现。
+ *
+ * 用法：
+ *   pnpm tsx scripts/encode-stacked-alpha.ts <输入 webm 目录> <输出目录> [编码器]
+ *   编码器：hvc1（默认，libx265，Safari/Chromium 都认）| av01（libaom-av1，体积更小）
+ *
+ * 输出：<stem>.mp4，与输入 webm 同名主键，内容为 vstack 堆叠（上半颜色 + 下半 alpha）。
+ * 产物放置：<已安装预设目录>/stacked/<stem>.mp4，由 preset_pet.rs 的 stacked manifest
+ * 自动发现（见 src-tauri/src/bridge/preset_pet.rs get_preset_pet_assets）。
+ *
+ * 转码管线参考 jakearchibald "Video with alpha transparency on the web"（2024-08）：
+ *   https://jakearchibald.com/2024/video-with-transparency/
+ *   [0:v]format=pix_fmts=yuva444p[main];[main]split[main][alpha];
+ *   [alpha]alphaextract[alpha];[main][alpha]vstack
+ *
+ * 说明：
+ * - 输入端解码必须显式 -c:v libvpx-vp9（libvpx 解码才保留 VP9 alpha，ffmpeg 自动选
+ *   解码器会丢 alpha 导致黑底——与 source/dsh-pet/scripts 各脚本同一纪律）;
+ * - 输出端是普通 yuv420p（无 alpha 平面），因此任何支持 hvc1/av01 的编码器均可替代
+ *   ffmpeg（如 macOS AVAssetWriter、GStreamer vah265enc 等）；不想引入 ffmpeg 时，
+ *   用系统自带的解码/编码库实现同一条 filter 链即可，本脚本仅作参考实现;
+ * - 断点续跑：输出比源新则跳过。
+ */
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
+const FFMPEG = process.env.FFMPEG_BIN || 'ffmpeg'
+
+const [, , inputDir, outputDir, encoderArg = 'hvc1'] = process.argv
+if (!inputDir || !outputDir) {
+  console.error('usage: pnpm tsx scripts/encode-stacked-alpha.ts <input webm dir> <output dir> [hvc1|av01]')
+  process.exit(1)
+}
+const encoder = encoderArg === 'av01' ? 'av01' : 'hvc1'
+
+const filter = '[0:v]format=pix_fmts=yuva444p[main];[main]split[main][alpha];[alpha]alphaextract[alpha];[main][alpha]vstack'
+const args = encoder === 'av01'
+  ? ['-c:v', 'libaom-av1', '-crf', '45', '-cpu-used', '3', '-b:v', '0']
+  : ['-c:v', 'libx265', '-tag:v', 'hvc1', '-preset', 'medium', '-crf', '30', '-b:v', '0']
+
+mkdirSync(outputDir, { recursive: true })
+const files = readdirSync(inputDir).filter(file => file.endsWith('.webm')).sort()
+if (files.length === 0) {
+  console.error(`no .webm files in ${inputDir}`)
+  process.exit(1)
+}
+
+let converted = 0
+let skipped = 0
+for (const file of files) {
+  const src = join(inputDir, file)
+  const stem = file.slice(0, -'.webm'.length)
+  const dst = join(outputDir, `${stem}.mp4`)
+  if (existsNewer(dst, src)) {
+    skipped++
+    continue
+  }
+  console.log(`[${converted + skipped + 1}/${files.length}] ${file} → ${encoder}`)
+  const result = spawnSync(FFMPEG, [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-y',
+    '-c:v',
+    'libvpx-vp9',
+    '-i',
+    src,
+    '-an',
+    '-filter_complex',
+    filter,
+    '-pix_fmt',
+    'yuv420p',
+    ...args,
+    dst,
+  ], { stdio: 'inherit' })
+  if (result.status !== 0) {
+    console.error(`encode failed: ${file} (ffmpeg exit ${result.status ?? 'signal'})`)
+    process.exit(1)
+  }
+  converted++
+}
+console.log(`done: converted=${converted} skipped=${skipped} total=${files.length} out=${outputDir}`)
+
+function existsNewer(dst: string, src: string): boolean {
+  try {
+    return statSync(dst).mtimeMs > statSync(src).mtimeMs
+  }
+  catch {
+    return false
+  }
+}

--- a/src-tauri/src/bridge/preset_pet.rs
+++ b/src-tauri/src/bridge/preset_pet.rs
@@ -904,10 +904,18 @@ const PRESET_ASSET_ORIGIN: &str = "http://dsh-pet.localhost";
 #[cfg(not(target_os = "windows"))]
 const PRESET_ASSET_ORIGIN: &str = "dsh-pet://localhost";
 
-/// 预设宠物媒体 URL manifest（name → URL；name 为 webm 文件主名，URL 经 dsh-pet 协议按需流式提供）。
+/// 预设宠物媒体 URL manifest（name → URL；name 为媒体文件主名，URL 经 dsh-pet 协议按需流式提供）。
+///
+/// 两组映射：
+/// - `assets`：VP9-alpha webm（Chromium/WebView2 原生支持 alpha，Windows/Linux 走此组）+ preview gif 兜底；
+/// - `stacked`：stacked-alpha 堆叠视频（普通不透明编码的 mp4，上半颜色下半 alpha 亮度，由前端 WebGL
+///   shader 合成透明）——macOS WKWebView 不认 VP9-alpha（渲染黑底，issue #434），需要此组资产。
+///   同一动画名在两个映射中的 URL 指向不同子目录（webm/ 与 stacked/），前端按平台选择。
 #[derive(Debug, Clone, Serialize)]
 pub struct PresetPetAssets {
     pub assets: BTreeMap<String, String>,
+    #[serde(default)]
+    pub stacked: BTreeMap<String, String>,
 }
 
 /// 只对非保留字符做百分号编码（UTF-8 逐字节），其余原样保留：视频文件名含中文时
@@ -948,10 +956,10 @@ fn percent_decode_segment(value: &str) -> Result<String, String> {
         .map_err(|_| "PET_PRESET_ASSET_PATH_INVALID: asset name is not valid UTF-8".to_string())
 }
 
-/// 已安装预设宠物目录下的受控相对路径（webm/ 或 preview/ 单层子目录内）。
+/// 已安装预设宠物目录下的受控相对路径（webm/、preview/ 或 stacked/ 单层子目录内）。
 fn resolve_preset_asset(app: &AppHandle, id: &str, subdir: &str, name: &str) -> Result<PathBuf, String> {
-    if !matches!(subdir, "webm" | "preview") {
-        return Err("PET_PRESET_ASSET_PATH_INVALID: subdir must be webm or preview".to_string());
+    if !matches!(subdir, "webm" | "preview" | "stacked") {
+        return Err("PET_PRESET_ASSET_PATH_INVALID: subdir must be webm, preview or stacked".to_string());
     }
     let root = preset_pets_root(app);
     let dir = installed_dir(&root, id);
@@ -1038,9 +1046,9 @@ pub fn preset_pet_asset_response(
         return protocol_error(StatusCode::FORBIDDEN, "PET_PRESET_ASSET_PATH_INVALID: asset name is not a safe relative path");
     };
     if relative.components().count() != 1
-        || !matches!(name.rsplit_once('.').map(|(_, ext)| ext), Some("webm" | "gif"))
+        || !matches!(name.rsplit_once('.').map(|(_, ext)| ext), Some("webm" | "mp4" | "gif"))
     {
-        return protocol_error(StatusCode::FORBIDDEN, "PET_PRESET_ASSET_PATH_INVALID: asset must be a single webm/gif file");
+        return protocol_error(StatusCode::FORBIDDEN, "PET_PRESET_ASSET_PATH_INVALID: asset must be a single webm/mp4/gif file");
     }
     let path = match resolve_preset_asset(app, id, subdir, &name) {
         Ok(path) => path,
@@ -1052,7 +1060,11 @@ pub fn preset_pet_asset_response(
     let Ok(length) = file.metadata().map(|metadata| metadata.len()) else {
         return protocol_error(StatusCode::NOT_FOUND, "PET_PRESET_ASSET_READ_FAILED: asset metadata unavailable");
     };
-    let mime = if name.ends_with(".webm") { "video/webm" } else { "image/gif" };
+    let mime = match name.rsplit_once('.').map(|(_, ext)| ext) {
+        Some("webm") => "video/webm",
+        Some("mp4") => "video/mp4",
+        _ => "image/gif",
+    };
     let base = Response::builder()
         .header("Content-Type", mime)
         .header("Accept-Ranges", "bytes");
@@ -1109,8 +1121,8 @@ fn parse_single_byte_range(value: &str, length: u64) -> Option<(u64, u64)> {
     (end >= start).then_some((start, end))
 }
 
-/// 列出已安装预设宠物的全部媒体（webm 动画 + preview 首张 gif 兜底图）。
-/// 池条目（config.jsonc 里的动画名）即 webm 文件名主名，与 dsh-pet 协议一致。
+/// 列出已安装预设宠物的全部媒体（webm 动画 + stacked-alpha 堆叠视频 + preview 首张 gif 兜底图）。
+/// 池条目（config.jsonc 里的动画名）即媒体文件主名，与 dsh-pet 协议一致。
 #[tauri::command]
 pub fn get_preset_pet_assets(app: AppHandle, id: String) -> Result<PresetPetAssets, String> {
     let id = id.trim();
@@ -1145,6 +1157,33 @@ pub fn get_preset_pet_assets(app: AppHandle, id: String) -> Result<PresetPetAsse
             assets.insert(stem, url);
         }
     }
+    // stacked-alpha 堆叠视频（mp4）：与 webm 同名主键、独立 stacked/ 子目录，按平台选源。
+    // 资产缺失时该组为空，前端天然回落到 webm（Chromium）或无动画（macOS 无 stacked 资产时保持透明，
+    // 不出现黑底——见 issue #434）。文件名依 vstack 后是单视频流，无需区分编码。
+    let stacked_dir = dir.join("stacked");
+    let mut stacked = BTreeMap::new();
+    if stacked_dir.is_dir() {
+        let mut entries = fs::read_dir(&stacked_dir)
+            .map_err(|error| format!("PET_PRESET_ASSETS_READ_FAILED: failed to list {}: {error}", stacked_dir.display()))?;
+        let mut files = Vec::new();
+        while let Some(entry) = entries.next() {
+            let entry = entry.map_err(|error| format!("PET_PRESET_ASSETS_READ_FAILED: {error}"))?;
+            let file_name = entry.file_name();
+            let Some(name) = file_name.to_str() else { continue };
+            if name.ends_with(".mp4") || name.ends_with(".webm") {
+                files.push(name.to_string());
+            }
+        }
+        files.sort();
+        for file in files {
+            let stem = file.rsplit_once('.').map(|(stem, _)| stem).unwrap_or(&file).to_string();
+            let url = format!(
+                "{PRESET_ASSET_ORIGIN}/{id}/stacked/{}",
+                percent_encode_segment(&file)
+            );
+            stacked.insert(stem, url);
+        }
+    }
     // 兜底图：preview 目录第一张 gif（按文件名排序，与 dsh-pet preview 语义一致）。
     let preview_dir = dir.join("preview");
     if preview_dir.is_dir() {
@@ -1168,7 +1207,7 @@ pub fn get_preset_pet_assets(app: AppHandle, id: String) -> Result<PresetPetAsse
             assets.insert("fallback".to_string(), url);
         }
     }
-    Ok(PresetPetAssets { assets })
+    Ok(PresetPetAssets { assets, stacked })
 }
 
 /// 统一预设配置校验错误前缀。

--- a/src/pet/components/pet.tsx
+++ b/src/pet/components/pet.tsx
@@ -5,11 +5,12 @@ import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window'
 import { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
-import { If } from 'react-if-lite'
+import { Else, If, Then } from 'react-if-lite'
 import { PET_STATUSES } from '../hooks/use-pet'
 import {
   fallbackPresetName,
   isLoopingAnimation,
+  isStackedAlphaPreferred,
   pick,
   pickCategoryAction,
   poolEntryToStatus,
@@ -17,8 +18,18 @@ import {
   rollKind,
   spriteStatusFallback,
 } from '../pet-config'
+// stacked-alpha-video 自定义元素（副作用注册 <stacked-alpha-video> + HTMLElementTagNameMap）；
+// 类型声明见 src/pet/stacked-alpha-video.d.ts。
+import 'stacked-alpha-video'
 
 const PET_BASE_WIDTH = 220
+/**
+ * 当前渲染引擎是否不用 VP9-alpha WebM（WKWebView/WebKitGTK）→ 预设宠物改用
+ * stacked-alpha 堆叠视频（上半颜色 + 下半 alpha，WebGL shader 合成透明，见
+ * src/pet/stacked-alpha-video.d.ts 与 issue #434）。UA 判定与 pet-config
+ * isStackedAlphaPreferred 保持一致；窗口引擎进程内不变，作模块级常量。
+ */
+const STACKED_ALPHA_PREFERRED = isStackedAlphaPreferred(globalThis.navigator?.userAgent ?? '')
 /** 已安装预设被清理/未安装时的提示文案：桌宠窗口无 i18n 基础设施（气泡文案同样硬编码），按窗口语言就近显示。 */
 const PRESET_MISSING_HINT = (document.documentElement.lang || navigator.language || 'zh-CN').toLowerCase().startsWith('zh')
   ? '预设宠物未安装，请在设置中下载'
@@ -107,12 +118,14 @@ export function Pet(props: PetProps) {
   const adHocRef = useRef(adHoc)
   adHocRef.current = adHoc
   const adHocSeqRef = useRef(0)
-  // 预设宠物资源（config.jsonc + webm manifest）：按宠物 id 一起拉取并整体更新，
+  // 预设宠物资源（config.jsonc + webm/stacked manifest）：按宠物 id 一起拉取并整体更新，
   // 避免切换宠物时残留上一个宠物的动画池/URL（旧数据在 fetch 完成前不生效）。
   const [petResources, setPetResources] = useState<{
     pet: string
     config: PetConfig | null
     assets: Record<string, string>
+    /** stacked-alpha 堆叠视频 manifest（name → stacked/ 子目录 URL）；WebKit 渲染引擎优先取用。 */
+    stacked: Record<string, string>
     /** 预设资源拉取失败的错误信息（如 PET_PRESET_NOT_INSTALLED）；null = 成功。 */
     error: string | null
   } | null>(null)
@@ -135,11 +148,23 @@ export function Pet(props: PetProps) {
   const isPreset = !activePet.includes(':')
   // 预设宠物资源按当前激活宠物生效：切换宠物时旧资源保持到新 fetch 完成，避免闪烁。
   // 统一 memo 成稳定的 config/assets 引用，避免每次渲染产生新对象导致视频 effect 重跑。
+  // assets 为「当前引擎有效资产表」：WebKit（STACKED_ALPHA_PREFERRED）且安装含 stacked
+  // 清单时 = stacked 覆盖视图（透明播放），否则 = webm 视图。fallback 兜底图（gif）两
+  // 视图都保留；WebKit 下缺失 stacked 版本的动画名在合成表里不存在 → resolvePresetName
+  // 自然返回 null/降级，绝不在 WebKit 下播放黑底 webm（issue #434）。
   const { config, assets, error } = useMemo(() => {
     const preset = petResources !== null && petResources.pet === activePet ? petResources : null
+    const webmAssets = preset?.assets ?? {}
+    const stackedAssets = preset?.stacked ?? {}
+    const assets = STACKED_ALPHA_PREFERRED && Object.keys(stackedAssets).length > 0
+      ? {
+          ...stackedAssets,
+          ...(webmAssets.fallback !== undefined ? { fallback: webmAssets.fallback } : {}),
+        }
+      : webmAssets
     return {
       config: preset?.config ?? null,
-      assets: preset?.assets ?? {},
+      assets,
       error: preset?.error ?? null,
     }
   }, [activePet, petResources])
@@ -226,16 +251,16 @@ export function Pet(props: PetProps) {
         loadError ??= String(error)
         return null
       }),
-      invoke<{ assets?: Record<string, string> }>('get_preset_pet_assets', { id: activePet }).catch((error) => {
+      invoke<{ assets?: Record<string, string>, stacked?: Record<string, string> }>('get_preset_pet_assets', { id: activePet }).catch((error) => {
         console.warn('[pet] PET_PRESET_ASSETS_LOAD_FAILED:', error)
         loadError ??= String(error)
-        return { assets: {} }
+        return { assets: {}, stacked: {} }
       }),
     ]).then(([config, value]) => {
       if (disposed)
         return
       // 一起提交，避免 config 与 assets 不同步导致短暂按旧池解析。
-      setPetResources({ pet: activePet, config, assets: value.assets ?? {}, error: loadError })
+      setPetResources({ pet: activePet, config, assets: value.assets ?? {}, stacked: value.stacked ?? {}, error: loadError })
     })
     return () => {
       disposed = true
@@ -526,25 +551,60 @@ export function Pet(props: PetProps) {
           .dsh-pet-hit 一致），事件从命中区冒泡到 app.tsx 的 dragRef 壳触发拖拽。 */}
       <div className="pointer-events-none relative h-[calc(var(--pet-width)*var(--pet-aspect))] w-[var(--pet-width)] select-none">
         <If cond={isPreset}>
-          {/* 双 video 缓冲：前台 opacity-100 淡入、后台 opacity-0 淡出，
-              切换经 loadeddata 就绪后交换（见开关 effect），无空窗/黑帧闪跳。
-              视频均 pointer-events-none，避免截获命中区外的点击。 */}
-          <video
-            ref={videoARef}
-            className={`pointer-events-none absolute inset-0 h-full w-full object-contain transition-opacity duration-200 ${frontIdx === 0 ? 'opacity-100' : 'opacity-0'}`}
-            muted
-            playsInline
-            preload="auto"
-            onError={() => setFailed(true)}
-          />
-          <video
-            ref={videoBRef}
-            className={`pointer-events-none absolute inset-0 h-full w-full object-contain transition-opacity duration-200 ${frontIdx === 1 ? 'opacity-100' : 'opacity-0'}`}
-            muted
-            playsInline
-            preload="auto"
-            onError={() => setFailed(true)}
-          />
+          <If cond={STACKED_ALPHA_PREFERRED}>
+            {/* WebKit（macOS WKWebView / Linux WebKitGTK）不支持 VP9-alpha webm（黑底，
+                issue #434）：改用 stacked-alpha 堆叠视频。组件内部是 shadow canvas +
+                无 slot 的 light <video>（只解码不渲染），我们把 opacity 过渡放在宿主
+                上（canvas 随宿主淡入淡出）；<video> 仍是双缓冲 effect 的直接操作对象
+                （src/loop/onended/load/loadeddata/play/pause 全部不变）。 */}
+            <Then>
+              <stacked-alpha-video
+                className={`pointer-events-none absolute inset-0 h-full w-full object-contain transition-opacity duration-200 ${frontIdx === 0 ? 'opacity-100' : 'opacity-0'}`}
+              >
+                <video
+                  ref={videoARef}
+                  className="pointer-events-none absolute inset-0 h-full w-full object-contain"
+                  muted
+                  playsInline
+                  preload="auto"
+                  onError={() => setFailed(true)}
+                />
+              </stacked-alpha-video>
+              <stacked-alpha-video
+                className={`pointer-events-none absolute inset-0 h-full w-full object-contain transition-opacity duration-200 ${frontIdx === 1 ? 'opacity-100' : 'opacity-0'}`}
+              >
+                <video
+                  ref={videoBRef}
+                  className="pointer-events-none absolute inset-0 h-full w-full object-contain"
+                  muted
+                  playsInline
+                  preload="auto"
+                  onError={() => setFailed(true)}
+                />
+              </stacked-alpha-video>
+            </Then>
+            <Else>
+              {/* 双 video 缓冲（Chromium/WebView2，VP9-alpha webm 原生支持）：前台
+                   opacity-100 淡入、后台 opacity-0 淡出，切换经 loadeddata 就绪后交换
+                   （见开关 effect），无空窗/黑帧闪跳。视频均 pointer-events-none。 */}
+              <video
+                ref={videoARef}
+                className={`pointer-events-none absolute inset-0 h-full w-full object-contain transition-opacity duration-200 ${frontIdx === 0 ? 'opacity-100' : 'opacity-0'}`}
+                muted
+                playsInline
+                preload="auto"
+                onError={() => setFailed(true)}
+              />
+              <video
+                ref={videoBRef}
+                className={`pointer-events-none absolute inset-0 h-full w-full object-contain transition-opacity duration-200 ${frontIdx === 1 ? 'opacity-100' : 'opacity-0'}`}
+                muted
+                playsInline
+                preload="auto"
+                onError={() => setFailed(true)}
+              />
+            </Else>
+          </If>
         </If>
         <If cond={!isPreset && hasCustomAsset}>
           <div

--- a/src/pet/pet-config.test.ts
+++ b/src/pet/pet-config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   fallbackPresetName,
   isLoopingAnimation,
+  isStackedAlphaPreferred,
   pick,
   pickCategoryAction,
   pickWeightedCategory,
@@ -189,6 +190,27 @@ describe('resolvePresetName', () => {
   it('returns null when the pool entry is not backed by an asset', () => {
     expect(resolvePresetName('idle', { ...pools, idlePool: ['不存在.webm'] }, assets)).toBeNull()
     expect(resolvePresetName('idle', { ...pools, idlePool: [] }, assets)).toBeNull()
+  })
+})
+
+describe('isStackedAlphaPreferred', () => {
+  it('返回 true（WebKit 系：macOS WKWebView / Linux WebKitGTK）', () => {
+    // macOS WKWebView（Tauri macOS 桌宠窗口）
+    expect(isStackedAlphaPreferred('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15')).toBe(true)
+    // 旧版 macOS WKWebView UA
+    expect(isStackedAlphaPreferred('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15')).toBe(true)
+  })
+
+  it('返回 false（Chromium 系：Windows WebView2 / Electron）', () => {
+    // Windows WebView2（Tauri Windows 桌宠窗口）
+    expect(isStackedAlphaPreferred('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.0.0')).toBe(false)
+    // Electron（dsh-pet 上游桌面模式）
+    expect(isStackedAlphaPreferred('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) dsh-pet/1.0.0 Chrome/128.0.0.0 Safari/537.36')).toBe(false)
+  })
+
+  it('非 WebKit UA 返回 false', () => {
+    expect(isStackedAlphaPreferred('')).toBe(false)
+    expect(isStackedAlphaPreferred('curl/8.0.1')).toBe(false)
   })
 })
 

--- a/src/pet/pet-config.ts
+++ b/src/pet/pet-config.ts
@@ -185,6 +185,20 @@ export const PRESET_SESSION_ANIMATIONS: Record<string, string> = {
 }
 
 /**
+ * 是否应优先使用 stacked-alpha（堆叠透明视频）资产。
+ *
+ * 判定依据是渲染引擎而非操作系统：WKWebView/WebKitGTK（macOS Tauri 桌宠窗口、
+ * Linux WebKitGTK）不支持 VP9-alpha 透明 WebM（解码丢 alpha 平面 → 黑底，见
+ * issue #434）；Chromium（Windows WebView2）原生支持 VP9-alpha，走 webm 即可。
+ * UA 无 Chrome/Chromium/Edg 标记的 AppleWebKit 即 WebKit 系（Safari 类 UA）。
+ *
+ * 纯函数，可单测；调用方传 navigator.userAgent。
+ */
+export function isStackedAlphaPreferred(ua: string): boolean {
+  return /AppleWebKit/.test(ua) && !/Chrome|Chromium|CriOS|Edg\//i.test(ua)
+}
+
+/**
  * 预设宠物：把播放状态解析为实际动画名（webm 文件名主名，如 待机呼吸休闲）。
  * - 活动名本身就是可播放动画名（adHoc 池条目 / 会话状态映射名）时直接命中资产；
  * - 会话状态（waiting/running/review/failed/bubble）经 PRESET_SESSION_ANIMATIONS

--- a/src/pet/stacked-alpha-video.d.ts
+++ b/src/pet/stacked-alpha-video.d.ts
@@ -1,0 +1,24 @@
+import type * as React from 'react'
+
+/**
+ * stacked-alpha-video 自定义元素（jakearchibald/stacked-alpha-video）的 React JSX 声明。
+ *
+ * 库自身声明了 `HTMLElementTagNameMap['stacked-alpha-video']`（全局 DOM API 层面），
+ * React 的 JSX.IntrinsicElements 需要单独增强：桌宠窗口（WebKit，无 VP9-alpha 支持）
+ * 用它把「上半颜色 + 下半 alpha 亮度」的堆叠视频合成为带透明通道的画布，见
+ * src/pet/components/pet.tsx 的 stacked-alpha 渲染分支与 issue #434。
+ *
+ * `premultipliedalpha`：仅当源视频使用预乘 alpha（半透明边缘偏暗）时设 true；
+ * dsh-pet 素材链（yuva420p / yuva444p 直通编码）默认非预乘，通常不需要。
+ */
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'stacked-alpha-video': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        premultipliedalpha?: string
+      }
+    }
+  }
+}
+
+export {}


### PR DESCRIPTION
## 背景

macOS 桌宠窗口显示黑色背景（issue #434）。根因：macOS Tauri 桌宠窗口用 WKWebView 渲染，而 WKWebView 不支持 VP9-alpha 透明 WebM——解码时 alpha 平面被丢弃，视频按不透明渲染，透明区呈黑色且无 error 事件。窗口/CSS/WebView 透明链路本身正常（wry 0.55.1 + tao 0.35.3 已正确设置 transparent）。

## 方案：stacked-alpha 堆叠视频（参考 BongoCat canvas 渲染方向 + stacked-alpha-video 库）

- 上半像素 = 颜色，下半像素 = alpha 亮度，前端 WebGL shader 合成透明
- 产物是**普通不透明编码**（hvc1/av01 均可），不需要 HEVC-with-Alpha 专属 API
- macOS（WKWebView）原生解码无 alpha 问题 → 透明恢复

## 改动

### Rust 协议（src-tauri/src/bridge/preset_pet.rs）
- `PresetPetAssets` 新增 `stacked` manifest（`stacked/` 子目录，mp4）
- 子目录白名单 `webm|preview|stacked`，扩展名白名单加 `mp4`，mime 支持 `video/mp4`
- `get_preset_pet_assets` 扫描 `stacked/*.mp4`，与 webm 同名主键

### 前端（src/pet）
- `pet.tsx`：WebKit 渲染引擎（`isStackedAlphaPreferred` UA 判定）走 `<stacked-alpha-video>` 渲染分支；优先 stacked 资产、缺失时降级 webm/兜底图——绝不在 WebKit 下播放黑底 webm
- 双 video 缓冲 effect 逻辑不变（video 作为 light child 只解码）
- `pet-config.ts`：新增纯函数 `isStackedAlphaPreferred(ua)`（WebKit 系 + 无 Chrome/Chromium/Edg 标记）+ 3 个单测
- 新增 `stacked-alpha-video.d.ts`：React JSX 类型声明（库自带 HTMLElementTagNameMap，React 19 JSX namespace 需单独增强）

### 转码脚本（scripts/encode-stacked-alpha.ts）
把 VP9-alpha webm 批量转码为 stacked mp4（hvc1 默认 / av01 可选），断点续跑。参考 jakearchibald stacked-alpha 文章与上游 source/dsh-pet 的编码流水线。

## 验证

- `pnpm typecheck` ✅
- `pnpm eslint`（改动文件）✅
- `pnpm vitest run`：38 files / 295 tests ✅（含 pet-config 23 tests，新 isStackedAlphaPreferred 3 个）
- `cargo check` ✅、`cargo test`：491 passed ✅

## 备注

- 转码脚本本机未实际执行（无 ffmpeg 环境），仅类型 + lint 验证；上游素材需用其产出 `stacked/` 资产后 macOS 端才真正显示动画
- 无 stacked 资产的预设宠物在 WebKit 下保持透明（不黑底），等待预设仓库/发布流程产出 stacked 资产

Refs #434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stacked-alpha video assets for preset pets.
  * WebKit-based environments now use stacked-alpha videos when available, with WebM fallback support.
  * Added support for serving and discovering stacked video assets.
  * Added a utility to convert VP9-alpha WebM files into stacked-alpha video formats.

* **Tests**
  * Added coverage for engine detection and stacked-alpha asset preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->