### PR TITLE
fix(pet): 会话中止后 toast 与动画一直持续——补 agent/status idle 兜底

### DIFF
--- a/packages/dsh-tauri-pet/README.md
+++ b/packages/dsh-tauri-pet/README.md
@@ -28,6 +28,20 @@ Chat 宠物安装在 `${DSH_HOME:-$HOME/.dsh}/pets`，Codex 宠物安装在
 `providerName: dsh-tauri-pet` 与 `includeDefaultRoots: false`，避免覆盖其他
 skill provider 或默认根目录。
 
+## 会话展示态来源（host half）
+
+宿主编排侧（`src/index.ts` + `src/host/reducer.ts`）订阅宿主事件，把「会话增量」投影成
+桌宠展示态后经 SSE（`/api/dsh-pet/session-stream`）下发给 Rust 侧再 `emit_to` 桌宠窗口：
+
+- `session/event`：回合生命周期的权威来源（turn/start → thinking、tool/call → working、
+  approval/asked → waiting、turn/end 按 reason 落定 success/error/waiting 或回空闲…）。
+- `agent/status`：`status === 'idle'` 时作为**回合收尾兜底**。核心在异常收尾时可能不追加
+  `turn/end`（用户中止、被父级中断、崩溃修复补写的 `interrupted` 只进日志、不再发
+  `session/event`），只认 `turn/end` 会让桌宠永远停在「思考中」气泡 + 循环动画。
+  兜底只在会话仍处于回合内（`running || turnActive || stepActive`）时生效，`turn/end`
+  已落定的终态档（success/error）与 blocked 等待态不被改写。
+- `session/disposed`：会话消失 → 移除对应气泡与展示态。
+
 ## Bridge commands
 
 | command | 说明 |

--- a/packages/dsh-tauri-pet/docs/sync-log.md
+++ b/packages/dsh-tauri-pet/docs/sync-log.md
@@ -20,6 +20,36 @@
 
 ## 同步记录
 
+### 2026 —— 修复「会话被用户中止后 toast 与动画一直持续」（分支 `fix/pet-abort-hang`）
+
+不是上游同步，而是宿主收尾信号缺失导致的桌宠挂死，记录在此以便后续核对收尾语义。
+
+- **现象**：用户中止一个刚起流的会话后，桌宠气泡（标题 + 档位文案）与循环工作动画
+  （thinking/working 档）一直持续，直到会话被销毁或重开桌宠。
+- **根因（有抓包与日志证据）**：桌宠展示态只认 `turn/end`，但核心 0.1.5-rc.1 在异常收尾时
+  可能**永远不追加** `turn/end`。真实现场 `session-2a2abd15`（用户中止，等待 5 秒的会话）：
+  - 宿主 `session/event` 只到 `assistant/attempt{stream:[]}` + `step/end`；SSE 抓包（订阅
+    `/api/dsh-pet/session-stream`）在最后一条 `workStatus=thinking` 之后**再无该会话的任何帧**；
+  - 会话日志里 `turn/end` 直到 2.5 分钟后该会话被重新加载时才出现，且是崩溃修复补写的
+    `{kind:'interrupted'}`；崩溃修复属于构造 seed，**不会再发 `session/event`**，桌宠永远等不到。
+  - 结论：`turn/end` 不能作为「回合收尾」的唯一信号，与 turnrewind 宿主侧早就存在的
+    `agent/status → idle` 兜底（`packages/dsh-tauri-turnrewind/src/host/apply.ts`）同源。
+- **修复**：
+  - `src/host/reducer.ts`：抽出 `settleIdle(state)`（turn/end 中断分支与 idle 兜底共用同一份
+    收尾语义），新增 `idle(id)` —— 只在会话仍处于「回合内」（`running || turnActive || stepActive`）
+    时才落定回空闲并去重转发；`turn/end` 已写好的终态档（success/error）与 blocked 等待态
+    必须保留，否则刚弹出的失败/完成气泡与一次性动画会被立刻掐断。
+  - `src/index.ts`：`attachSessionEvents` 增加 `ctx.on('agent/status', ...)`，`status==='idle'`
+    时用 `agent.session.id` 调 `reducer.idle`；与 `session/event` / `session/disposed` 同生命周期
+    （无消费者不订阅）。载荷形状 `{status, agent}` 来自核心 `agentEvents` 的 fused payload，
+    0.1.2-rc.1 与 0.1.5-rc.1 一致（旧核心同样是 `dispatch.emit("agent/status", { status })`）。
+  - `src/pet/hooks/bubble-copy.ts`：`sessionTitle()` 从 `use-bubble.ts` 迁入（纯函数可单测），
+    标题缺失时回落 `UNTITLED_SESSION_TITLE`（「新会话」/「New session」），**不再回落
+    `session.id`**（此前把 `session-xxxx-xxxx…` 漏成气泡标题）。
+  - 测试：reducer.test.ts 新增 4 条（漏发 turn/end 时清空并转发、终态/等待态不被改写、
+    未知会话与重复通知不转发、create 仅凭 summary `running=true` 也能回落）；
+    bubble-copy.test.ts 新增 3 条（标题优先级、缺失标题回落且不含 `session-`、前缀保留）。
+
 ### 2025 —— PR #414（已合并 main，分支 `dsh/pet-work-status`）
 
 预设 ref 升级 + 工作状态 6 档 + 动画/气泡接线：

