### PR TITLE
fix(pet): guard click-through switch on never-shown pet window

### DIFF
--- a/src-tauri/src/bridge/pet.rs
+++ b/src-tauri/src/bridge/pet.rs
@@ -21,7 +21,7 @@ use std::io::{Cursor, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, WebviewWindow};
 use zip::ZipArchive;
 use futures_util::StreamExt;
 
@@ -393,6 +393,45 @@ pub fn hide_pet(app: AppHandle) -> Result<PetStatus, String> {
     let status = status_from_setting(&config::get_store_dat_setting(&app));
     emit_pet_status(&app, &status);
     Ok(status)
+}
+
+/// pet 窗口点击穿透开关；返回实际生效的穿透态，前端据此对齐本地 optimistic 状态。
+///
+/// # 为什么不直接用 `setIgnoreCursorEvents`（issue #437）
+///
+/// Linux 下 tao 处理 `CursorIgnoreEvents(true)` 时对 GtkWindow 的底层 GdkWindow
+/// 直接 `unwrap()`（tao 0.35.3 event_loop.rs:457，截至 0.37.0 上游仍未修复），
+/// 窗口从未显示（未 realize，GdkWindow 不存在）即 panic；panic 发生在 GTK
+/// 事件循环回调里无法回卷 → SIGABRT，整个桌面端崩溃。而本应用在 setup 阶段
+/// 总会预创建隐藏的 pet 窗口（`desktop::pet::init_pet_window`，全新安装默认
+/// 不启用桌宠则永远不 show），其 webview 仍会加载 pet.html 并在收到首个全局
+/// 鼠标事件时请求穿透——这正是 v0.11.0 初始化阶段必崩的路径。
+///
+/// 因此所有穿透切换必须经由此命令：窗口不可见（GTK 未 map，必然未 realize）
+/// 时吞掉 `true` 请求并返回未生效；`false`（恢复接收事件）在 tao 走无 unwrap
+/// 的分支，始终安全转发。GTK 窗口 hide 只 unmap 不 unrealize，首次 show 之后
+/// GdkWindow 持续存在，故「可见 ⇒ 转发安全」。
+#[tauri::command]
+pub fn set_pet_ignore_cursor_events(window: WebviewWindow, ignore: bool) -> Result<bool, String> {
+    if window.label() != pet_window::PET_WINDOW_LABEL {
+        return Err(
+            "PET_WINDOW_LABEL_MISMATCH: this command is restricted to the pet window".to_string(),
+        );
+    }
+    if ignore {
+        let visible = window
+            .is_visible()
+            .map_err(|error| format!("PET_WINDOW_STATE_FAILED: {error}"))?;
+        if !visible {
+            // 隐藏窗口的穿透无意义：吞掉并上报「未生效」，避免 tao 在未
+            // realize 窗口上的 unwrap panic（issue #437）。
+            return Ok(false);
+        }
+    }
+    window
+        .set_ignore_cursor_events(ignore)
+        .map_err(|error| format!("PET_CURSOR_IGNORE_FAILED: {error}"))?;
+    Ok(ignore)
 }
 
 /// 返回来源对应的真实目录；chat 直接使用 `$DSH_HOME/pets`，codex 直接使用

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -592,6 +592,7 @@ pub fn handler() -> impl Fn(Invoke<Wry>) -> bool + Send + Sync + 'static {
         crate::bridge::move_pet_window,
         crate::bridge::show_pet,
         crate::bridge::hide_pet,
+        crate::bridge::set_pet_ignore_cursor_events,
         crate::bridge::list_pets,
         crate::bridge::import_pet,
         crate::bridge::get_pet_asset,

--- a/src/pet/hooks/use-omit-ignore-cursor-events.ts
+++ b/src/pet/hooks/use-omit-ignore-cursor-events.ts
@@ -9,6 +9,12 @@ interface DeviceMousePosition {
   y: number
 }
 
