### PR TITLE
chore: release v0.12.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.11.3",
+  "version": "0.12.0-beta.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.11.3"
+version = "0.12.0-beta.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.11.3"
+version = "0.12.0-beta.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.11.3",
+  "version": "0.12.0-beta.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.12.0-beta.1` (`0.11.3` → `0.12.0-beta.1`).

### Features

- **turnrewind**: open files in the sidebar on the new kernel, stay silent on the old one (f93c64b)
- **turnrewind**: harden capture, retention and undo (733091a)
- **turnrewind**: per-turn change cards with one-click undo (a74564e)
- **turnrewind**: put the per-turn Undo button in the message action strip (36f9c2b)
- add turnrewind spec (566d322)
- **turnrewind**: per-turn Undo button in the conversation (3575573)
- **bundle**: ship dsh-tauri-turnrewind in the desktop build out of the box (7cdd9bb)
- **turnrewind**: one-time heads-up for unignored sensitive files (655548c)
- **turnrewind**: Escape plus focus trap on both modals via a shared a11y helper (355e79b)
- **turnrewind**: /undo --doctor read-only diagnostics (d5471b7)
- **turnrewind**: ledger quick_check on open plus a daily rolling backup (9da42d5)
- **turnrewind**: in-app recovery panel for needs-recovery workspaces (2bcd964)
- **turnrewind**: rebuild oversized snapshot repos via a two-phase quarantine (b7e3818)
- **turnrewind**: retention takes the workspace lock and prunes unreachable loose objects (d4e7b59)
- **turnrewind**: correctness hardening sweep (audit P2-11 + P1-4 leftovers) (b18ecd9)
- **turnrewind**: audit P1 hardening batch (fences, locks, routes, concurrency) (4ebdcd1)
- **turnrewind**: snapshot capacity governance (P2-4) (dc964b9)
- **turnrewind**: revalidate path chains at write points, junction test (P1-5) (c39b60e)
- **turnrewind**: persist and restore file modes (P1-4) (d27815a)
- **turnrewind**: archive expired plans instead of deleting them (510ca82)
- **turnrewind**: refuse snapshot symlinks instead of faking files (P1-3) (9bf50fa)
- **turnrewind**: cross-process workspace lock (P1-1) (9e2c1fb)
- **turnrewind**: bind pending plans to their previewed snapshots (P1-2) (37dd7c3)
- **turnrewind**: freeze redo at the entry with its recovery path hardened (c902668)
- **turnrewind**: full client UI, keep settled plans traceable, drop legacy JS (d263dae)
- **turnrewind**: TypeScript rewrite aligned with the packages/ plugin conventions (a735888)
- **turnrewind**: atomic restore via bak-swap with startup sweep (5cea66b)
- **turnrewind**: per-file oversize reporting instead of aborting the undo (91a6cae)
- **turnrewind**: self-heal when alternates lose borrowed objects (4625951)
- **turnrewind**: pending plans carry outcome status for the card to poll (654cb72)
- **turnrewind**: confirm via same-origin plugin routes instead of prompt RPC (c0776e0)
- **turnrewind**: two-phase /undo with in-card confirm buttons (18ab321)
- **turnrewind**: colored undo command card with badge, file list and diffs (ed3d3a0)
- **dsh-tauri-turnrewind**: same-page colored undo preview + snapshot guard (f8ec342)
- **turnrewind**: add local turn-aware workspace undo prototype (3217ea8)

### Bug Fixes