--- a/packages/dsh-tauri-pet/docs/sync-log.md
+++ b/packages/dsh-tauri-pet/docs/sync-log.md
@@ -45,7 +45,8 @@
     0.1.2-rc.1 与 0.1.5-rc.1 一致（旧核心同样是 `dispatch.emit("agent/status", { status })`）。
   - `src/pet/hooks/bubble-copy.ts`：`sessionTitle()` 从 `use-bubble.ts` 迁入（纯函数可单测），
     标题缺失时回落 `UNTITLED_SESSION_TITLE`（「新会话」/「New session」），**不再回落
-    `session.id`**（此前把 `session-xxxx-xxxx…` 漏成气泡标题）。
+    `session.id`**（此前把 `session-xxxx-xxxx…` 漏成气泡标题）；`taskCopy()` 按用户反馈去掉
+    dsh-dafeiyu 的句末语气词「呢」（`正在处理「…」` 不再以「呢」收尾，三个分支统一）。
   - 测试：reducer.test.ts 新增 4 条（漏发 turn/end 时清空并转发、终态/等待态不被改写、
     未知会话与重复通知不转发、create 仅凭 summary `running=true` 也能回落）；
     bubble-copy.test.ts 新增 3 条（标题优先级、缺失标题回落且不含 `session-`、前缀保留）。
@@ -133,6 +134,9 @@
 - dsh-dafeiyu：气泡文案/优先级逻辑已采纳（见 PR #414）；其 TASK 消息（todo/write →
   `taskCopy(task)` + 已完成 a/b 步）与 multi-session `#select()` 为多会话渲染方案，
   本仓库会话 Toast 一对一定位，未采纳。
+- dsh-dafeiyu `taskCopy` 的句末语气词「呢」：**有意去掉**（用户反馈「正在处理 […] 后面的
+  『呢』要去掉」）。句式结构（正在+原文 / 正在处理「原文」）仍与上游一致，只是不再带语气词；
+  若后续再次同步上游文案，勿把「呢」带回来。
 
 ## 后续同步流程
 

--- a/packages/dsh-tauri-pet/src/host/reducer.test.ts
+++ b/packages/dsh-tauri-pet/src/host/reducer.test.ts
@@ -281,4 +281,66 @@ describe('petSessionReducer (host)', () => {
     reducer.apply(peer(), ev('todo/write', { todos: [{ id: 't1', status: 'in_progress', content: '整理文档' }] }, 4))
     expect(pushes.length).toBe(before + 1)
   })
