### PR TITLE
chore: release v0.12.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.12.0-beta.3",
+  "version": "0.12.0-beta.4",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.3"
+version = "0.12.0-beta.4"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.3"
+version = "0.12.0-beta.4"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.12.0-beta.3",
+  "version": "0.12.0-beta.4",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.12.0-beta.4` (`0.12.0-beta.3` → `0.12.0-beta.4`).

### Features

- **turnrewind**: 开放「审核」按钮（新核心打开侧边栏文件树） (22f2bd2)
- **pet**: adjust the directory and optimize the style (740bb33)

### Bug Fixes

- **harness**: 启动期健康探测单次失败降级为 warn (88aaec9)
- **pet**: 会话流重连日志按状态节流 (c3c3bb8)
- **plugin**: 更新检测先把 catalog 依赖换成生效 spec (9accd65)
- **plugin**: 升级加 --latest 并核验是否真的落地 (ce6fa77)
- **turnrewind**: 非 Git 工作区不再渲染变更卡片 (3d2a255)

### Refactors

- **dsh-tauri-ui**: 样式工具下沉到 client/utils (d1d656f)

### Documentation

- **turnrewind**: 同步 README 与实现文档（非 Git 静默 + 开放「审核」） (f20a274)

### Styles

- **dsh-tauri-ui**: 新增全局样式挂载点，收敛右侧栏引导槽样式 (70d3027)

### Chores

- **core-version**: update the baseline of the core destructive change version to 0.1.2-rc.1 (8af2632)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.12.0-beta.4** across all release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->