### PR TITLE
chore: release v0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.11.0"
+version = "0.11.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.11.1` (`0.11.0` → `0.11.1`).

### Bug Fixes

- **core**: 原生模块探测纳入目录链接形式的包 (66cb1f5)
- **core**: 原生模块 ABI 不匹配时改用捆绑运行时并给出精确诊断 (f8fdcfa)
- **pet**: guard click-through switch on never-shown pet window (4a30fe9)
- **test**: mock @hairy/react-lib in toast lifecycle test (4fa259a)
- **ui**: restore panel collapse and dismissible update notifications (67a5f43)
- **pet**: hide sidebar button without pets (839edfc)

### Other Changes

- Merge pull request #442 from dsh-tauri-desk/fix/issue-441-native-addon-abi (731bbaa)
- Merge pull request #440 from dsh-tauri-desk/fix/pet-ignore-cursor-events-guard (e35a7ff)
- Merge pull request #436 from dunzic/codex/fix-panel-controls-and-notifications (e3c7424)
- Merge pull request #433 from dsh-tauri-desk/feat/panel-sidebar-compat-class (d559eca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 0.11.0 to 0.11.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->