### PR TITLE
perf(pet): 修复宿主逐事件全量折叠导致的吐字变慢，并支持关闭桌宠即停订阅

### DIFF
--- a/packages/dsh-tauri-pet/src/index.test.ts
+++ b/packages/dsh-tauri-pet/src/index.test.ts
@@ -1,0 +1,151 @@
+import type { HostContext } from 'dsh-tauri'
+/**
+ * src/index.test.ts — 宿主装配 apply() 的热路径回归。
+ *
+ * 背景（0.11.x 用户反馈「吐字变慢」）：宿主在**每个** session/event（含逐 token 的
+ * assistant/chunk）上都调用 `sessionTitle.get(session)`，而该方法内部是
+ * `foldSessionTitle(session.snapshotEvents())` —— 整份会话事件日志 O(N) 复制 + O(N)
+ * 扫描，成熟会话单次 1–4 ms。它跑在 append() 的同步发布路径上（与流式转发同进程），
+ * 因此会拖慢逐 token 的吐字。本测试锁死「标题折叠次数与会话事件数无关」。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { apply, SESSION_STREAM_PATH } from './index'
+
+interface FakeHost {
+  ctx: HostContext
+  states: Map<string, (...args: unknown[]) => void>
+  routes: string[]
+  frames: string[]
+  titleLookups: () => number
+  emitEvent: (session: unknown, event: unknown) => void
+  emitDisposed: (session: unknown) => void
+  connect: () => void
+}
+
+/** 最小宿主上下文替身：记录 sessionTitle 折叠次数、路由与 SSE 帧。 */
+function createHost(): FakeHost {
+  const states = new Map<string, (...args: unknown[]) => void>()
+  const routes: string[] = []
+  const frames: string[] = []
+  let lookups = 0
+  let routeHandler: ((request: unknown, response: unknown) => void) | undefined
+
+  const ctx = {
+    get: (name: string) => {
+      if (name !== 'sessionTitle')
+        return undefined
+      return {
+        get: () => {
+          lookups += 1
+          return { title: `title-${lookups}` }
+        },
+      }
+    },
+    on: (name: string, handler: (...args: unknown[]) => void) => {
+      states.set(name, handler)
+    },
+    effect: (fn: () => unknown) => {
+      fn()
+    },
+    webServer: {
+      register: (route: { path: string, handler: (request: unknown, response: unknown) => void }) => {
+        routes.push(route.path)
+        routeHandler = route.handler
+        return () => {}
+      },
+    },
+  } as unknown as HostContext
+
+  return {
+    ctx,
+    states,
+    routes,
+    frames,
+    titleLookups: () => lookups,
+    emitEvent: (session, event) => {
+      states.get('session/event')?.(session, event)
+    },
+    emitDisposed: (session) => {
+      states.get('session/disposed')?.(session)
+    },
+    connect: () => {
+      routeHandler?.({ on: () => {} }, {
+        writeHead: () => {},
+        write: (chunk: string) => {
+          frames.push(chunk)
+        },
+        end: () => {},
+      })
+    },
+  }
+}
+
+/** 取出 SSE 数据帧里的半结构化载荷。 */
+function payloads(frames: readonly string[]): Array<{ action: string, payload: Record<string, unknown> }> {
+  return frames
+    .filter(frame => frame.startsWith('data: '))
+    .map(frame => JSON.parse(frame.slice('data: '.length).trim()) as { action: string, payload: Record<string, unknown> })
+}
+
+/** 一段流式正文事件（逐 token 的 assistant/chunk）。 */
+function chunk(seq: number) {
+  return { type: 'assistant/chunk', seq, time: seq, data: { chunk: { type: 'text-delta', text: 'x' } } }
+}
+
+describe('pet host apply()', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('注册会话流路由', () => {
+    const host = createHost()
+    apply(host.ctx)
+    expect(host.routes).toEqual([SESSION_STREAM_PATH])
+  })
+
+  it('标题折叠只在会话首次出现时各读一次，不随流式事件数增长', () => {
+    const host = createHost()
+    apply(host.ctx)
+    const session = { id: 's1' }
+
+    for (let seq = 0; seq < 500; seq++)
+      host.emitEvent(session, chunk(seq))
+    expect(host.titleLookups()).toBe(1)
+
+    // 另一个会话首次出现：再读一次；同会话后续事件不再触发。
+    const other = { id: 's2' }
+    host.emitEvent(other, { type: 'turn/start', seq: 0, time: 0, data: {} })
+    for (let seq = 1; seq < 200; seq++)
+      host.emitEvent(other, chunk(seq))
+    expect(host.titleLookups()).toBe(2)
+  })
+
+  it('会话销毁后再次出现会重新读一次标题（缓存随会话失效）', () => {
+    const host = createHost()
+    apply(host.ctx)
+    const session = { id: 's1' }
+
+    host.emitEvent(session, chunk(0))
+    host.emitDisposed(session)
+    host.emitEvent(session, chunk(1))
+    expect(host.titleLookups()).toBe(2)
+  })
+
+  it('后续标题变化仍由 session/title 事件增量转发到 SSE', () => {
+    const host = createHost()
+    apply(host.ctx)
+    host.connect()
+    const session = { id: 's1' }
+
+    host.emitEvent(session, { type: 'turn/start', seq: 0, time: 0, data: {} })
+    host.emitEvent(session, { type: 'session/title', seq: 1, time: 1, data: { title: '新标题' } })
+
+    const last = payloads(host.frames).at(-1)
+    expect(last?.action).toBe('update')
+    expect(last?.payload).toMatchObject({ id: 's1', title: '新标题', displayTitle: '新标题' })
+    expect(host.titleLookups()).toBe(1)
+  })
+})

