### PR TITLE
fix(ui): 修复右侧栏收起按钮与通知关闭交互

### DIFF
--- a/src-tauri/src/desktop/style.rs
+++ b/src-tauri/src/desktop/style.rs
@@ -5,7 +5,7 @@
 //! 其余平台 `initialization_script_for_all_frames`），因此 iframe 每次重新加载都会重建。
 //!
 //! 本脚本只负责把一段内置 CSS 以 `<style>` 元素注入 iframe 文档（幂等：按 id 去重）。
-//! 具体样式写在下方的 `IFRAME_CSS` 模板字符串里（当前是占位，按需填写/替换即可）。
+//! 具体样式写在下方的 `css` 模板字符串里，兼容内嵌插件的面板控件。
 
 /// 注入 `<style>` 的脚本（带 `__dsh_iframe_styles__` 幂等守卫，重复注入安全）。
 /// 样式直接写在 `css` 模板字符串里，改这里即可。
@@ -15,10 +15,19 @@ pub(crate) const IFRAME_STYLES_JS: &str = r#"(function () {
 
   var STYLE_ID = 'dsh-desktop-injected-styles';
 
-  // ══ 在这里按需填写注入到 dsh iframe 页面的自定义样式``` ════
+  // 优先使用插件的稳定标记，旧版插件保留类名兼容。
+  // 页面按 aria-label 隐藏左侧收起按钮的规则会误伤右侧面板，这里只恢复面板开关。
   var css = `
-    .nArs4W_toggleCluster {top:6px !important; right: 6px !important; gap: 2px !important;}
-    .nArs4W_toggleButton {border-radius: 8px !important;}
+    [data-dsh-toggle-cluster], .nArs4W_toggleCluster {
+      top: 6px !important;
+      right: 6px !important;
+      gap: 2px !important;
+    }
+    [data-dsh-toggle-cluster] button[aria-label], .nArs4W_toggleCluster button[aria-label] {
+      display: flex !important;
+      border-radius: 8px !important;
+      flex-shrink: 0;
+    }
   `;
 
   function apply() {

--- a/src/components/toast-provider.tsx
+++ b/src/components/toast-provider.tsx
@@ -12,8 +12,8 @@ interface ToastProviderProps {
 }
 
 /**
- * 应用共用的 HeroUI queue/provider。桌宠窗口仅通过 hideCloseButton 使用
- * 自定义渲染分支，仍复用这里的 queues 与 src/utils/toast.ts API。
+ * 应用共用的 HeroUI queue/provider。桌宠窗口通过 custom 渲染精简气泡，
+ * 主窗口保留 HeroUI 默认的操作和关闭按钮。
  */
 export function ToastProvider(props: ToastProviderProps) {
   const [updates, setUpdates] = useState(() => new Map<string, ToastUpdateEvent['options']>())
@@ -35,6 +35,7 @@ export function ToastProvider(props: ToastProviderProps) {
           key={placement}
           placement={placement}
           queue={activeQueues[placement]}
+          className="[&_[data-frontmost=true]_[data-slot=toast-close]]:pointer-events-auto [&_[data-frontmost=true]_[data-slot=toast-close]]:opacity-100"
         >
           {props.custom
             ? ({ toast: item }) => {

--- a/src/layout/components/desktop-updater.tsx
+++ b/src/layout/components/desktop-updater.tsx
@@ -49,7 +49,7 @@ export function DesktopUpdater() {
         },
         variant: 'tertiary',
       },
-      timeout: 0,
+      timeout: 8000,
       placement: 'bottom end',
       description: t('update.desktop_new'),
       variant: 'default',

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -80,9 +80,9 @@ export const toast = Object.assign(
     const key = activeQueues[placement].add(content, {
       timeout,
       onClose: () => {
-        // 自动超时 / 用户关闭 / 外部 close 都会走到这里（HeroUI 包了一层 rAF 异步）
+        // 自动超时 / 用户关闭 / 外部 close 都会走到这里；延后业务回调，避免渲染中更新组件。
         forgetKey(key)
-        onClose?.()
+        queueMicrotask(() => onClose?.())
       },
     })
     toastContents.set(key, content)

--- a/test/toast.test.ts
+++ b/test/toast.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { activeQueues as queues, toast } from '../src/utils/toast'
+
+afterEach(() => {
+  toast.clear()
+  vi.useRealTimers()
+})
+
+describe('toast lifecycle', () => {
+  it('keeps persistent notifications open until explicitly closed and runs their callback', async () => {
+    vi.useFakeTimers()
+    const onClose = vi.fn()
+    const key = toast('Update available', { timeout: 0, onClose })
+    const queue = queues['bottom end']
+    const notification = queue.visibleToasts.find(item => item.key === key)!
+
+    expect(notification.timer).toBeUndefined()
+    expect(notification.content).not.toHaveProperty('onClose')
+    expect(notification.content).not.toHaveProperty('timeout')
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(queue.visibleToasts.some(item => item.key === key)).toBe(true)
+
+    // HeroUI 的关闭按钮直接关闭底层队列，也必须触发业务层的忽略版本回调。
+    queue.close(key)
+    expect(onClose).not.toHaveBeenCalled()
+    await Promise.resolve()
+    expect(queue.visibleToasts.some(item => item.key === key)).toBe(false)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('expires a notification using its requested timeout', async () => {
+    vi.useFakeTimers()
+    const onClose = vi.fn()
+    const key = toast('Update available', { timeout: 8000, onClose })
+    const queue = queues['bottom end']
+    const notification = queue.visibleToasts.find(item => item.key === key)!
+
+    // 组件挂载时会启动计时，这里模拟显示后开始倒计时。
+    notification.timer!.resume()
+    await vi.advanceTimersByTimeAsync(7999)
+    expect(queue.visibleToasts.some(item => item.key === key)).toBe(true)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(queue.visibleToasts.some(item => item.key === key)).toBe(false)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('closes only the selected notification in its own placement', async () => {
+    const onClose = vi.fn()
+    const key = toast('Download complete', { placement: 'top', onClose })
+    const otherKey = toast('Update available', { timeout: 0 })
+
+    toast.close(key)
+    await Promise.resolve()
+
+    expect(queues.top.visibleToasts.some(item => item.key === key)).toBe(false)
+    expect(queues['bottom end'].visibleToasts.some(item => item.key === otherKey)).toBe(true)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/test/toast.test.ts
+++ b/test/toast.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { activeQueues as queues, toast } from '../src/utils/toast'
 
+// @hairy/react-lib 会经 react-use（CJS）引入 useMount，Node 互操作下无法静态解析命名导出；
+// toast 模块只用 emitter.emit，测试统一 mock 掉（与 runtime-exit-store / preinstall-uncheck 一致）。
+vi.mock('@hairy/react-lib', () => ({ emitter: { emit: vi.fn() } }))
+
 afterEach(() => {
   toast.clear()
   vi.useRealTimers()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitest/config'
 
 /**
- * 根测试配置：只跑内置插件（packages/**）的测试，限制并发 worker 数与放宽超时。
+ * 根测试配置：运行内置插件（packages/**）及 toast 生命周期回归测试，限制并发 worker 数与放宽超时。
  *
  * 仓库根还 vendored 了 dsh 核心源码（src/、source/、test/），其测试依赖 dsh 核心
  * 的 `@/` paths 解析（在插件 workspace 的 vitest 下不可用），故 exclude 出本范围。
@@ -12,7 +12,7 @@ import { defineConfig } from 'vitest/config'
  */
 export default defineConfig({
   test: {
-    include: ['packages/**/*.{test,spec}.{ts,tsx,js,mjs,cjs}'],
+    include: ['packages/**/*.{test,spec}.{ts,tsx,js,mjs,cjs}', 'test/toast.test.ts'],
     maxWorkers: 4,
     testTimeout: 30_000,
     hookTimeout: 30_000,


### PR DESCRIPTION
展开右侧 Files/Tasks 面板后，隐藏左侧栏按钮的全局 aria-label 样式会误伤右侧收起按钮；更新通知常驻且关闭入口不明显，会遮挡后续操作。

修复内容：
- 通过面板的稳定 data 属性限定样式覆盖，并兼容旧版插件类名，恢复右侧面板收起按钮；右侧栏开关与底部交互式 Terminal 开关保持独立。
- 让主窗口最前方通知的关闭按钮始终可见、可点击，保留 HeroUI 默认操作按钮及桌宠的精简通知渲染。
- 桌面更新通知在显示 8 秒后自动关闭，沿用现有关闭回调记录已忽略版本。
- 通知关闭时立即清理队列映射，再通过微任务执行业务回调，避免渲染过程中更新其他组件。
- 将通知生命周期回归测试纳入默认 Vitest 配置，覆盖常驻通知、自动超时、跨位置关闭及回调异步执行。

验证（本 PR 基于最新 main）：
- `pnpm build`、`pnpm typecheck` 通过。
- `pnpm exec vitest run`：19 个测试文件、116 项测试通过。
- 修改的 TS/TSX 文件及测试配置通过 ESLint；`git diff --check` 通过。
- `cargo check --locked`、`cargo test --locked` 通过，483 项 Rust 测试通过。
- macOS arm64 安装验证已在对应的 0.10.7 本地回移版本完成：DMG 完整性与签名校验、安装启动、右侧面板反复开合、底部 Terminal 命令输入输出、通知关闭。该安装验证不代表本 PR 的 0.11.0 基线安装包已重新验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop panel toggle styling and restored toggle button visibility.
  - Toast close buttons are now visible and interactive for the frontmost notification.
  - Desktop update notifications now dismiss automatically after 8 seconds.
  - Improved toast closing behavior, including callback handling and placement-specific removal.

- **Tests**
  - Added coverage for toast timeouts, persistence, callbacks, explicit closure, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->