+
+  // ---------------------------------------------------------------------------
+  // agent/status idle 兜底：核心漏发 turn/end 的中断必须回落空闲，否则 toast + 循环动画一直持续。
+  // 真实现场见 session-2a2abd15（用户中止一个刚起流的会话）：日志只有 assistant/attempt +
+  // step/end，turn/end 直到 2.5 分钟后会话重载才由崩溃修复以 interrupted 补写。
+  // ---------------------------------------------------------------------------
+  it('idle 兜底：回合内漏发 turn/end 时清空 workStatus/running/工具等待并把展示态转发下去', () => {
+    const { reducer, pushes } = collect()
+    reducer.create(peer())
+    reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
+    reducer.apply(peer(), ev('tool/call', { turn: 1, step: 1, callId: 'c1', name: 'pwsh', arguments: '{}' }, 2))
+    expect(pushes.at(-1)!.payload).toMatchObject({ running: true, workStatus: 'working' })
+    const before = pushes.length
+    reducer.idle('a')
+    expect(pushes.length).toBe(before + 1)
+    const last = pushes.at(-1)!
+    expect(last.action).toBe('update')
+    expect(last.payload).toMatchObject({ id: 'a', running: false })
+    expect(last.payload.workStatus).toBeUndefined()
+    expect(last.payload.status).toBeUndefined()
+    expect(last.payload.liveActivity).toBeUndefined()
+  })
+
+  it('idle 兜底：turn/end 已落定的终态档与等待态不被改写（气泡/一次性动画不被掐断）', () => {
+    for (const reason of [{ kind: 'completed' }, { kind: 'error', error: { message: 'boom' } }, { kind: 'blocked' }]) {
+      const { reducer, pushes } = collect()
+      reducer.create(peer())
+      reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
+      reducer.apply(peer(), ev('turn/end', { turn: 1, reason }, 2))
+      const settled = pushes.at(-1)!.payload
+      const count = pushes.length
+      reducer.idle('a')
+      expect(pushes.length).toBe(count)
+      expect(pushes.at(-1)!.payload).toBe(settled)
+    }
+  })
+
+  it('idle 兜底：无累计态、已空闲或重复通知都不转发', () => {
+    const { reducer, pushes } = collect()
+    // 未见过这个会话：不凭空建态、不转发。
+    reducer.idle('unknown')
+    expect(pushes).toHaveLength(0)
+
+    reducer.create(peer())
+    reducer.apply(peer(), ev('turn/start', { turn: 1 }, 1))
+    const before = pushes.length
+    reducer.idle('a')
+    expect(pushes.length).toBe(before + 1)
+    // 已回空闲：重复 idle 不再转发。
+    reducer.idle('a')
+    expect(pushes.length).toBe(before + 1)
+  })
+
+  it('idle 兜底：新建会话仅凭 summary running=true（无事件）也能回落空闲', () => {
+    const { reducer, pushes } = collect()
+    // 桌面端订阅流之前会话已在跑：create 直接带 running=true，此后没有新事件。
+    reducer.create(peer({ running: true }))
+    expect(pushes.at(-1)!.payload).toMatchObject({ running: true, status: 'running' })
+    reducer.idle('a')
+    expect(pushes.at(-1)!.payload).toMatchObject({ running: false })
+    expect(pushes.at(-1)!.payload.status).toBeUndefined()
+  })
 })

--- a/packages/dsh-tauri-pet/src/host/reducer.ts
+++ b/packages/dsh-tauri-pet/src/host/reducer.ts
@@ -184,6 +184,32 @@ function payloadEqual(a: PetSessionPayload, b: PetSessionPayload): boolean {
     && Object.is(a.liveActivity?.args, b.liveActivity?.args)
 }
 
+/**
+ * 把累计态落定为「回合已收尾、空闲」：清掉回合内的一切瞬时态（工具/推理/正文/等待/档位/错误）。
+ *
+ * `turn/end` 的中断分支与 `agent/status → idle` 兜底共用同一份语义，避免两条收尾路径漂移出
+ * 「一条清干净、另一条残留 thinking」这类只在真实中断时复现的差异。
+ * @param state - 待落定的会话累计态（就地修改）。
+ */
+function settleIdle(state: PetSessionState): void {
+  state.turnActive = false
+  state.stepActive = false
+  state.running = false
+  state.openTools.clear()
+  state.reasoningTail = ''
+  state.assistantText = ''
+  state.waitingKind = undefined
+  state.waitingApprovalId = undefined
+  state.waitingCallId = undefined
+  state.workStatus = undefined
+  state.lastAgentError = undefined
+}
+
+/** 会话是否仍处于「回合内」：只有这种状态才允许被 idle 兜底改写（终态档/等待态由 turn/end 落定）。 */
+function inTurn(state: PetSessionState): boolean {
+  return state.running || state.turnActive || state.stepActive
+}
+
 /** 从累计态 fold 出当前展示 payload（只投影桌宠关心的字段）。 */
 export function foldPetPayload(state: PetSessionState): PetSessionPayload {
   // 活动优先级：正在等结果的工具调用 > 累计的 reasoning 文本 > 无。
@@ -513,13 +539,10 @@ export function reduceSessionEvent(
           state.lastAgentError = errBody?.error?.message ?? kind
         }
         else {
-          // aborted 等：回合中断，清档回空闲（绝不残留上一档，防止「一直 working」挂死）。
+          // aborted/interrupted/未知：回合中断，静默回空闲（绝不残留上一档，防止「一直 working」挂死）。
           // 手动取消是用户主动中断而非失败：不得写入 lastAgentError，否则 use-bubble 下一帧
-          // 判 failed 弹「失败：aborted」toast（kind==='error' 已在上面分支处理，此处到不了；
-          // 旧代码 if (kind === 'error' || kind === 'aborted') 实际只会命中 aborted，
-          // 把取消误记成错误）。lastAgentError 一并清空，保证取消后彻底静默回落空闲。
-          state.workStatus = undefined
-          state.lastAgentError = undefined
+          // 判 failed 弹「失败：aborted」toast。与 agent/status idle 兜底共用 settleIdle。
+          settleIdle(state)
         }
       }
       break
