### PR TITLE
chore: release v0.12.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.12.0-beta.2",
+  "version": "0.12.0-beta.3",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.12.0-beta.2",
+  "version": "0.12.0-beta.3",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.12.0-beta.3` (`0.12.0-beta.2` → `0.12.0-beta.3`).

### Bug Fixes

- **pet**: 气泡 taskCopy 去掉句末语气词「呢」 (576bffa)
- **pet**: 会话中止后 toast 与动画一直持续——补 agent/status idle 兜底 (6bfa120)

### Other Changes

- Merge pull request #462 from dsh-tauri-desk/fix/pet-abort-hang (ee2cfd3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.12.0-beta.3**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->