--- a/packages/dsh-tauri-pet/src/index.test.ts
+++ b/packages/dsh-tauri-pet/src/index.test.ts
@@ -1,48 +1,74 @@
 import type { HostContext } from 'dsh-tauri'
 /**
- * src/index.test.ts — 宿主装配 apply() 的热路径回归。
+ * src/index.test.ts — 宿主装配 apply() 的性能约定回归。
  *
- * 背景（0.11.x 用户反馈「吐字变慢」）：宿主在**每个** session/event（含逐 token 的
- * assistant/chunk）上都调用 `sessionTitle.get(session)`，而该方法内部是
+ * 背景（0.11.x 用户反馈「吐字变慢」）：宿主曾在**每个** session/event（含逐 token 的
+ * assistant/chunk）上调用 `sessionTitle.get(session)`，其内部是
  * `foldSessionTitle(session.snapshotEvents())` —— 整份会话事件日志 O(N) 复制 + O(N)
- * 扫描，成熟会话单次 1–4 ms。它跑在 append() 的同步发布路径上（与流式转发同进程），
- * 因此会拖慢逐 token 的吐字。本测试锁死「标题折叠次数与会话事件数无关」。
+ * 扫描，成熟会话单次 1–4 ms，跑在 append() 的同步发布路径上（与流式转发同进程）。
+ *
+ * 本文件锁死三条约定：
+ *   1. 无 SSE 消费者（桌宠停用/隐藏）时不挂载监听，会话事件不触发任何工作；
+ *   2. 标题折叠次数与会话事件数无关（每会话至多一次全量折叠）；
+ *   3. 有 `title` 投影时只走 O(新事件) 的 `stateOf`，不再全量折叠。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { apply, SESSION_STREAM_PATH } from './index'
 
+interface FakeHostOptions {
+  /** 是否提供 sessionTitle 服务（`get()` = O(整份日志) 折叠）。默认提供。 */
+  titleService?: boolean
+  /** 是否提供注册了 key='title' 的 sessionProjections 服务（O(新事件) 投影）。 */
+  projections?: boolean
+}
+
 interface FakeHost {
   ctx: HostContext
-  states: Map<string, (...args: unknown[]) => void>
   routes: string[]
   frames: string[]
   titleLookups: () => number
+  listenerCount: (name: string) => number
   emitEvent: (session: unknown, event: unknown) => void
   emitDisposed: (session: unknown) => void
-  connect: () => void
+  /** 接入一个 SSE 消费者，返回其断开函数。 */
+  connect: () => () => void
 }
 