@@ -602,6 +625,34 @@ export function createPetSessionReducer(
       if (previous && payloadEqual(previous, payload))
         return
       lastSent.set(peer.id, payload)
+      handle('update', payload)
+    },
+    /**
+     * agent 空闲兜底（宿主 `agent/status → idle`）。
+     *
+     * 【为什么必须有】`turn/end` 不是「回合收尾」的可靠信号：核心在异常收尾时可能**永远不追加**
+     * 它——真实现场（0.1.5-rc.1，用户中止一个刚起流的会话）里日志只有 `assistant/attempt` +
+     * `step/end`，`turn/end` 直到 2.5 分钟后会话被重新加载时才由崩溃修复以 `interrupted` 补写；
+     * 而崩溃修复属于构造 seed，不会再走 `session/event`。桌宠只认 `turn/end`，于是永远停在
+     * 「思考中」气泡 + 循环工作动画（用户报告：会话被中止后 toast 跟动画一直持续）。
+     * turnrewind 宿主侧对此早已有同样的 idle 兜底，这里补齐桌宠这一侧。
+     *
+     * 【为什么限定 inTurn】`agent/status → idle` 总是紧跟在 `turn/end` 之后（同一轮收尾：
+     * turn/end 在 `finally` 里先落定，driver 再切 idle）。只有当回合内标志仍然成立（说明
+     * `turn/end` 根本没到）才改写，避免把刚由 turn/end 写好的终态档（success 庆祝 / error 失败）
+     * 与 blocked 等待态立刻清掉、掐断刚弹出的气泡与一次性动画。
+     * @param id - 进入空闲的会话 id（无累计态或已非回合内时静默忽略）。
+     */
+    idle(id: string): void {
+      const state = states.get(id)
+      if (state === undefined || !inTurn(state))
+        return
+      settleIdle(state)
+      const payload = foldPetPayload(state)
+      const previous = lastSent.get(id)
+      if (previous && payloadEqual(previous, payload))
+        return
+      lastSent.set(id, payload)
       handle('update', payload)
     },
     /** 会话消失：push remove 并清态。 */

--- a/packages/dsh-tauri-pet/src/index.ts
+++ b/packages/dsh-tauri-pet/src/index.ts
@@ -7,8 +7,9 @@
  *
  * 角色划分：
  *   - host/reducer.ts  纯函数「增量事件 → 桌宠展示态」reducer（单测覆盖）；
- *   - index.ts（本文件） 宿主装配：订阅 session/event + session/disposed，把
- *                        变化经 reducer 投影后广播到 SSE 客户端；
+ *   - index.ts（本文件） 宿主装配：订阅 session/event + session/disposed + agent/status，
+ *                        把变化经 reducer 投影后广播到 SSE 客户端（agent/status → idle
+ *                        是「核心漏发 turn/end」的中断兜底，见 reducer.idle）；
  *   - Rust 消费端       新后台任务 reqwest GET 本 SSE 流 → emit_to
  *                        (pet_window::PET_WINDOW_LABEL, "session:*").
  *
@@ -188,15 +189,34 @@ export function apply(ctx: HostContext): void {
     reducer.remove(peer.id)
   }
 