+/** `pet://status` 事件载荷（Rust PetStatus，snake_case 字段）。 */
+interface RustPetStatus {
+  enabled?: boolean
+  visible?: boolean | null
+}
+
 /**
  * 根据元素的真实屏幕位置自动切换桌宠窗口的点击穿透。
  *
@@ -16,14 +22,20 @@ interface DeviceMousePosition {
  * 全局鼠标流获取设备像素坐标，再与元素的 DOMRect 命中区比较。调用方只需
  * 传入可交互元素的 ref，不需要管理启动监听、窗口移动、缩放或穿透状态。
  *
- * # 兼容性（issue #394）
+ * # 兼容性（issue #394、#437）
  *
- * 初始整体穿透**不**在挂载时急切调用 `setIgnoreCursorEvents(true)`：Linux /
- * Wayland 下窗口是异步 realize 的，挂载时 GDK 窗口实体可能尚未建立，tao
- * 0.35.3 收到 `CursorIgnoreEvents` 请求会走 `window.window().unwrap()` →
- * panic 崩掉整个事件循环。改为延后到首个 `device-mouse-move` 事件（此时窗口
- * 已 realize、事件循环健康）再按命中区计算应用，与 BongoCat 只在鼠标移动回调
- * 里才 `setIgnoreCursorEvents` 的做法一致。
+ * 穿透切换一律经由 Rust 命令 `set_pet_ignore_cursor_events` 而非直接调用
+ * `setIgnoreCursorEvents`：Linux / Wayland 下 tao 处理 `CursorIgnoreEvents(true)`
+ * 时对底层 GdkWindow 直接 `unwrap()`（tao 0.35.3 event_loop.rs:457，上游截至
+ * 0.37.0 未修复），窗口从未显示（未 realize）即 panic 崩掉整个桌面端。本应用
+ * 在 setup 阶段总会预创建隐藏的 pet 窗口（`desktop::pet::init_pet_window`），
+ * 全新安装默认不启用桌宠则窗口永远不 show，其 WebView 仍会收到首个全局鼠标
+ * 事件并请求穿透——挂载即崩（issue #437）。Rust 侧对不可见窗口吞掉 `true`
+ * 请求，前端再叠加一层：跟踪窗口可见性（`pet://status`），窗口隐藏时直接跳过
+ * 穿透请求，避免对禁用桌宠的默认安装逐次移动鼠标都产生无效 IPC。
+ *
+ * issue #394 的「延后到首个 device-mouse-move 再应用」仍然保留：避免挂载时
+ * 立刻与事件循环竞争，但真正防止 panic 的是上面的两层可见性保护。
  */
 export function useOmitIgnoreCursorEvents(elementRef: RefObject<HTMLElement | null>): void {
   useEffect(() => {
@@ -33,17 +45,43 @@ export function useOmitIgnoreCursorEvents(elementRef: RefObject<HTMLElement | nu
     // 时急切开启穿透（见函数上方的 #394 说明），穿透态由首个 device-mouse-move
     // 事件按命中区计算后应用。
     let isIgnored = false
+    // 窗口可见性未知（undefined）时放行请求，由 Rust 命令兜底；确认隐藏后跳过。
+    let windowVisible: boolean | undefined
+    // 递增的穿透请求序号：丢弃失序响应，防止旧请求的「实际生效态」覆盖新状态。
+    let ignoreRequestRevision = 0
     let windowPosition: { x: number, y: number } | undefined
     let geometryRevision = 0
     let unlistenMouseMove: (() => void) | undefined
     let unlistenMoved: (() => void) | undefined
     let unlistenResized: (() => void) | undefined
+    let unlistenStatus: (() => void) | undefined
 
     function setIgnoreCursorEvents(ignore: boolean): void {
       if (ignore === isIgnored)
         return
+      if (ignore && windowVisible === false)
+        return
+      const revision = ++ignoreRequestRevision
       isIgnored = ignore
-      void appWindow.setIgnoreCursorEvents(ignore).catch(() => {})
+      void invoke<boolean>('set_pet_ignore_cursor_events', { ignore }).then((applied) => {
+        if (!disposed && revision === ignoreRequestRevision)
+          isIgnored = applied
+      }).catch(() => {})
+    }
+
+    function handleVisibility(visible: boolean): void {
+      windowVisible = visible
+      if (visible)
+        return
+      // 窗口隐藏后穿透无意义：复位本地状态并同步关闭穿透（false 分支在
+      // Rust 侧始终安全转发），保证重新显示后由鼠标事件重新计算并应用，
+      // 也避免复用窗口时残留空输入区导致无法点击。
+      isIgnored = false
+      const revision = ++ignoreRequestRevision
+      void invoke<boolean>('set_pet_ignore_cursor_events', { ignore: false }).then((applied) => {
+        if (!disposed && revision === ignoreRequestRevision)
+          isIgnored = applied
+      }).catch(() => {})
     }
 
     async function refreshWindowPosition(): Promise<void> {
@@ -67,17 +105,25 @@ export function useOmitIgnoreCursorEvents(elementRef: RefObject<HTMLElement | nu
       return x >= left && x <= left + width && y >= top && y <= top + height
     }
 
-    // 初始整窗穿透延后应用（见上方 #394 说明）：这里只启动鼠标流与窗口几何追踪，
-    // 首个 device-mouse-move 事件到来后再按命中区决定穿透态，避免挂载即调用
-    // setIgnoreCursorEvents 触发 tao 在未 realize 窗口上的 unwrap（issue #394）。
+    // 初始整窗穿透延后应用（见上方 #394 说明）：这里只启动鼠标流、可见性与窗口
+    // 几何追踪，首个 device-mouse-move 事件到来后再按命中区决定穿透态。
     void invoke('start_pet_mouse_stream').catch(() => {})
     void refreshWindowPosition()
+    void appWindow.isVisible().then((visible) => {
+      if (!disposed)
+        handleVisibility(visible)
+    }).catch(() => {})
 
     const movedPromise = appWindow.onMoved(() => {
       void refreshWindowPosition()
     })
     const resizedPromise = appWindow.onResized(() => {
       void refreshWindowPosition()
+    })
+    const statusPromise = listen<RustPetStatus>('pet://status', ({ payload }) => {
+      // Rust PetTransientState::default() 的 visible 为 true，启用桌宠的启动
+      // 流程会报告 visible=true；任一字段显式为 false 都视为窗口不可见。
+      handleVisibility(payload.enabled !== false && payload.visible !== false)
     })
     const mouseMovePromise = listen<DeviceMousePosition>('device-mouse-move', ({ payload }) => {
       // 挂载时的位置刷新是异步的，首个事件到来时可能还没拿到窗口坐标；补拉一次，
@@ -89,16 +135,18 @@ export function useOmitIgnoreCursorEvents(elementRef: RefObject<HTMLElement | nu
         setIgnoreCursorEvents(!inElement)
     })
 
-    void Promise.all([movedPromise, resizedPromise, mouseMovePromise]).then(([moved, resized, mouseMove]) => {
+    void Promise.all([movedPromise, resizedPromise, mouseMovePromise, statusPromise]).then(([moved, resized, mouseMove, status]) => {
       if (disposed) {
         moved()
         resized()
         mouseMove()
+        status()
       }
       else {
         unlistenMoved = moved
         unlistenResized = resized
         unlistenMouseMove = mouseMove
+        unlistenStatus = status
       }
     }).catch(() => {})
 
@@ -108,6 +156,7 @@ export function useOmitIgnoreCursorEvents(elementRef: RefObject<HTMLElement | nu
       unlistenMoved?.()
       unlistenResized?.()
       unlistenMouseMove?.()
+      unlistenStatus?.()
     }
   }, [elementRef])
 }


### PR DESCRIPTION
Fixes #437

## 问题

v0.11.0 全新安装在 ds-key 设置界面移动鼠标即崩溃（SIGABRT，web 端 3080 正常）。Hermes 堆栈：

```
tao-0.35.3/src/platform_impl/linux/event_loop.rs:457:18:
called `Option::unwrap()` on a `None` value
```

## 根因

- Linux 下 tao 处理 `CursorIgnoreEvents(true)` 时对底层 GdkWindow 直接 `unwrap()`（tao 0.35.3 `event_loop.rs:457`，实测上游 0.37.0 同一行未修复，升级 tao 无效）：窗口从未显示（未 realize，GdkWindow 不存在）即 panic。panic 发生在 GTK 事件循环回调内无法回卷 → SIGABRT，整个桌面端崩溃。
- 本应用在 setup 阶段总会预创建隐藏的 pet 窗口（`desktop::pet::init_pet_window`，`.visible(false)`），全新安装默认不启用桌宠则窗口永远不 show，但其 WebView 仍加载 pet.html 并启动全局鼠标流，首个 `device-mouse-move` 事件到来时请求开启穿透——正是 #437 的必崩路径。#394 的「延后到首个鼠标移动再调用」假设此时窗口已 realize，对从未显示的窗口不成立。
- 窗口可见 ⇒ GTK 已 map ⇒ 已 realize ⇒ GdkWindow 存在（hide 只 unmap 不 unrealize），故「可见时调用」是安全边界。

## 修复（两层防御）

1. **Rust 权威防护**：新增 `set_pet_ignore_cursor_events(window, ignore) -> Result<bool, String>` 命令：
   - 校验调用方必须是 pet 窗口，否则 `PET_WINDOW_LABEL_MISMATCH`；
   - `ignore == true` 且窗口不可见（`is_visible()`，错误 `PET_WINDOW_STATE_FAILED`）时吞掉请求，返回 `Ok(false)`（未生效）；
   - 其余转发 `set_ignore_cursor_events`（错误 `PET_CURSOR_IGNORE_FAILED`），返回实际生效态供前端对齐；`false` 走 tao 无 unwrap 分支，始终安全转发；
   - 同步命令在主线程内联执行，`tauri-runtime-wry` 的 `getter!`/`send_user_message` 主线程路径内联处理消息，无死锁风险。
2. **前端配合**：`useOmitIgnoreCursorEvents` 改经 `invoke<boolean>('set_pet_ignore_cursor_events')` 应用穿透，并跟踪 `pet://status` + 挂载时 `isVisible()` 的窗口可见性：隐藏时跳过穿透请求（避免禁用桌宠的默认安装逐次鼠标移动产生无效 IPC）、复位穿透态并同步关闭穿透，重新显示后由鼠标事件重新计算命中区再应用；递增请求序号丢弃失序响应。

## 验证

- `pnpm run typecheck`、`pnpm run lint`（0 errors）、`pnpm run test -- --run`（18 files / 113 tests）全部通过；
- `cargo check` 通过；`cargo test --all-features --locked` 491 passed / 0 failed。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pet window click-through behavior to prevent unintended interactions while the window is hidden.
  - Automatically disables click-through when the pet window becomes hidden and restores safe behavior when visibility changes.
  - Ensures rapid setting changes are applied in the correct order, preventing outdated responses from overriding newer requests.
  - Added safeguards so click-through controls only affect the pet window and return clearer errors when requests cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->