### PR TITLE
chore: release v0.12.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.12.0-beta.1",
+  "version": "0.12.0-beta.2",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.12.0-beta.1",
+  "version": "0.12.0-beta.2",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.12.0-beta.2` (`0.12.0-beta.1` → `0.12.0-beta.2`).

### Features

- **update**: 桌面端更新静默下载、导航栏「更新可用」chip 与退出自动安装 (69d5ea1)

### Bug Fixes

- **turnrewind**: 按 CodeRabbit 复核修掉实时读数泄漏与结算健壮性 (669abc3)
- **turnrewind**: idle 兜底只结算 idle 那一刻已在跑的 turn (c9ca738)
- **turnrewind**: 手动停止的 turn 不再丢卡片（结算时序 + 等待窗口） (9a3e367)
- **turnrewind**: 提示条置顶 dock，并修掉让每一轮快照都失败的被忽略 pathspec (bcf8bc0)
- **ui**: 「更新可用」chip 改用 success 配色 (7b8bc36)

### Other Changes

- Merge pull request #460 from dsh-tauri-desk/fix/turnrewind-dock-order-and-ignored-pathspec (5d13b47)
- Merge pull request #459 from dsh-tauri-desk/feat/desktop-silent-update-chip (41be688)