### PR TITLE
chore: release v0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.11.1"
+version = "0.11.2"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.11.2` (`0.11.1` → `0.11.2`).

### Bug Fixes

- **worktree**: 兼容 0.1.5-alpha.1 附件 API 并自动链接依赖目录 (128818d)
- **pet**: demote historical sync log heading to satisfy markdown lint (175e08e)

### Documentation

- **pet**: add upstream sync log for dsh-tauri-pet (62394be)
- **scheduler**: add automation sync log (21df6a9)

### Other Changes

- Merge pull request #445 from dsh-tauri-desk/fix/worktree-alpha-attachments-deps-link (eec5431)
- Merge pull request #418 from dsh-tauri-desk/dsh/pet-update (efccabf)
- Merge branch 'main' into dsh/pet-update (67655db)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.11.2 across release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->