+  /**
+   * agent 空闲兜底（`agent/status → idle`）：把「回合已收尾」这个事实传给 reducer，
+   * 让核心漏发 `turn/end` 的中断（用户中止、被父级中断、异常收尾）也能回落空闲。
+   * 载荷形状来自核心的 agent-scoped 事件（`agentEvents` 把 agent 融进 payload）：
+   * `{ status, agent }`，会话 id 在 `agent.session.id`；与 turnrewind 宿主侧同一读取面。
+   */
+  function handleAgentStatus(payload: unknown): void {
+    const event = payload as { status?: unknown, agent?: { session?: { id?: unknown } } } | undefined
+    if (event?.status !== 'idle')
+      return
+    const id = event.agent?.session?.id
+    if (typeof id !== 'string' || id.length === 0)
+      return
+    reducer.idle(id)
+  }
+
   /** 首个消费者接入：挂载会话事件监听（幂等）。 */
   function attachSessionEvents(): void {
     if (disposeSessionEvents !== undefined)
       return
     const disposeEvent = ctx.on('session/event', handleSessionEvent) as () => void
     const disposeDisposed = ctx.on('session/disposed', handleSessionDisposed) as () => void
+    // idle 兜底与 session/event 同生命周期：没有消费者时同样不订阅（热路径彻底退出）。
+    const disposeStatus = ctx.on('agent/status', handleAgentStatus) as () => void
     disposeSessionEvents = () => {
       disposeEvent()
       disposeDisposed()
+      disposeStatus()
     }
   }
 

--- a/src/pet/hooks/bubble-copy.test.ts
+++ b/src/pet/hooks/bubble-copy.test.ts
@@ -5,7 +5,7 @@
  * 文案、taskCopy 句式（对齐 dsh-dafeiyu：正在/继续、动作动词、默认处理「…」）。
  */
 import { describe, expect, it } from 'vitest'