-/** 最小宿主上下文替身：记录 sessionTitle 折叠次数、路由与 SSE 帧。 */
-function createHost(): FakeHost {
-  const states = new Map<string, (...args: unknown[]) => void>()
+/** 最小宿主上下文替身：记录标题折叠次数、路由、SSE 帧与监听挂载情况。 */
+function createHost(options: FakeHostOptions = {}): FakeHost {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
   const routes: string[] = []
   const frames: string[] = []
   let lookups = 0
   let routeHandler: ((request: unknown, response: unknown) => void) | undefined
+  const closers = new Set<() => void>()
 
   const ctx = {
     get: (name: string) => {
-      if (name !== 'sessionTitle')
-        return undefined
-      return {
-        get: () => {
-          lookups += 1
-          return { title: `title-${lookups}` }
-        },
+      if (name === 'sessionTitle' && options.titleService !== false) {
+        return {
+          get: () => {
+            lookups += 1
+            return { title: `title-${lookups}` }
+          },
+        }
       }
+      if (name === 'sessionProjections' && options.projections === true) {
+        return {
+          stateOf: (session: unknown, key: string) => key === 'title'
+            ? (session as { title?: string }).title
+            : undefined,
+        }
+      }
+      return undefined
     },
     on: (name: string, handler: (...args: unknown[]) => void) => {
-      states.set(name, handler)
+      const set = listeners.get(name) ?? new Set<(...args: unknown[]) => void>()
+      listeners.set(name, set)
+      set.add(handler)
+      return () => {
+        set.delete(handler)
+      }
     },
     effect: (fn: () => unknown) => {
       fn()
@@ -58,24 +84,38 @@ function createHost(): FakeHost {
 
   return {
     ctx,
-    states,
     routes,
     frames,
     titleLookups: () => lookups,
+    listenerCount: name => listeners.get(name)?.size ?? 0,
     emitEvent: (session, event) => {
-      states.get('session/event')?.(session, event)
+      for (const handler of listeners.get('session/event') ?? [])
+        handler(session, event)
     },
     emitDisposed: (session) => {
-      states.get('session/disposed')?.(session)
+      for (const handler of listeners.get('session/disposed') ?? [])
+        handler(session)
     },
     connect: () => {
-      routeHandler?.({ on: () => {} }, {
+      const request = {
+        on: (name: string, handler: () => void) => {
+          if (name === 'close')
+            closers.add(handler)
+        },
+      }
+      routeHandler?.(request, {
         writeHead: () => {},
         write: (chunk: string) => {
           frames.push(chunk)
         },
         end: () => {},
       })
+      return () => {
+        for (const closer of [...closers]) {
+          closers.delete(closer)
+          closer()
+        }
+      }
     },
   }
 }
@@ -106,11 +146,24 @@ describe('pet host apply()', () => {
     expect(host.routes).toEqual([SESSION_STREAM_PATH])
   })
 
-  it('标题折叠只在会话首次出现时各读一次，不随流式事件数增长', () => {
+  it('无消费者（桌宠停用/隐藏）时不挂载监听，会话事件不触发任何工作', () => {
     const host = createHost()
     apply(host.ctx)
-    const session = { id: 's1' }
+    expect(host.listenerCount('session/event')).toBe(0)
+    expect(host.listenerCount('session/disposed')).toBe(0)
 
+    host.emitEvent({ id: 's1' }, chunk(0))
+    expect(host.titleLookups()).toBe(0)
+    expect(host.frames).toHaveLength(0)
+  })
+
+  it('首个消费者接入才挂载监听，标题折叠不随流式事件数增长', () => {
+    const host = createHost()
+    apply(host.ctx)
+    host.connect()
+    expect(host.listenerCount('session/event')).toBe(1)
+
+    const session = { id: 's1' }
     for (let seq = 0; seq < 500; seq++)
       host.emitEvent(session, chunk(seq))
     expect(host.titleLookups()).toBe(1)
@@ -123,14 +176,27 @@ describe('pet host apply()', () => {
     expect(host.titleLookups()).toBe(2)
   })
 
-  it('会话销毁后再次出现会重新读一次标题（缓存随会话失效）', () => {
+  it('最后一个消费者断开后注销监听并丢弃状态，重新接入再折叠一次', () => {
     const host = createHost()
     apply(host.ctx)
+    const disconnect = host.connect()
     const session = { id: 's1' }
 
     host.emitEvent(session, chunk(0))
-    host.emitDisposed(session)
+    expect(host.titleLookups()).toBe(1)
+
+    disconnect()
+    expect(host.listenerCount('session/event')).toBe(0)
+    expect(host.listenerCount('session/disposed')).toBe(0)
+
+    // 断开期间的会话事件不再产生任何工作（也不读标题）。
     host.emitEvent(session, chunk(1))
+    host.emitDisposed(session)
+    expect(host.titleLookups()).toBe(1)
+
+    // 重新接入：状态从零重建，标题重新折叠一次。
+    host.connect()
+    host.emitEvent(session, chunk(2))
     expect(host.titleLookups()).toBe(2)
   })
 
@@ -147,5 +213,25 @@ describe('pet host apply()', () => {
     expect(last?.action).toBe('update')
     expect(last?.payload).toMatchObject({ id: 's1', title: '新标题', displayTitle: '新标题' })
     expect(host.titleLookups()).toBe(1)
+  })
+
+  it('有 title 投影时只走 O(新事件) 的 stateOf，不做全量折叠', () => {
+    const host = createHost({ projections: true })
+    apply(host.ctx)
+    host.connect()
+    const session = { id: 's1', title: '投影标题' }
+
+    for (let seq = 0; seq < 200; seq++)
+      host.emitEvent(session, chunk(seq))
+
+    // 投影路径：sessionTitle.get() 一次都不该被调用。
+    expect(host.titleLookups()).toBe(0)
+    const create = payloads(host.frames).find(frame => frame.action === 'create')
+    expect(create?.payload).toMatchObject({ id: 's1', title: '投影标题' })
+
+    // 标题在外部变化后，下一次事件即带上新值（无需 session/title 事件）。
+    session.title = '改名后'
+    host.emitEvent(session, { type: 'turn/start', seq: 200, time: 200, data: {} })
+    expect(payloads(host.frames).at(-1)?.payload).toMatchObject({ id: 's1', title: '改名后' })
   })
 })

--- a/packages/dsh-tauri-pet/src/index.ts
+++ b/packages/dsh-tauri-pet/src/index.ts
@@ -29,14 +29,31 @@ export const inject = ['webServer', 'sessions']
 /** SSE 流路径（Rust 消费端按 `http://127.0.0.1:<DSH_WEB_PORT>` + 此路径订阅）。 */
 export const SESSION_STREAM_PATH = '/api/dsh-pet/session-stream'
 
+/** 从宿主 session / 事件读取会话 id（`peerOf` 复用，避免为取 id 重复推导整份 peer）。 */
+function sessionIdOf(session: unknown, event: PetSessionEvent): string {
+  const s = session as { id?: unknown, sessionId?: unknown } | undefined
+  if (typeof s?.id === 'string')
+    return s.id
+  if (typeof s?.sessionId === 'string')
+    return s.sessionId
+  return String(event.data?.sessionId ?? '')
+}
+
 /**
  * 从宿主 session 对象读取的最小身份字段（运行时形状在此解耦，字段缺失即 undefined）。
  * 标题从宿主 `sessionTitle` 服务（`session/title` 事件折叠）读取 —— 裸 Session 类没有 title。
+ *
+ * `foldTitle` 只在**会话首次出现**时传入：`sessionTitle.get()` 内部是
+ * `foldSessionTitle(session.snapshotEvents())`，而 `snapshotEvents()` 会整份复制
+ * 会话事件日志（37k 事件 ≈ 288 KiB/次）再 `findLast` 扫描一遍 —— O(事件总数)。
+ * 若在每次 `session/event`（含逐 token 的 assistant/chunk）都调用，宿主进程每 token
+ * 都要付 1–4 ms CPU 与数百 KiB 垃圾，直接拖慢同进程的流式转发。后续标题变化由
+ * reducer 的 `session/title` 分支增量带入，无需重复全量折叠。
  */
 function peerOf(
   session: unknown,
   event: PetSessionEvent,
-  titleOf?: (session: unknown) => string | undefined,
+  foldTitle?: (session: unknown) => string | undefined,
 ): PetSessionPeer {
   const s = session as {
     id?: unknown
@@ -54,14 +71,10 @@ function peerOf(
     cwd?: string
     running?: boolean
   } | undefined
-  const id = typeof s?.id === 'string'
-    ? s.id
-    : typeof s?.sessionId === 'string'
-      ? s.sessionId
-      : String(event.data?.sessionId ?? '')
+  const id = sessionIdOf(session, event)
   const header = s?.header
   const summary = s?.summary
-  const foldedTitle = titleOf?.(session)
+  const foldedTitle = foldTitle?.(session)
   const title = summary?.title ?? s?.title ?? foldedTitle
   return {
     id,
@@ -151,17 +164,24 @@ export function apply(ctx: HostContext): void {
   const known = new Set<string>()
   ctx.on('session/event', (session: unknown, event: unknown) => {
     const petEvent = asPetEvent(event)
-    const peer = peerOf(session, petEvent, titleOf)
-    if (!peer.id)
+    const id = sessionIdOf(session, petEvent)
+    if (!id)
       return
-    if (!known.has(peer.id)) {
-      known.add(peer.id)
+    // 标题折叠是 O(整份会话日志)：只在会话首次出现时读一次，之后的标题变化由
+    // `session/title` 事件增量带入（reducer 已处理），热路径上不再触碰 title 服务。
+    const firstSight = !known.has(id)
+    if (firstSight)
+      known.add(id)
+    const peer = firstSight
+      ? peerOf(session, petEvent, titleOf)
+      : peerOf(session, petEvent)
+    if (firstSight)
       reducer.create(peer)
-    }
     reducer.apply(peer, petEvent)
   })
   ctx.on('session/disposed', (session: unknown) => {
-    const peer = peerOf(session, { type: '', seq: 0, time: 0, data: {} }, titleOf)
+    // remove 载荷只用 id：这里同样不折叠标题，避免销毁路径再付一次 O(日志) 成本。
+    const peer = peerOf(session, { type: '', seq: 0, time: 0, data: {} })
     if (!peer.id)
       return
     known.delete(peer.id)

--- a/packages/dsh-tauri-pet/src/index.ts
+++ b/packages/dsh-tauri-pet/src/index.ts
@@ -97,19 +97,52 @@ function asPetEvent(event: unknown): PetSessionEvent {
   }
 }
 
+/** `ctx.sessionProjections` 的最小读取面（只读本插件需要的 key，避免运行期依赖）。 */
+interface ProjectionRegistryLike {
+  stateOf?: (session: unknown, key: string) => unknown
+}
+
 /**
  * 插件体：订阅会话增量总线，经 reducer 投影后广播到 SSE 客户端。
+ *
+ * 消费模型（性能约定）：**没有 SSE 消费者就没有监听**。桌宠停用/隐藏后 Rust
+ * 会主动断开订阅（`sync_pet_session_stream`），宿主侧最后一个客户端断开时注销
+ * `session/event` + `session/disposed` 并丢弃累计态；下次有客户端接入再挂载。
+ *
  * @param ctx - 宿主根上下文（注入 webServer / sessions）。
  */
 export function apply(ctx: HostContext): void {
   // 已接入的 SSE 响应句柄（Rust 订阅者）。断连即移除。
   const clients = new Set<Parameters<RouteHandler>[1]>()
+  // 会话出生：首次出现的 id 推 create，随后交由 apply() 推增量 update。
+  const known = new Set<string>()
 
   // 会话标题折叠源：宿主 `sessionTitle` 服务（`session/title` 事件）。可选 —— 未挂载时回退 id。
   const titleService = ctx.get?.('sessionTitle') as
     | { get?: (session: unknown) => { title?: string } | undefined }
     | undefined
-  const titleOf = (session: unknown): string | undefined => titleService?.get?.(session)?.title
+
+  // 投影注册表：`@deepseek-ai/dsh-session-title` 注册了 key='title' 的投影单元。
+  // 惰性解析 —— apply() 时 registry 未必就绪（装配顺序不保证）。
+  let projections: ProjectionRegistryLike | undefined
+  /**
+   * O(新事件) 读取当前标题：注册表按水位线增量推进每个单元的折叠，`stateOf`
+   * 只补齐本会话尚未折叠的事件（每事件全局只折叠一次）。热路径用这个。
+   */
+  function projectedTitleOf(session: unknown): string | undefined {
+    projections ??= ctx.get?.('sessionProjections') as ProjectionRegistryLike | undefined
+    const title = projections?.stateOf?.(session, 'title')
+    return typeof title === 'string' && title ? title : undefined
+  }
+
+  /**
+   * 会话首次出现时的标题：优先投影；投影不可用（未装配 session-projection 或
+   * key 未注册）才退化为 `sessionTitle.get()` —— 后者是 O(整份会话日志) 的
+   * `foldSessionTitle(session.snapshotEvents())`，因此每个会话只允许调用一次。
+   */
+  function titleOnFirstSight(session: unknown): string | undefined {
+    return projectedTitleOf(session) ?? titleService?.get?.(session)?.title
+  }
 
   const reducer = createPetSessionReducer((action, payload) =>
     broadcast(action, payload))
@@ -125,6 +158,58 @@ export function apply(ctx: HostContext): void {
     }
   }
 
+  /** 会话事件监听的注销句柄；undefined = 当前无消费者、未挂载。 */
+  let disposeSessionEvents: (() => void) | undefined
+
+  function handleSessionEvent(session: unknown, event: unknown): void {
+    const petEvent = asPetEvent(event)
+    const id = sessionIdOf(session, petEvent)
+    if (!id)
+      return
+    // 标题：首次出现走一次「投影 → 全量折叠」；此后只读 O(1) 投影（不可用时
+    // 由 reducer 的 session/title 分支增量带入，绝不重新全量折叠）。
+    const firstSight = !known.has(id)
+    if (firstSight)
+      known.add(id)
+    const peer = firstSight
+      ? peerOf(session, petEvent, titleOnFirstSight)
+      : peerOf(session, petEvent, projectedTitleOf)
+    if (firstSight)
+      reducer.create(peer)
+    reducer.apply(peer, petEvent)
+  }
+
+  function handleSessionDisposed(session: unknown): void {
+    // remove 载荷只用 id：这里同样不折叠标题，避免销毁路径再付一次 O(日志) 成本。
+    const peer = peerOf(session, { type: '', seq: 0, time: 0, data: {} })
+    if (!peer.id)
+      return
+    known.delete(peer.id)
+    reducer.remove(peer.id)
+  }
+
+  /** 首个消费者接入：挂载会话事件监听（幂等）。 */
+  function attachSessionEvents(): void {
+    if (disposeSessionEvents !== undefined)
+      return
+    const disposeEvent = ctx.on('session/event', handleSessionEvent) as () => void
+    const disposeDisposed = ctx.on('session/disposed', handleSessionDisposed) as () => void
+    disposeSessionEvents = () => {
+      disposeEvent()
+      disposeDisposed()
+    }
+  }
+
+  /** 最后一个消费者断开：注销监听并丢弃累计态，下次订阅从零重建。 */
+  function detachSessionEvents(): void {
+    if (disposeSessionEvents === undefined)
+      return
+    disposeSessionEvents()
+    disposeSessionEvents = undefined
+    reducer.clear()
+    known.clear()
+  }
+
   const sseHandler: RouteHandler = (request, response) => {
     response.writeHead(200, {
       'content-type': 'text/event-stream; charset=utf-8',
@@ -135,6 +220,8 @@ export function apply(ctx: HostContext): void {
     })
     response.write('retry: 1000\n\n')
     clients.add(response)
+    // 有消费者才开始监听会话总线（桌宠关闭时 Rust 不会连上来）。
+    attachSessionEvents()
     // 心跳注释帧，防止代理/空闲断连。
     const ping = setInterval(() => {
       for (const res of clients) {
@@ -149,6 +236,9 @@ export function apply(ctx: HostContext): void {
     const onClose = () => {
       clients.delete(response)
       clearInterval(ping)
+      // 无消费者：注销监听，热路径彻底退出（桌宠重新打开会自动重连并挂载）。
+      if (clients.size === 0)
+        detachSessionEvents()
       try {
         response.end()
       }
@@ -160,34 +250,6 @@ export function apply(ctx: HostContext): void {
     request.on('error', onClose)
   }
 
-  // 会话出生：首次出现的 id 推 create，随后交由 apply() 推增量 update。
-  const known = new Set<string>()
-  ctx.on('session/event', (session: unknown, event: unknown) => {
-    const petEvent = asPetEvent(event)
-    const id = sessionIdOf(session, petEvent)
-    if (!id)
-      return
-    // 标题折叠是 O(整份会话日志)：只在会话首次出现时读一次，之后的标题变化由
-    // `session/title` 事件增量带入（reducer 已处理），热路径上不再触碰 title 服务。
-    const firstSight = !known.has(id)
-    if (firstSight)
-      known.add(id)
-    const peer = firstSight
-      ? peerOf(session, petEvent, titleOf)
-      : peerOf(session, petEvent)
-    if (firstSight)
-      reducer.create(peer)
-    reducer.apply(peer, petEvent)
-  })
-  ctx.on('session/disposed', (session: unknown) => {
-    // remove 载荷只用 id：这里同样不折叠标题，避免销毁路径再付一次 O(日志) 成本。
-    const peer = peerOf(session, { type: '', seq: 0, time: 0, data: {} })
-    if (!peer.id)
-      return
-    known.delete(peer.id)
-    reducer.remove(peer.id)
-  })
-
   // 路由注册 + 卸载清理。
   ctx.effect(() => {
     const disposeRoute = ctx.webServer.register({
@@ -197,6 +259,7 @@ export function apply(ctx: HostContext): void {
     })
     return () => {
       disposeRoute()
+      detachSessionEvents()
       for (const res of clients) {
         try {
           res.end()

--- a/src-tauri/src/bridge/pet.rs
+++ b/src-tauri/src/bridge/pet.rs
@@ -193,6 +193,8 @@ pub fn set_pet_enabled(app: AppHandle, enabled: bool) -> Result<PetStatus, Strin
         .unwrap_or_else(|error| error.into_inner())
         .visible = enabled;
     pet_window::set_pet_window_visible(&app, enabled)?;
+    // 停用即无消费者：停掉宿主会话流订阅（启用时窗口已可见，直接恢复订阅）。
+    sync_pet_session_stream(&app, enabled);
     let status = status_from_setting(&updated);
     emit_pet_status(&app, &status);
     Ok(status)
@@ -336,10 +338,46 @@ async fn consume_pet_session_stream(app: &AppHandle, url: &str) -> Result<(), St
     Ok(())
 }
 
-/// 启动「宿主会话增量 SSE」消费后台任务（见 consume_pet_session_stream）。
-/// 应用 setup 时调用一次；内部无限重连。
-pub fn spawn_pet_session_stream(app: AppHandle) {
-    tauri::async_runtime::spawn(async move {
+/// 会话增量流消费任务的句柄：桌宠停用/隐藏时 abort，宿主侧 SSE 客户端随连接
+/// 关闭归零（宿主插件据此注销 `session/event` 监听）。
+fn pet_stream_handle() -> &'static Mutex<Option<tauri::async_runtime::JoinHandle<()>>> {
+    static HANDLE: OnceLock<Mutex<Option<tauri::async_runtime::JoinHandle<()>>>> = OnceLock::new();
+    HANDLE.get_or_init(|| Mutex::new(None))
+}
+
+/// 是否需要订阅宿主会话增量流：桌宠已启用且窗口可见。
+///
+/// 临时隐藏（`hide_pet`）同样视为无消费者——窗口不渲染时转发毫无意义，停掉
+/// 订阅即让宿主的热路径与逐会话累计态一并短路。
+pub fn pet_stream_wanted(app: &AppHandle) -> bool {
+    let status = status_from_setting(&config::get_store_dat_setting(app));
+    status.enabled && status.visible
+}
+
+/// 按「是否有消费者」启停「宿主会话增量 SSE」消费任务（见
+/// [`consume_pet_session_stream`]），幂等：启用且无活动任务才 spawn；停用时
+/// abort 任务，连接立即关闭。
+///
+/// 调用点：应用 setup、`set_pet_enabled` / `show_pet` / `hide_pet`。桌宠关闭或
+/// 隐藏后 Rust 不再是宿主流的消费者，宿主侧随即不再为桌宠做任何转发。
+pub fn sync_pet_session_stream(app: &AppHandle, wanted: bool) {
+    let slot = pet_stream_handle();
+    let mut handle = slot.lock().unwrap_or_else(|error| error.into_inner());
+    if !wanted {
+        if let Some(task) = handle.take() {
+            task.abort();
+            log::info!("[pet-stream] host session stream stopped (pet disabled or hidden)");
+        }
+        return;
+    }
+    if handle
+        .as_ref()
+        .is_some_and(|task| !task.inner().is_finished())
+    {
+        return;
+    }
+    let app = app.clone();
+    *handle = Some(tauri::async_runtime::spawn(async move {
         loop {
             let setting = config::get_store_dat_setting(&app);
             let url = format!("http://127.0.0.1:{}{}", setting.port, SESSION_STREAM_PATH);
@@ -353,7 +391,7 @@ pub fn spawn_pet_session_stream(app: AppHandle) {
             }
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         }
-    });
+    }));
 }
 
 /// 按物理像素增量移动桌宠窗口，限制在可见显示器并保存最终位置。
@@ -377,6 +415,8 @@ pub fn show_pet(app: AppHandle) -> Result<PetStatus, String> {
         .unwrap_or_else(|error| error.into_inner())
         .visible = true;
     pet_window::set_pet_window_visible(&app, true)?;
+    // 恢复显示 = 重新有消费者：重开会话流订阅。
+    sync_pet_session_stream(&app, true);
     let status = status_from_setting(&setting);
     emit_pet_status(&app, &status);
     Ok(status)
@@ -390,6 +430,8 @@ pub fn hide_pet(app: AppHandle) -> Result<PetStatus, String> {
         .unwrap_or_else(|error| error.into_inner())
         .visible = false;
     pet_window::set_pet_window_visible(&app, false)?;
+    // 隐藏 = 无人渲染：停掉宿主会话流订阅，宿主侧热路径整条短路。
+    sync_pet_session_stream(&app, false);
     let status = status_from_setting(&config::get_store_dat_setting(&app));
     emit_pet_status(&app, &status);
     Ok(status)

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -631,8 +631,12 @@ pub fn builder() -> tauri::Builder<tauri::Wry> {
             crate::desktop::pet::init_pet_window(&app_handle);
             setup(app_handle.clone());
             // 方案 1（host → rust → pet）：Rust 作为宿主会话增量 SSE 流的消费者，
-            // 不再依赖 iframe 的 invoke 桥转发（#396 根因）。断连自动重连。
-            crate::bridge::pet::spawn_pet_session_stream(app_handle.clone());
+            // 不再依赖 iframe 的 invoke 桥转发（#396 根因）。断连自动重连；
+            // 仅当桌宠已启用且可见才订阅——关闭桌宠则宿主不做任何转发。
+            crate::bridge::pet::sync_pet_session_stream(
+                &app_handle,
+                crate::bridge::pet::pet_stream_wanted(&app_handle),
+            );
             Ok(())
         })
         .on_menu_event(|app, event| match event.id().as_ref() {


### PR DESCRIPTION
## 背景

用户反馈 0.11.1「吐字变慢」，降级到 0.10.7 仍慢、只有回到 **0.10.5** 才恢复。

版本边界与内置桌宠插件完全重合：

| 版本 | `dsh-tauri-pet` | 慢 |
| --- | --- | --- |
| ≤ 0.10.5 | 未内置（`internal-plugins.json` 无此项） | 否 |
| 0.10.6 | 内置；转发在 iframe 客户端（#396 的整窗重折 + 全量快照 invoke） | 是 |
| ≥ 0.10.7（含 0.11.1/0.11.2） | 转发搬到宿主（#414 一线），引入本 PR 修复的热路径 | 是 |

## 根因

宿主对**每个** `session/event`（含逐 token 的 `assistant/chunk`、`reasoning-chunks`、`tool-call-chunks`）都调用一次 `peerOf(session, petEvent, titleOf)`，其中无条件执行 `titleOf(session)`：

```js
// @deepseek-ai/dsh-session-title
get(session) { return foldSessionTitle(session.snapshotEvents()) }  // findLast 全量扫描
// @deepseek-ai/dsh-session
this.eventsSnapshot ??= Object.freeze([...this.log])                // 整份日志复制 + 冻结
```

`Session.append()` 每次都会置空 `eventsSnapshot` 并在**同一调用栈内同步**发布 `session/event`，因此每个流式事件都会：整份复制会话日志 → `Object.freeze`（V8 把冻结的大数组退化为字典元素，后续扫描慢一个量级）→ `findLast` 全量扫描。成本 O(事件总数)/token、O(N²)/回合。

这条路径跑在 `dsh web` 宿主进程的事件循环里，而**同进程正负责把 token 流转发给浏览器**，所以表现为吐字变慢/一顿一顿，并且越聊越慢（成熟会话、subagent/fork 会话更严重）。

## 实测（本机真实会话，Node 22.22，7 轮中位数）

样本 `~/.dsh/sessions/.../session-00aaf853…`：**36,823 事件**（12,141 `assistant/chunk` + 9,457 `tool-call-chunks` + 6,266 `reasoning-chunks`）

```
快照物化 Object.freeze([...log]) :   229 µs/次
冻结快照 findLast 全量扫描       : 3,218 µs/次
pet 现路径（两者相加）           : 3,676 µs/次   ← 每个流式事件
每次调用临时数组                 :   288 KiB
25 event/s → 92 ms/s CPU（9.2% 单核），垃圾 7.0 MiB/s
60 event/s → 221 ms/s CPU（22% 单核），垃圾 16.9 MiB/s
手写倒序扫描（等价语义）         :   275 µs/次（1/13）
```

## 修复

### 1) 热路径不再折叠全量日志（`25e9b52`）

- 标题折叠只允许发生**每会话一次**；后续标题变化由 reducer 既有的 `session/title` 分支增量带入。
- `session/disposed` 的 remove 载荷只用 `id`，不再折叠标题。
- 抽出 `sessionIdOf()`，避免为取 id 重复推导整份 peer。

### 2) 关闭/隐藏桌宠 = 没有消费者就没有监听（`9c8da30`）

Rust：

- `spawn_pet_session_stream` → `sync_pet_session_stream(app, wanted)`，`wanted = pet_stream_wanted(app)`（桌宠启用且可见）；停用/隐藏时 `abort()` 消费任务、连接立即关闭，启用/显示时幂等重开（`set_pet_enabled` / `show_pet` / `hide_pet` / setup 各同步一次）。

宿主：

- 首个 SSE 消费者接入才注册 `session/event` + `session/disposed`；最后一个断开即注销监听、`reducer.clear()` 并丢弃身份缓存，从零重建。

### 3) 标题改走上游推荐的增量读法

调研（Exa / GitHub 代码搜索 / 官方文档）结论：上游 [Session Projections 参考](https://deepseek-harness.github.io/deepseek-harness/en/reference/subsystems/session-projection) 明确「**domains hold no subscriptions and clients never fold domain events**」，log-derived 的按会话值应经 `ctx.sessionProjections` 读取；社区插件（如 [omdsh-dev/dsh-notification](https://github.com/omdsh-dev/dsh-notification)）即 `inject = ['sessionProjections']` + 注册纯折叠单元。

因此标题优先读 `@deepseek-ai/dsh-session-title` 已注册的 `title` 投影：

```ts
ctx.sessionProjections.stateOf(session, 'title')   // 注册表按水位线只折叠新事件，O(新事件)
```

仅在投影不可用（未装配 registry / key 未注册）时，才对「会话首次出现」退化调用一次 `sessionTitle.get()`。投影路径下 `sessionTitle.get()` 调用次数为 **0**。

未把桌宠自身状态注册成投影单元的原因：投影 `state` 必须是 plain JSON（持久化缓存前置条件）、并带 `stateSchema`/`stateVersion`，而桌宠展示态是进程内瞬态（`openTools` 用 `Map`）；注册单元不会减少每事件成本（注册表同样逐事件 drive），收益不足以承担持久化语义的复杂度。

## 验证

- `pnpm exec eslint packages/dsh-tauri-pet/src --max-warnings=0` ✅
- `pnpm test -- --run packages/dsh-tauri-pet` ✅ **39 passed**（新增 `src/index.test.ts` 6 条：无消费者不挂载监听、首个消费者才挂载、断开即注销并重建、折叠次数不随事件数增长、`session/title` 仍增量转发、投影路径 0 次全量折叠）
- `cargo check --manifest-path src-tauri/Cargo.toml --lib` ✅
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` ✅ **505 passed**

## 兼容性与用户侧

- 行为语义不变：标题、SSE 载荷、桌宠展示态字段均无变化。
- 桌宠开关（`set_pet_enabled`）与临时隐藏（`hide_pet`）现在都会真正停掉宿主侧转发；重新启用/显示会自动重连并从后续事件重建展示态（最迟在下一个 `assistant/message` 收敛为完整文案）。
- 若宿主侧插件是旧版而 Rust 新版（或反之），两边各自独立成立：旧宿主少了注销优化、旧 Rust 少了停订阅，均不产生新错误。