- **turnrewind**: swallow the child stdin error that broke the Linux CI run (6d558ac)
- **turnrewind**: declare the remote service instead of reading it un-injected (08055a2)
- **turnrewind**: release the undo reservation when target selection throws (cc177ac)
- **turnrewind**: address remaining CodeRabbit findings (1b451ed)
- **turnrewind**: address CodeRabbit review findings (123d717)
- **test**: alias dsh-tauri/client to TS source in root vitest config (d98a6a2)
- **build**: pin client target so the intentional CJS bundle stops failing tsdown under CI (387c2ae)
- **turnrewind**: canonical path identity using realpathSync.native for Windows 8.3 and mac /var aliases (a1c44b9)
- **turnrewind**: consistent realpath normalization across gitWorkspace calls (81e257f)
- **turnrewind**: CI lint errors — sort files array, method signature style, purge CLI cleanup (d7611dc)
- **turnrewind**: structural typing for slot host, avoid cordis Context version clash (77d2070)
- **turnrewind**: recovery-state hint says 'interrupted files' not 'files below' (7c673ee)
- **turnrewind**: recovery entry visible on fence errors in /undo and confirm routes (9a33737)
- **turnrewind**: recovery panel reachable from the /undo error card (audit P0-2 follow-up) (e91c8fd)
- **turnrewind**: recovery panel reachable from the /undo error card (audit P0-2 follow-up) (8c5bc17)
- **turnrewind**: test fixtures use the platform workspaceKey helper (8e177c2)
- **turnrewind**: render plain-text command bodies (doctor report, multi-line errors) (9e2cf55)
- **turnrewind**: ignore CR-at-EOL in preview and conflict diffs like the conflict check (2944663)
- **turnrewind**: precise cancel outcomes, separate gone-plan hint from expiry (884f155)
- **turnrewind**: left-align only the landed result, collapse cancelled plans to the thin row (59bb2aa)
- **turnrewind**: claim rewind notices inside one BEGIN IMMEDIATE transaction (2275e78)
- **turnrewind**: rmdirSync for the empty-directory restore branch, pin root/dir refusals in tests (c6db405)
- **turnrewind**: client compat resolution, purge CLI, seed-logic tests (audit step 2) (c20ef15)
- **turnrewind**: per-session-once heads-up, archive-backed (9f026ca)
- **turnrewind**: emit px units in css-render trees (root cause of the square card) (df78137)
- **turnrewind**: namespace dialog styles to stop cross-tree class collisions (2693fcd)
- **turnrewind**: data-safety P0 fixes from the 2026-09-03 review (2634adc)
- **turnrewind**: parse padded created paths in the TS command card (ee90b29)
- **turnrewind**: parse padded created paths in the TS command card (cfed4da)
- **turnrewind**: close the three legacy review debts (1723028)
- **turnrewind**: reject externally killed git subprocesses (04bc244)
- **turnrewind**: clear the remaining P3 review findings (8ed8528)
- **turnrewind**: address external review findings (redo deferred) (cd683a0)
- **desktop**: fall back to the newest stable release when latest is a preview (f621205)
- **turnrewind**: harden undo safety, plan claims and client lifecycle (8fbc2da)
- **turnrewind**: add baseline execution barrier (cbba4ad)
- **turnrewind**: guard undo confirm against rapid double-clicks (b3e7fe5)
- **turnrewind**: rebuild undo card state from the persisted plan status (03ed0bf)
- **turnrewind**: export the missing getPendingPlanRow plan lookup (d284e6f)
- **turnrewind**: diffs in pending previews, awaited confirm submission (952a80e)
- **turnrewind**: merge dialog into the manifest-imported client module (3c3a57c)
- **turnrewind**: use a unique module id for the dialog client module (6fdf4ab)
- **turnrewind**: poll projection snapshot for the unsupported dialog (9848278)
- **turnrewind**: claim queued notices for hard-guard-refused sessions (4362878)
- **turnrewind**: unify guard limits and surface probe rejections (3b16bee)
- **turnrewind**: skip dead snapshot refs when picking the undo target (dc53717)
- **download**: recognize dsh-src- prerelease tags in preview detection (1e33541)
- **turnrewind**: run git async and self-heal broken snapshot chains (f2d2437)
- **turnrewind**: guard unsafe workspaces and surface unavailable notices (3d0a59b)
- **turnrewind**: preserve interrupted turns and queued notices (61e5c40)

### Performance

- **turnrewind**: collapse workspace rev-parse into one subprocess with background refresh, async conflict reads (d7305fa)

### Refactors

- archive the current implementation and write an implementation plan (4977076)
- **turnrewind**: precompute plain-text row keys (drop the react lint disable) (541d741)
- **turnrewind**: converge the dialog runner on createLifecycleController, latest-owner-wins channels (1104620)
- **turnrewind**: move the undo card's hardcoded strings into the locale dictionaries (236197f)
- **turnrewind**: shared API prefix everywhere, stable expand keys, typed props (audit item 11) (4864b10)
- **turnrewind**: migrate command-view card styles to css-render (824351d)
- **turnrewind**: css-render styles for the unavailable dialog + route method limits + workspace probe cache (06f9431)

### Documentation

