### PR TITLE
fix(pet): 同一会话状态重复下发时不再重播动画

### DIFF
--- a/src/pet/app.tsx
+++ b/src/pet/app.tsx
@@ -25,10 +25,9 @@ export function App() {
   const { clickCount, direction, dragging } = useDrag(dragRef)
   useOmitIgnoreCursorEvents(dragRef)
   const drawStatus = direction === undefined ? undefined : DRAW_STATUS[direction]
-  // useWatch 的 deps 是每次渲染新建的字面量数组（见 @hairy/react-lib），effect 在
-  // 每次渲染都会执行；拖拽期间 direction/clickCount 会高频触发重渲染，若不节流，
-  // 每次渲染都会 pet.change() 使 override.revision 递增，视频效果随之反复重载
-  // 同一个动画（拖拽动画被 Moved 事件不断重启）。会话状态未变化时跳过下发。
+  // 会话状态未变化时跳过下发：同一档位的重复命令不应重启动画。视频层还有第二层
+  // 按「动画目标（资源 + 循环语义 + 重播序号）」的去重（pet.tsx → shouldReloadAnimation），
+  // 即使不同档位解析到同一个动画也不会重新播放。
   const lastStatusRef = useRef<PetStatus | undefined>(undefined)
 
   useWatch(

--- a/src/pet/components/pet.tsx
+++ b/src/pet/components/pet.tsx
@@ -497,6 +497,11 @@ export function Pet(props: PetProps) {
     const front = frontIdxRef.current === 0 ? videoARef.current : videoBRef.current
     if (source !== undefined && source !== front)
       return
+    // 一次性动画已播完：前台视频停在末帧，appliedRef 记录的「已下发目标」不再代表
+    // 正在播放的动画，必须作废——否则同一个一次性目标（终态档重复到达、回落又切回）
+    // 若在兜底动画加载完成前再次下发，会被 shouldReloadAnimation 判为「目标未变」而
+    // 跳过加载，前台就永远停在末帧。作废后同一目标也一定会重新加载播放。
+    appliedRef.current = null
     // 一次性动画播完：优先清 adHoc（点击回应 waving / 待机转向 turn），
     // 否则清非 loop 的 override 命令（bubble 会话动画播完回 idle）。
     if (adHocRef.current !== null) {

--- a/src/pet/components/pet.tsx
+++ b/src/pet/components/pet.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, Ref, RefObject, SyntheticEvent } from 'react'
 import type { PetHandle, PetStatus } from '../hooks/use-pet'
-import type { PetConfig } from '../pet-config'
+import type { PetAnimationTarget, PetConfig } from '../pet-config'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window'
@@ -15,6 +15,7 @@ import {
   poolEntryToStatus,
   resolvePresetName,
   rollKind,
+  shouldReloadAnimation,
   spriteStatusFallback,
 } from '../pet-config'
 
@@ -121,7 +122,10 @@ export function Pet(props: PetProps) {
   const videoBRef = useRef<HTMLVideoElement | null>(null)
   const frontIdxRef = useRef(0)
   const [frontIdx, setFrontIdx] = useState(0)
-  const pendingRef = useRef<null | { anim: string, gen: number, once: boolean, revision: number | undefined, seq: number }>(null)
+  /** 正在后台加载的切换代次（gen）；loadeddata 回调据此判断自己是否已被更新的切换取代。 */
+  const pendingRef = useRef<number | null>(null)
+  /** 已下发播放的动画目标（资源 URL + 循环语义 + 重播序号）；目标不变即不重载，见 shouldReloadAnimation。 */
+  const appliedRef = useRef<PetAnimationTarget | null>(null)
   const genRef = useRef(0)
   const spriteRef = useRef<HTMLDivElement | null>(null)
   const overrideRef = useRef(override)
@@ -177,8 +181,16 @@ export function Pet(props: PetProps) {
 
   useImperativeHandle(props.ref, () => ({
     change(options) {
-      if (isPetStatus(options.status))
-        setOverride({ loop: options.loop === true, revision: ++revisionRef.current, status: options.status })
+      if (!isPetStatus(options.status))
+        return
+      const current = overrideRef.current
+      // 同一档位重复下发（会话状态未变化，或多会话聚合档位来回切到同一档）不刷新 override：
+      // revision 递增会让视频层重新加载同一个动画并从头播放——用户报告「明明是同一条信息
+      // 『整理结果中』，下一条还是它，动画却一直重新播放」。override 已被 handleEnded 清空
+      // （终态一次性动画播完回落）时不做该去重，仍按新命令重新下发。
+      if (current !== null && current.status === options.status && current.loop === (options.loop === true))
+        return
+      setOverride({ loop: options.loop === true, revision: ++revisionRef.current, status: options.status })
     },
     clear() {
       setOverride(null)
@@ -328,18 +340,18 @@ export function Pet(props: PetProps) {
     const once = adHoc === null
       ? !(override?.loop ?? isLoopingAnimation(activity))
       : !isLoopingAnimation(activity)
-    const revision = override?.revision
     // adHoc seq：点击同一动画时 seq 递增强制重播（对应 dsh-pet 的 seq 重放）。
     const seq = adHoc?.seq ?? 0
-    const pending = pendingRef.current
-    // 防重：同一动画名 + 同一 revision + 同一 seq（未显式重播）不重复加载；
-    // override/点击每次触发 revision/seq 递增，同动画重播仍会重载并从头播放。
-    if (pending !== null && pending.anim === name && pending.once === once
-      && pending.revision === revision && pending.seq === seq) {
+    // 防重：同一播放目标（资源 URL + 循环语义 + 重播序号）不重复加载。
+    // override.revision 不是重播依据 —— 会话档位反复下发（同一档位重复到达，或多会话
+    // 交错让聚合档位在解析结果相同的动画之间来回切）时，按 revision 重载会让同一个
+    // webm 从头播放：用户看到「气泡信息没变，动画却一直重新播放」。只有点击回应等
+    // 显式重播（seq 递增）或目标真的变化时才重载。
+    const nextTarget: PetAnimationTarget = { once, seq, src: source }
+    if (!shouldReloadAnimation(appliedRef.current, nextTarget))
       return undefined
-    }
     const gen = ++genRef.current
-    pendingRef.current = { anim: name, gen, once, revision, seq }
+    pendingRef.current = gen
     const target = frontIdxRef.current === 0 ? videoBRef.current : videoARef.current
     target.src = source
     target.loop = !once
@@ -347,7 +359,7 @@ export function Pet(props: PetProps) {
     target.load()
     const onReady = () => {
       target.removeEventListener('loadeddata', onReady)
-      if (pendingRef.current?.gen !== gen)
+      if (pendingRef.current !== gen)
         return // 已被更新的切换取代
       const old = frontIdxRef.current === 0 ? videoARef.current : videoBRef.current
       if (old !== null && old !== target) {
@@ -359,6 +371,7 @@ export function Pet(props: PetProps) {
       // 而非渲染副作用；规则无法区分事件回调与 effect 同步阶段，忽略。
       // eslint-disable-next-line react/set-state-in-effect
       setFrontIdx(frontIdxRef.current)
+      appliedRef.current = nextTarget
       pendingRef.current = null
       void target.play().catch(() => setFailed(true))
     }
@@ -369,7 +382,7 @@ export function Pet(props: PetProps) {
       target.removeEventListener('loadeddata', onReady)
       // 若本次加载尚未完成（StrictMode 双挂载 / 依赖变化提前清理），清掉 pending，
       // 让下一次 effect 重新发起加载，避免「监听器已移除但 pending 仍在」的死锁。
-      if (pendingRef.current?.gen === gen)
+      if (pendingRef.current === gen)
         pendingRef.current = null
     }
   }, [activity, adHoc, assets, isPreset, override?.loop, override?.revision, pools])

--- a/src/pet/pet-config.test.ts
+++ b/src/pet/pet-config.test.ts
@@ -1,4 +1,4 @@
-import type { PetCategory, PetWeights } from './pet-config'
+import type { PetAnimationTarget, PetCategory, PetWeights } from './pet-config'
 import { describe, expect, it, vi } from 'vitest'
 import {
   fallbackPresetName,
@@ -9,6 +9,7 @@ import {
   poolEntryToStatus,
   resolvePresetName,
   rollKind,
+  shouldReloadAnimation,
   spriteStatusFallback,
 } from './pet-config'
 
@@ -189,6 +190,49 @@ describe('resolvePresetName', () => {
   it('returns null when the pool entry is not backed by an asset', () => {
     expect(resolvePresetName('idle', { ...pools, idlePool: ['不存在.webm'] }, assets)).toBeNull()
     expect(resolvePresetName('idle', { ...pools, idlePool: [] }, assets)).toBeNull()
+  })
+})
+
+describe('shouldReloadAnimation', () => {
+  const thinking: PetAnimationTarget = {
+    once: false,
+    seq: 0,
+    src: 'dsh-pet://localhost/maid-deepseek-whale/webm/%E6%80%9D.webm',
+  }
+
+  it('首次下发（无已播放目标）必须加载', () => {
+    expect(shouldReloadAnimation(null, thinking)).toBe(true)
+  })
+
+  it('同一状态重复下发解析到同一目标时不重载（动画不重新播放）', () => {
+    // 会话档位「整理结果中」连续两次（或聚合档位来回切到同一解析结果）：
+    // 资源/循环语义/重播序号都不变 → 继续播放，不从头重播。
+    expect(shouldReloadAnimation(thinking, { ...thinking })).toBe(false)
+  })
+
+  it('目标动画变化时重载', () => {
+    const result: PetAnimationTarget = {
+      once: false,
+      seq: 0,
+      src: 'dsh-pet://localhost/maid-deepseek-whale/webm/%E6%B8%85.webm',
+    }
+    expect(shouldReloadAnimation(thinking, result)).toBe(true)
+  })
+
+  it('同名动画但资源 URL 不同（切换宠物）必须重载', () => {
+    const other: PetAnimationTarget = {
+      ...thinking,
+      src: 'dsh-pet://localhost/other-pet/webm/%E6%80%9D.webm',
+    }
+    expect(shouldReloadAnimation(thinking, other)).toBe(true)
+  })
+
+  it('循环语义变化必须重载', () => {
+    expect(shouldReloadAnimation(thinking, { ...thinking, once: true })).toBe(true)
+  })
+
+  it('显式重播序号变化必须重载（点击同一动画再看一次）', () => {
+    expect(shouldReloadAnimation(thinking, { ...thinking, seq: 1 })).toBe(true)
   })
 })
 

--- a/src/pet/pet-config.ts
+++ b/src/pet/pet-config.ts
@@ -254,3 +254,41 @@ export function fallbackPresetName(
   }
   return null
 }
+
+/**
+ * 动画播放目标：真正决定「播放哪个媒体、怎么播」的三要素。
+ * - src：解析后的动画资源 URL（不是动画名——切换宠物时同名动画的 URL 不同，必须重载）；
+ * - once：一次性/循环语义（决定视频 loop 与 ended 回落）；
+ * - seq：显式重播序号（点击回应等 adHoc 每触发一次就递增，对应 dsh-pet 的 seq 重放）。
+ *
+ * 会话档位（thinking/working/result/…）刻意【不在】目标里：档位只是解析目标的输入，
+ * 不是重播依据。
+ */
+export interface PetAnimationTarget {
+  once: boolean
+  seq: number
+  src: string
+}
+
+/**
+ * 是否需要重载视频来切换动画（纯函数，可单测）。
+ *
+ * 【为什么存在】会话档位反复下发时（同一档位重复到达、或多会话交错让聚合档位在
+ * 解析结果相同的动画之间来回切），旧实现按 override.revision 递增重载同一个 webm
+ * 并从头播放——用户看到的现象是「气泡信息明明是同一个『整理结果中』，动画却一直
+ * 重新播放」。动画是否重播只由播放目标决定：
+ * - 目标资源变化（真换了动画 / 换了宠物）→ 重载；
+ * - once（循环语义）变化 → 重载，因为要重新设置 video.loop；
+ * - seq（点击回应等显式重播）变化 → 重载，用户重新点击就是要再看一次。
+ * 三者都不变 = 同一个动画目标，继续播放，不刷新。
+ */
+export function shouldReloadAnimation(
+  previous: PetAnimationTarget | null,
+  next: PetAnimationTarget,
+): boolean {
+  if (previous === null)
+    return true
+  return previous.src !== next.src
+    || previous.once !== next.once
+    || previous.seq !== next.seq
+}


### PR DESCRIPTION
## 背景

用户报告：会话状态没变时（气泡一直是「整理结果中」），桌宠动画却一直重新播放。

## 根因

预设宠物（WebM）的动画重播原本只由 `override.revision` 递增驱动：`pet.change()` 被调用一次 revision 就 +1，视频切换 effect 依赖 `override?.revision`，于是重载同一个 webm 并从头播放。因此这些情况都会「气泡信息没变，动画却一直重播」：

- 同一档位重复下发；
- 不同档位解析到同一个动画（旧预设缺 `工作状态-*` 资产时 thinking/working/result/waiting 都经 `fallbackPresetName` 降级成「写代码」）；
- 多会话交错让聚合档位在解析结果相同的动画之间来回切。

另外 effect 内按 `pendingRef` 的旧防重键包含 revision，且 `pendingRef` 在每次 effect 重跑前都被 cleanup 清空，实际是死代码，起不到防重作用。

## 改动

1. `src/pet/pet-config.ts`：新增纯函数 `shouldReloadAnimation(previous, next)` 与 `PetAnimationTarget`。是否重播只由**播放目标**决定：
   - `src`：资源 URL（切换宠物时同名动画 URL 不同，必须重载）；
   - `once`：一次性/循环语义（需要重新设置 `video.loop`）；
   - `seq`：显式重播序号（点击回应等 adHoc 每次触发递增）。

   三者都不变 = 同一个动画目标，继续播放、不刷新。
2. `src/pet/components/pet.tsx`：
   - `change()` 变为幂等命令：同一档位 + 同一 loop 重复下发直接忽略（不递增 revision、不触发重渲染）；override 已被 `handleEnded` 清空（终态一次性动画播完回落）时不适用去重，仍按新命令下发；
   - 视频切换层改用持久化的 `appliedRef` 记录已下发播放的目标（在 `loadeddata` 换前台时写入），替换原来恒为 null 的 `pendingRef` 死防重；`pendingRef` 简化为后台加载代次 `gen`。
3. `src/pet/app.tsx`：更新注释，说明 app 层（按档位）+ 视频层（按动画目标）的两层去重语义。

点击回应（seq 递增）与真实动画切换照旧重载，行为不变。

## 验证

- `pnpm exec vitest run --config vite.config.ts src/pet` → 42 passed（pet-config 26 条，含新增 `shouldReloadAnimation` 6 条）
- `pnpm exec eslint src/pet --max-warnings=0` → 零 warning
- `pnpm exec tsc --noEmit` → `src/` 无报错（本机 `packages/*` 报错为未 materialize workspace 依赖的既有环境问题，与本次改动无关）
- `pnpm exec vite build` → 成功（含 pet 入口）

## 生效说明

桌宠是独立 WebView（`pet.html`），需重新构建桌面端并 reload pet 窗口后才可见。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pet animations from reloading when repeated commands result in the same playback target.
  * Pet animations now reload correctly when the animation, pet resource, looping behavior, or explicit replay request changes.
  * Reduced unnecessary video interruptions during repeated updates, providing smoother playback.
  * Ensured one-time animations can be played again after they finish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->