-import { activityCopy, seedNumber, statusCopy, taskCopy, toolActivityGroup } from './bubble-copy'
+import { activityCopy, seedNumber, sessionTitle, statusCopy, taskCopy, toolActivityGroup, UNTITLED_SESSION_TITLE } from './bubble-copy'
 
 describe('seedNumber', () => {
   it('numeric strings resolve to the absolute truncated integer', () => {
@@ -100,5 +100,31 @@ describe('taskCopy', () => {
     expect(taskCopy(undefined)).toBeUndefined()
     expect(taskCopy('   ')).toBeUndefined()
     expect(taskCopy('')).toBeUndefined()
+  })
+})
+
+describe('sessionTitle', () => {
+  it('prefers title/displayTitle/name as the base', () => {
+    expect(sessionTitle({ title: '修复宠物' })).toBe('修复宠物')
+    expect(sessionTitle({ displayTitle: '修复宠物' })).toBe('修复宠物')
+    expect(sessionTitle({ name: '修复宠物' })).toBe('修复宠物')
+  })
+
+  it('falls back to the untitled label instead of leaking the internal session id', () => {
+    const title = sessionTitle({ id: 'session-2a2abd15-b0d4-499c-aed1-dd1424003bb3' })
+    expect(title).toBe(UNTITLED_SESSION_TITLE)
+    expect(title).not.toContain('session-')
+    // 空白标题与缺失标题同档：都不得回落到 id。
+    expect(sessionTitle({ title: '   ', displayTitle: '' })).toBe(UNTITLED_SESSION_TITLE)
+  })
+
+  it('keeps the attention prefixes on top of the untitled fallback', () => {
+    for (const phase of ['approval', 'user-question', 'blocked']) {
+      const title = sessionTitle({ phase, title: '会话' })
+      expect(title).toContain('会话')
+      expect(title).toBe(sessionTitle({ phase, title: '会话' }))
+    }
+    expect(sessionTitle({ phase: 'approval' })).toContain(UNTITLED_SESSION_TITLE)
+    expect(sessionTitle({ origin: 'subagent' })).toContain(UNTITLED_SESSION_TITLE)
   })
 })

--- a/src/pet/hooks/bubble-copy.test.ts
+++ b/src/pet/hooks/bubble-copy.test.ts
@@ -81,19 +81,24 @@ describe('toolActivityGroup', () => {
 })
 
 describe('taskCopy', () => {
-  it('strips trailing punctuation and keeps 正在/继续-prefixed tasks as-is plus 呢', () => {
-    expect(taskCopy('正在写测试。')).toBe('正在写测试呢')
-    expect(taskCopy('继续修改文档')).toBe('继续修改文档呢')
+  it('strips trailing punctuation and keeps 正在/继续-prefixed tasks as-is', () => {
+    expect(taskCopy('正在写测试。')).toBe('正在写测试')
+    expect(taskCopy('继续修改文档')).toBe('继续修改文档')
   })
 
-  it('prefixes action-verb tasks with 正在 (dsh-dafeiyu 句式：正在 + 原文 + 呢)', () => {
-    expect(taskCopy('修改 bug')).toBe('正在修改 bug呢')
-    expect(taskCopy('搜索相关代码')).toBe('正在搜索相关代码呢')
-    expect(taskCopy('整理文档')).toBe('正在整理文档呢')
+  it('prefixes action-verb tasks with 正在 (dsh-dafeiyu 句式：正在 + 原文)', () => {
+    expect(taskCopy('修改 bug')).toBe('正在修改 bug')
+    expect(taskCopy('搜索相关代码')).toBe('正在搜索相关代码')
+    expect(taskCopy('整理文档')).toBe('正在整理文档')
   })
 
-  it('wraps other tasks in 正在处理「…」呢', () => {
-    expect(taskCopy('把动画接到气泡')).toBe('正在处理「把动画接到气泡」呢')
+  it('wraps other tasks in 正在处理「…」', () => {
+    expect(taskCopy('把动画接到气泡')).toBe('正在处理「把动画接到气泡」')
+  })
+
+  it('never appends the dsh-dafeiyu sentence-final particle 呢', () => {
+    for (const task of ['正在写测试', '继续修改文档', '修改 bug', '把动画接到气泡'])
+      expect(taskCopy(task)).not.toContain('呢')
   })
 
   it('returns undefined for empty/whitespace tasks', () => {

--- a/src/pet/hooks/bubble-copy.ts
+++ b/src/pet/hooks/bubble-copy.ts
@@ -117,3 +117,47 @@ export function toolActivityGroup(tool: string | undefined): string {
     return 'commanding'
   return 'working'
 }
+
+/** 会话标题兜底文案：标题还没生成（或首条提示尚未出标题）时不要暴露内部 session id。 */
+export const UNTITLED_SESSION_TITLE = IS_ZH ? '新会话' : 'New session'
+
+/** 会话标题前缀（等待/子代理等需要用户注意的态）。 */
+const SESSION_LABELS = {
+  subagent: IS_ZH ? '子代理' : 'Subagent',
+  waitApproval: IS_ZH ? '需授权' : 'Needs approval',
+  waitChoice: IS_ZH ? '需选择' : 'Needs your input',
+} as const
+
+/**
+ * 标题展示只读这些字段：标题与身份来自宿主投影，phase/origin 决定前缀。
+ * 带索引签名是为了直接吃完整展示态（`use-bubble` 的会话对象），多余字段一律忽略。
+ */
+export interface SessionTitleSource {
+  [key: string]: unknown
+  title?: unknown
+  displayTitle?: unknown
+  name?: unknown
+  phase?: unknown
+  origin?: unknown
+}
+
+/**
+ * 会话标题（含等待/子代理前缀）。
+ *
+ * 标题缺失时回落到 {@link UNTITLED_SESSION_TITLE}（「新会话」），**绝不回落到 `session.id`**：
+ * 会话 id 是内部标识，标题还没生成时它会以 `session-xxxx-xxxx…` 形态漏进气泡标题。
+ */
+export function sessionTitle(session: SessionTitleSource): string {
+  const base = [session.title, session.displayTitle, session.name]
+    .find((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    ?.trim()
+    ?? UNTITLED_SESSION_TITLE
+
+  if (session.phase === 'approval')
+    return `${SESSION_LABELS.waitApproval} · ${base}`
+  if (session.phase === 'user-question' || session.phase === 'blocked')
+    return `${SESSION_LABELS.waitChoice} · ${base}`
+  if (session.origin === 'subagent')
+    return `${SESSION_LABELS.subagent} · ${base}`
+  return base
+}

--- a/src/pet/hooks/bubble-copy.ts
+++ b/src/pet/hooks/bubble-copy.ts
@@ -90,18 +90,19 @@ export function activityCopy(activity: string, seed?: string | number): string {
 }
 
 /**
- * 任务文本 → 气泡文案（对齐 dsh-dafeiyu taskCopy 的句式：
- * 「正在/继续」开头 → 原文+呢；动作动词开头 → 正在+原文+呢；否则 正在处理「原文」呢）。
+ * 任务文本 → 气泡文案（对齐 dsh-dafeiyu taskCopy 的句式，但**不带句末语气词**：
+ * 「正在/继续」开头 → 原文；动作动词开头 → 正在+原文；否则 正在处理「原文」）。
+ * 上游 dsh-dafeiyu 每句都以「呢」收尾，本仓库按用户反馈去掉该语气词。
  */
 export function taskCopy(task: string | undefined): string | undefined {
   const value = String(task ?? '').trim().replace(/[。！？.!?]+$/u, '')
   if (!value)
     return undefined
   if (/^(?:正在|继续)/u.test(value))
-    return `${value}呢`
+    return value
   if (/^(?:准备|检查|验证|修改|修复|测试|构建|整理|分析|梳理|查找|搜索|读取|实现)/u.test(value))
-    return `正在${value}呢`
-  return `正在处理「${value}」呢`
+    return `正在${value}`
+  return `正在处理「${value}」`
 }
 
 /** 工具名 → 活动分类（对齐 dsh-dafeiyu toolActivity 正则 + DSH 实际工具名 pwsh；供 working 档无 liveActivity 时选文案）。 */

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -585,7 +585,7 @@ function toastContent(session: BubbleSession, status: PetStatus) {
       : statusCopy(status, seed)
   const description = getFirstString(
     session.lastAgentError ? (IS_ZH ? `失败：${String(session.lastAgentError)}` : `Failed: ${String(session.lastAgentError)}`) : undefined,
-    taskCopy(session.task as string | undefined), // todo 任务文案：正在处理「xxx」呢
+    taskCopy(session.task as string | undefined), // todo 任务文案：正在处理「xxx」
     getLiveActivity(), // 工具/思考活动详情（保留既有实用信息）
     fallbackCopy, // 档位状态文案（dsh-dafeiyu statusCopy）
     session.description,

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -3,7 +3,7 @@ import type { PetStatus } from './use-pet'
 import { listen } from '@tauri-apps/api/event'
 import { useEffect, useState } from 'react'
 import { toast } from '@/utils/toast'
-import { statusCopy, taskCopy, toolActivityGroup } from './bubble-copy'
+import { sessionTitle, statusCopy, taskCopy, toolActivityGroup } from './bubble-copy'
 
 export interface BubbleSession {
   [key: string]: unknown
@@ -44,13 +44,6 @@ const STATUS_COALESCE_MS = 100
 const IS_ZH = (typeof document !== 'undefined' ? document.documentElement.lang || navigator.language : 'zh-CN')
   .toLowerCase()
   .startsWith('zh')
-
-/** 常用文案常量 */
-const LABELS = {
-  subagent: IS_ZH ? '子代理' : 'Subagent',
-  waitApproval: IS_ZH ? '需授权' : 'Needs approval',
-  waitChoice: IS_ZH ? '需选择' : 'Needs your input',
-} as const
 
 /** 工具名 → toast 展示标签（沿用既有风格：英文工具名大写 / 中文动词）。 */
 const TOOL_LABELS: Record<string, string> = {
@@ -409,20 +402,6 @@ function rawSession(payload: unknown): BubbleSession | undefined {
   const session = (value.session && typeof value.session === 'object' ? value.session : value) as Record<string, unknown>
   const id = session.id ?? session.sessionId
   return typeof id === 'string' && id.length > 0 ? { ...session, id } : undefined
-}
-
-/** 会话标题处理 */
-function sessionTitle(session: BubbleSession): string {
-  const base = [session.title, session.displayTitle, session.name, session.id]
-    .find((v): v is string => typeof v === 'string' && Boolean(v.trim())) || '会话'
-
-  if (session.phase === 'approval')
-    return `${LABELS.waitApproval} · ${base}`
-  if (session.phase === 'user-question' || session.phase === 'blocked')
-    return `${LABELS.waitChoice} · ${base}`
-  if (session.origin === 'subagent')
-    return `${LABELS.subagent} · ${base}`
-  return base
 }
 
 /** 细分工作状态档位（host reducer workStatus 输出；动画名映射见 pet-config）。 */


### PR DESCRIPTION
## 现象

用户中止一个刚起流的会话后，桌宠气泡（标题 + 档位文案）与循环工作动画一直持续，直到会话被销毁或重开桌宠。用户报告：「如果会话被用户中止，那么 toast 跟动画将会一直持续」。

## 根因（有实证，不是推测）

桌宠展示态只认 `turn/end`，而核心 **0.1.5-rc.1 在异常收尾时可能永远不追加它**。真实现场 `session-2a2abd15`（用户中止「你好，等待5秒」会话，abort 落在首个 LLM 流上）：

| 证据 | 内容 |
| --- | --- |
| 宿主 `session/event` | 只到 `assistant/attempt{stream:[]}` + `step/end`，没有 `turn/end` |
| SSE 抓包 | 订阅 `/api/dsh-pet/session-stream`：该会话在最后一条 `workStatus=thinking` 帧之后**再无任何帧**（同批其它会话正常收到 `turn/end(completed)` 的 `{running:false,workStatus:success}`） |
| 会话日志 | `turn/end` 直到 2.5 分钟后该会话被重新加载时才出现，且是崩溃修复补写的 `{kind:"interrupted"}`；崩溃修复属于构造 seed，**不会再发 `session/event`** |

于是桌宠的累计态永远停在 `running=true, workStatus=thinking` → 气泡 + 循环动画不回落。

结论：`turn/end` 不能作为「回合收尾」的唯一信号。`dsh-tauri-turnrewind` 宿主侧早已有同源的 `agent/status → idle` 兜底（`src/host/apply.ts` 注释：「被取消/中断而没走到 turn/end 的 turn」），桌宠这一侧缺失。

## 修复

**host half（回合收尾兜底）**

- `src/host/reducer.ts`：抽出 `settleIdle()`（`turn/end` 中断分支与 idle 兜底共用同一份收尾语义，防止两条路径漂移），新增 `idle(id)`：
  - 仅在会话仍处回合内（`running || turnActive || stepActive`）时落定回空闲并去重转发；
  - `turn/end` 已落定的终态档（`success`/`error`）与 `blocked` 等待态**不被改写**——`agent/status → idle` 总是紧跟在 `turn/end` 之后，无差别清空会把刚弹出的失败/完成气泡与一次性庆祝动画立刻掐断。
- `src/index.ts`：`attachSessionEvents` 增加 `ctx.on('agent/status', ...)`，`status === 'idle'` 时用 `agent.session.id` 调 `reducer.idle`；与 `session/event`、`session/disposed` 同生命周期（无消费者不订阅，热路径不退化）。载荷形状 `{status, agent}` 来自核心 `agentEvents` 的 fused payload，`0.1.2-rc.1` 与 `0.1.5-rc.1` 一致。

**pet webview（气泡文案）**

- `src/pet/hooks/bubble-copy.ts`：`sessionTitle()` 从 `use-bubble.ts` 迁入（纯函数可单测）；标题缺失时回落 `UNTITLED_SESSION_TITLE`（「新会话」/「New session」），不再回落到 `session.id`（此前把 `session-xxxx-xxxx…` 漏成气泡标题）。
- `taskCopy()` 去掉 dsh-dafeiyu 的句末语气词「呢」（`正在处理「…」` 不再以「呢」收尾，三个分支统一）；sync-log「未采纳项」登记该有意分歧，避免后续同步上游文案时把语气词带回来。

## 测试与验证

- `reducer.test.ts` +4：漏发 `turn/end` 时清空并转发、终态/等待态不被改写、未知会话与重复通知不转发、`create` 仅凭 summary `running=true` 也能回落。
- `bubble-copy.test.ts` +4：标题优先级、缺失标题回落且不含 `session-`、注意力前缀保留、`taskCopy` 任何分支都不含「呢」。
- 本地：`pnpm typecheck` ✅ / `pnpm run lint` 0 error（23 条既有 warning）✅ / `pnpm run test -- --run` 37 文件 279 用例 ✅ / `pnpm build:plugins` ✅（部署产物 `dist` 已含 `agent/status` 订阅与 `reducer.idle`）。
- 文档：`packages/dsh-tauri-pet/docs/sync-log.md` 记录根因证据与文案分歧，`README.md` 新增「会话展示态来源」。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop pet sessions now reliably return to an idle state after user aborts, interruptions, crashes, or other abnormal turn endings.
  * Settled success, error, and waiting states remain unchanged when idle updates arrive.
  * Session bubbles now show localized approval, question, and subagent context labels.
  * Untitled sessions display a friendly fallback title instead of exposing an internal identifier.
  * Task messages no longer append the sentence-final “呢” particle.

* **Documentation**
  * Added documentation describing session display synchronization and abnormal-turn handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->