- record the message-side Undo button and the chain-slot pitfall (d249a5c)
- refresh the handoff status and align the package version with the published line (d2cc74a)
- **turnrewind**: describe the cordis mount row as shipped, not as an experimental local patch (d2d1ef8)
- re-sync turnrewind docs with the 09-06 implementation (77234d6)
- **turnrewind**: sync README with async resolution, sensitive-file notice and test counts (44dd41c)
- **turnrewind**: document the recovery panel, --doctor and ledger safeguards (3e6e725)
- **audit**: close item 15 (client lifecycle convergence, HMR token, locales) (77323ab)
- **turnrewind**: close audit item 2 and record the two defensive fixes (43abada)
- **turnrewind**: sync README/audit report, drop the frozen --redo from the command hint (2cf6f0d)
- align TURN_REWIND.md and PROJECT_STATUS.md with the current implementation (P2-2) (7d77010)
- **audit**: mark implementation step 2 done (285edeb)
- **audit**: merge findings into a unified prioritized todo list (04cfe26)
- **review**: P1-4/P1-5 closed (a5d2def)
- **review**: refresh fix-status addendum through 2026-09-05 (d930021)
- **turnrewind**: record real-host verification results (38c97f8)
- **turnrewind**: document the git directory mode and prune stale budget docs (ae58d23)
- **turnrewind**: anonymize local username in example paths (a966aea)
- project progress and device-handoff notes for turn-rewind (c71bc52)
- **turnrewind**: accurate README for the two-phase flow and colored card (f271a8e)

### Tests

- **turnrewind**: legacy-schema migration replay, darwin case-fold, CI matrix job (c75acd6)
- **turnrewind**: pin ignore semantics, worktree isolation and purge safety (77cf157)
- **turnrewind**: assert the source repository stays untouched (08ac4ee)
- **turnrewind**: migrate remaining fixtures to git workspaces (f93756f)

### Styles

- **turnrewind**: tighten card typography and pause hover/open-file affordances (175a38e)
- fix import order in client/index.ts (8bf00a7)
- **turnrewind**: keep the doctor title line unbulleted (4c70600)
- **turnrewind**: bullet the doctor report's top-level lines (0cc1448)
- **turnrewind**: push the preview hint flush right with text-align (35c190f)
- **turnrewind**: high-contrast hints and result alignment (3e650a1)
- **turnrewind**: align undo card radius with the native 10px card tier (9f0c5f6)
- **turnrewind**: plain cancelled label and persisted collapse state (89b7ca2)
- **turnrewind**: shorten the confirm button label (f3ebbb5)
- **turnrewind**: neutral color for the pre-submit undo hint (4d06476)
- **turnrewind**: cancelled undo collapses to a frameless native-style line (8d87491)
- **turnrewind**: deepen the green diff background (72860e9)
- **turnrewind**: VSCode-style clean diffs with deeper red/green (b684431)
- **turnrewind**: theme-token dialog, native command card (0325acd)
- **turnrewind**: normalize external contribution to repo lint rules (de5870b)

### CI

- **turnrewind**: build dsh-tauri before typecheck (efa5fac)

### Chores

- lint fix (ce6922c)
- change undo icon and size (00333dd)
- change ci step name (2bcdb3b)
- lint fix (512df13)
- **scripts**: add standalone-plugin.mjs to mirror a built-in plugin into its own repo (828a6e2)
- workspace lockfile after removing the JS package (1a1fa3b)
- **turnrewind**: drop the JS reference package from the PR branch (60572ff)
- update local ignore and TypeScript alias config (d324d8a)

### Other Changes

- Merge pull request #431 from yingtianlan/dsh/turnrewind-ts (97939b0)
- Merge branch 'dsh/turnrewind-ts' of https://github.com/yingtianlan/deepseek-harness-desktop-undo into dsh/turnrewind-ts (93cd3c7)
- Merge branch 'main' into dsh/turnrewind-ts (9187f01)
- Merge remote-tracking branch 'origin/dsh/turnrewind-ts-test' into dsh/turnrewind-ts (f199552)
- Merge remote-tracking branch 'upstream/main' into dsh/turnrewind-git-dir-undo (a8f8f9c)
- Merge pull request #2 from miaooo0000OOOO/feature/turn-rewind (6fa402e)
- Merge remote-tracking branch 'origin/feature/turn-rewind' into feature/turn-rewind (64a4e85)
- Merge upstream main into feature/turn-rewind (fdd9e27)
- Merge remote-tracking branch 'upstream/main' into feature/turn-rewind (bda40e7)
- upstream/main into dsh/turnrewind-ts (d79e572)
- **turnrewind**: prototype git directory snapshot mode (802c1b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to **0.12.0-beta.1** across its release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->