### PR TITLE
chore: release v0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.11.2"
+version = "0.11.3"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.11.3` (`0.11.2` → `0.11.3`).

### Bug Fixes

- **pet**: 一次性动画播完后作废已下发目标，避免卡在末帧 (89b102a)
- **pet**: 同一会话状态重复下发时不再重播动画 (a21e82c)
- **profile**: 补齐档案缺失的核心 web bundle 层 (5b73002)
- **pet**: 会话热路径不再逐事件折叠全量日志，修复吐字变慢 (25e9b52)
- **pnpm**: 版本探测关闭 stdin 并在超时后回退捆绑版（#449） (65f976e)
- **safe-mode**: 启动前清除安全档案里的用户插件 (3421bd8)

### Performance

- **pet**: 关闭/隐藏桌宠即停止会话流订阅与宿主监听 (9c8da30)

### Other Changes

- Merge pull request #456 from dsh-tauri-desk/fix/pet-same-status-animation-no-replay (9a8267e)
- Merge pull request #453 from dsh-tauri-desk/fix/issue-449-pnpm-probe-timeout (fe056f8)
- Merge pull request #454 from dsh-tauri-desk/fix/pet-title-hot-path (0ca07e4)
- Merge pull request #455 from dsh-tauri-desk/fix/issue-452-core-web-bundles (ba742e9)
- Merge pull request #450 from dsh-tauri-desk/fix/safe-mode-purge-user-plugins (c526a05)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.11.3** across release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->