### PR TITLE
fix(pet): 禁用屏幕唤醒锁，桌宠动画不再阻止息屏（#469）

### DIFF
--- a/src-tauri/src/bridge/pet.rs
+++ b/src-tauri/src/bridge/pet.rs
@@ -182,7 +182,7 @@ pub fn get_pet_status(app: AppHandle) -> PetStatus {
     status_from_setting(&config::get_store_dat_setting(&app))
 }
 
-/// 启用/停用桌宠；启用同时显示，停用同时隐藏并永久落盘。
+/// 启用/停用桌宠；启用同时显示，停用同时**销毁窗口**并永久落盘。
 #[tauri::command]
 pub fn set_pet_enabled(app: AppHandle, enabled: bool) -> Result<PetStatus, String> {
     let updated = config::update_store_dat_setting(&app, |setting| {
@@ -347,8 +347,8 @@ fn pet_stream_handle() -> &'static Mutex<Option<tauri::async_runtime::JoinHandle
 
 /// 是否需要订阅宿主会话增量流：桌宠已启用且窗口可见。
 ///
-/// 临时隐藏（`hide_pet`）同样视为无消费者——窗口不渲染时转发毫无意义，停掉
-/// 订阅即让宿主的热路径与逐会话累计态一并短路。
+/// 收起桌宠（`hide_pet`）会销毁窗口，同样视为无消费者——窗口不渲染时转发毫无意义，
+/// 停掉订阅即让宿主的热路径与逐会话累计态一并短路。
 pub fn pet_stream_wanted(app: &AppHandle) -> bool {
     let status = status_from_setting(&config::get_store_dat_setting(app));
     status.enabled && status.visible
@@ -457,6 +457,9 @@ pub fn move_pet_window(app: AppHandle, delta_x: i32, delta_y: i32) -> Result<(),
 }
 
 /// 显示桌宠窗口；只允许已永久启用的桌宠恢复显示。
+///
+/// 窗口不存在（首次启用，或上次收起时已被销毁）时在此重建——本命令是 `AppHandle`
+/// 命令，Tauri 在异步运行时执行，不违反「窗口创建不得在主线程」的约束。
 #[tauri::command]
 pub fn show_pet(app: AppHandle) -> Result<PetStatus, String> {
     let setting = config::get_store_dat_setting(&app);
@@ -475,19 +478,32 @@ pub fn show_pet(app: AppHandle) -> Result<PetStatus, String> {
     Ok(status)
 }
 
-/// 临时隐藏桌宠窗口，不改变永久 enabled；重启后已启用宠物重新显示。
+/// 临时收起桌宠（不改变永久 enabled；重启后已启用宠物重新显示）。
+///
+/// 「收起」= 销毁窗口实例（`set_pet_window_visible(false)` → `destroy()`），而不是
+/// hide：隐藏窗口里的 `<video>` 仍会播放并持有 Video Wake Lock，屏幕无法息屏
+/// （issue #469）。销毁后 webview 进程消失，视频与锁一并释放，会话流订阅也随即停止。
 #[tauri::command]
 pub fn hide_pet(app: AppHandle) -> Result<PetStatus, String> {
+    collapse_pet(&app)?;
+    let status = status_from_setting(&config::get_store_dat_setting(&app));
+    emit_pet_status(&app, &status);
+    Ok(status)
+}
+
+/// 收起桌宠窗口：销毁实例、置瞬态不可见、停掉宿主会话流订阅（幂等）。
+///
+/// 供 `hide_pet` 命令与「桌宠窗口自身收到关闭请求」两条路径共用：后者发生在主线程的
+/// 窗口事件回调里，销毁是异步投递、停流只是 abort 任务句柄，都不阻塞事件循环。
+pub fn collapse_pet(app: &AppHandle) -> Result<(), String> {
     transient_state()
         .lock()
         .unwrap_or_else(|error| error.into_inner())
         .visible = false;
-    pet_window::set_pet_window_visible(&app, false)?;
-    // 隐藏 = 无人渲染：停掉宿主会话流订阅，宿主侧热路径整条短路。
-    sync_pet_session_stream(&app, false);
-    let status = status_from_setting(&config::get_store_dat_setting(&app));
-    emit_pet_status(&app, &status);
-    Ok(status)
+    pet_window::set_pet_window_visible(app, false)?;
+    // 收起 = 无人渲染：停掉宿主会话流订阅，宿主侧热路径整条短路。
+    sync_pet_session_stream(app, false);
+    Ok(())
 }
 
 /// pet 窗口点击穿透开关；返回实际生效的穿透态，前端据此对齐本地 optimistic 状态。

--- a/src-tauri/src/desktop/builder.rs
+++ b/src-tauri/src/desktop/builder.rs
@@ -661,8 +661,13 @@ pub fn builder() -> tauri::Builder<tauri::Wry> {
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::CloseRequested { api, .. } => {
                 if window.label() == crate::desktop::pet::PET_WINDOW_LABEL {
+                    // 桌宠窗口没有装饰按钮，但 Alt+F4 / 系统关闭仍会走到这里：语义等同
+                    // 「收起宠物」——销毁窗口并同步瞬态可见性与会话流（issue #469）。
                     api.prevent_close();
-                    let _ = window.hide();
+                    let handle = window.app_handle().clone();
+                    if let Err(error) = crate::bridge::pet::collapse_pet(&handle) {
+                        log::warn!("[pet] PET_WINDOW_DESTROY_FAILED: {error}");
+                    }
                     return;
                 }
                 // get_store_dat_setting 内部已归一化，取值只可能是 tray 或 quit

--- a/src-tauri/src/desktop/pet.rs
+++ b/src-tauri/src/desktop/pet.rs
@@ -280,8 +280,12 @@ pub fn move_pet_window<R: Runtime>(
 
 /// 确保桌宠窗口存在并恢复位置。
 ///
-/// 幂等：已注册时直接复用返回；首次调用时创建 `pet` 窗口并恢复上一次保存的
-/// 位置（无记录则默认定位在主屏右下角略偏上，避免遮挡主工作区）。
+/// 幂等：已注册时直接复用返回；不存在（首次启用，或上次收起时已被销毁）时
+/// 创建 `pet` 窗口并恢复上一次保存的位置（无记录则默认定位在主屏右下角略偏上，
+/// 避免遮挡主工作区）。
+///
+/// **只能在非主线程调用**：内部经 `WebviewWindowBuilder::build()` 创建窗口，
+/// 主线程调用会与事件循环回包互相等待而死锁（见 [`set_pet_window_visible`]）。
 pub fn ensure_pet_window<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<WebviewWindow<R>> {
     if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {
         return Ok(window);
@@ -387,13 +391,30 @@ fn place_pet_at_default<R: Runtime>(window: &WebviewWindow<R>) {
     let _ = window.set_position(tauri::Position::Physical(PhysicalPosition::new(x, y)));
 }
 
-/// 显示或隐藏桌宠窗口；隐藏时保留窗口实例，显示时不抢占用户焦点。
+/// 显示或关闭桌宠窗口。
+///
+/// # 隐藏 = 销毁窗口实例（issue #469）
+///
+/// 这里**不做 hide**：隐藏只是把窗口从屏幕上撤下，WebView 进程与页面都还在，桌宠的
+/// 双 `<video>` 会继续解码播放——Chromium/WebView2 对「播放中（未暂停）的 video」
+/// 无条件持有 Video Wake Lock，屏幕因此永远无法息屏，还白占 CPU（用户报告：收起宠物
+/// 后仍无法黑屏）。销毁窗口才是真正「收起」：webview 进程随窗口一起消失，视频暂停、
+/// 唤醒锁释放、CPU 归零。代价是重新显示要重建 webview（页面前端挂载时用
+/// `get_pet_status` 拉取状态，不依赖创建时的事件投递）。
+///
+/// # 为什么 show 分支会创建窗口、而 destroy 分支不会死锁
+///
+/// `tauri-runtime-wry` 的 `RuntimeHandle::create_window` 经 channel 等待主线程事件循环
+/// 回包，**主线程调用必然死锁**（tauri-runtime-wry 2.11.4 lib.rs:2757 注释）。因此窗口
+/// 创建只允许发生在非主线程：调用方 `set_pet_enabled` / `show_pet` 都是 `AppHandle`
+/// 命令（Tauri 在异步运行时执行）；`hide_pet` 与窗口自己的关闭事件则只走 destroy，
+/// 而 `destroy()` 是 `proxy.send_event(Message::Destroy)` 的**非阻塞**投递，任何线程都安全。
 pub fn set_pet_window_visible<R: Runtime>(app: &AppHandle<R>, visible: bool) -> Result<(), String> {
     if !visible {
         if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {
             window
-                .hide()
-                .map_err(|error| format!("PET_WINDOW_HIDE_FAILED: {error}"))?;
+                .destroy()
+                .map_err(|error| format!("PET_WINDOW_DESTROY_FAILED: {error}"))?;
         }
         return Ok(());
     }
@@ -405,18 +426,19 @@ pub fn set_pet_window_visible<R: Runtime>(app: &AppHandle<R>, visible: bool) -> 
     Ok(())
 }
 
-/// 在 setup 阶段预创建两个隐藏窗口，再沿用永久启用设置显示它们。
-/// 这样设置页同步 command 只会 show/hide 已存在窗口，不会在 command handler
-/// 内调用 WebviewWindowBuilder，避免 Tauri/Windows 的消息循环死锁。
+/// setup 阶段按「是否永久启用」决定桌宠窗口的初始状态。
+///
+/// 启用才创建并显示；未启用**不创建**：窗口是「显示宠物」的唯一目的，没人看时连
+/// webview 都不该存在（隐藏窗口同样会加载 pet.html、播放动画）。窗口此后由
+/// [`set_pet_window_visible`] 按需创建/销毁。
 pub fn init_pet_window<R: Runtime>(app: &AppHandle<R>) {
-    let enabled = crate::config::get_store_dat_setting(app).pet_enabled;
-    let pet = ensure_pet_window(app);
-    if let Ok(pet) = pet {
-        if enabled {
-            let _ = pet.show();
-        }
-    } else {
-        log::error!("PET_WINDOW_INIT_FAILED: failed to pre-create pet windows");
+    if !crate::config::get_store_dat_setting(app).pet_enabled {
+        // 全新安装默认不启用桌宠：不预创建窗口（也顺带不触发 Linux 未 realize
+        // 窗口的穿透请求路径）。
+        return;
+    }
+    if let Err(error) = set_pet_window_visible(app, true) {
+        log::error!("PET_WINDOW_INIT_FAILED: failed to create pet window: {error}");
     }
 }
 
@@ -424,7 +446,8 @@ pub fn init_pet_window<R: Runtime>(app: &AppHandle<R>) {
 ///
 /// 桌宠窗口按 `activePet` 只拉取一次协议资源（config + webm manifest），
 /// 更新换入新文件后 URL 不变，WebView 可能继续命中缓存里的旧 webm；
-/// 显式 reload 让新资源立即生效。窗口隐藏时 reload 同样安全（页面本身常驻）。
+/// 显式 reload 让新资源立即生效。窗口已被收起（销毁）时无需 reload——下次显示
+/// 会重新创建 webview，天然加载新资源。
 pub fn reload_pet_window<R: Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {
         let _ = window.eval("location.reload()");

--- a/src-tauri/src/desktop/pet_mouse.rs
+++ b/src-tauri/src/desktop/pet_mouse.rs
@@ -56,10 +56,16 @@ const MACOS_MOUSE_EVENTS: &[core_graphics::event::CGEventType] = &[
     core_graphics::event::CGEventType::OtherMouseDragged,
 ];
 
-/// 全局鼠标流的进程级状态（幂等启动标记）。
+/// 全局鼠标流的进程级状态：幂等启动标记 + 当前事件的接收窗口。
+///
+/// 接收窗口必须是**可变**的：收起桌宠会销毁窗口（issue #469），重新显示时创建的是
+/// 新窗口（旧 handle 已失效，向它 emit 不会有任何效果）。若把 `start_pet_mouse_stream`
+/// 收到的窗口句柄直接搬进节流线程，重建后的桌宠就再也收不到鼠标位置，穿透永远无法
+/// 按命中区恢复——宠物会整窗吞掉输入。这里改由前端每次挂载时刷新共享句柄。
 #[derive(Default)]
 pub struct PetMouseStreamState {
     started: Arc<AtomicBool>,
+    emitter: Arc<Mutex<Option<WebviewWindow>>>,
 }
 
 /// 物理像素的光标位置（CGEvent 坐标为虚拟屏幕全局坐标，副屏可含负值）。
@@ -69,9 +75,13 @@ struct MouseCursorPos {
     y: f64,
 }
 
-/// 启动全局鼠标位置流（幂等：已启动时直接返回）。
+/// 启动全局鼠标位置流（幂等：已启动时只刷新接收窗口，不重复起线程）。
+///
+/// 命令参数带 `WebviewWindow`，Tauri 保证在主线程执行；`bind_pet_mouse_emitter`
+/// 只做一次短临界区的句柄替换，不阻塞事件循环。
 #[tauri::command]
 pub fn start_pet_mouse_stream(window: WebviewWindow, state: State<'_, PetMouseStreamState>) {
+    bind_pet_mouse_emitter(&state.emitter, window.clone());
     if state.started.swap(true, Ordering::SeqCst) {
         return;
     }
@@ -88,8 +98,9 @@ pub fn start_pet_mouse_stream(window: WebviewWindow, state: State<'_, PetMouseSt
         }
     });
 
-    // 节流线程：16ms 轮询最新坐标，变化才 emit（鼠标静止零事件）。
-    let emitter = window.clone();
+    // 节流线程：16ms 轮询最新坐标，变化才 emit（鼠标静止零事件）；每轮重新读取
+    // 接收窗口，保证窗口重建后事件仍然投递到桌宠。
+    let emitter = state.emitter.clone();
     thread::spawn(move || {
         let mut last_sent: Option<MouseCursorPos> = None;
         loop {
@@ -97,12 +108,24 @@ pub fn start_pet_mouse_stream(window: WebviewWindow, state: State<'_, PetMouseSt
             if let Some(pos) = current {
                 if last_sent != Some(pos) {
                     last_sent = Some(pos);
-                    let _ = emitter.emit(PET_MOUSE_MOVE_EVENT, pos);
+                    let target = emitter
+                        .lock()
+                        .unwrap_or_else(|error| error.into_inner())
+                        .clone();
+                    if let Some(target) = target {
+                        let _ = target.emit(PET_MOUSE_MOVE_EVENT, pos);
+                    }
                 }
             }
             thread::sleep(THROTTLE_INTERVAL);
         }
     });
+}
+
+/// 把鼠标事件接收窗口指向最新挂载的桌宠窗口（窗口重建后必须调用）。
+fn bind_pet_mouse_emitter(slot: &Arc<Mutex<Option<WebviewWindow>>>, window: WebviewWindow) {
+    let mut current = slot.lock().unwrap_or_else(|error| error.into_inner());
+    *current = Some(window);
 }
 
 /// 平台分发：macOS 走 CGEventTap，其它平台走 rdev。

--- a/src-tauri/src/desktop/pet_mouse.rs
+++ b/src-tauri/src/desktop/pet_mouse.rs
@@ -32,7 +32,7 @@
 //! - **Windows / Linux**：用 `rdev::listen`（这两平台 rdev 不调 TSM，无此 bug）。
 
 use serde::Serialize;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -62,10 +62,15 @@ const MACOS_MOUSE_EVENTS: &[core_graphics::event::CGEventType] = &[
 /// 新窗口（旧 handle 已失效，向它 emit 不会有任何效果）。若把 `start_pet_mouse_stream`
 /// 收到的窗口句柄直接搬进节流线程，重建后的桌宠就再也收不到鼠标位置，穿透永远无法
 /// 按命中区恢复——宠物会整窗吞掉输入。这里改由前端每次挂载时刷新共享句柄。
+///
+/// `revision` 同时是节流线程的去重复位信号：换窗口后必须**强制**补发一次位置，否则
+/// 光标静止时新页面收不到任何 `device-mouse-move`，穿透态停在「整窗接收事件」，
+/// 透明区域会吞掉点击（CodeRabbit review：force one cursor-state update after rebinding）。
 #[derive(Default)]
 pub struct PetMouseStreamState {
     started: Arc<AtomicBool>,
     emitter: Arc<Mutex<Option<WebviewWindow>>>,
+    revision: Arc<AtomicUsize>,
 }
 
 /// 物理像素的光标位置（CGEvent 坐标为虚拟屏幕全局坐标，副屏可含负值）。
@@ -78,10 +83,10 @@ struct MouseCursorPos {
 /// 启动全局鼠标位置流（幂等：已启动时只刷新接收窗口，不重复起线程）。
 ///
 /// 命令参数带 `WebviewWindow`，Tauri 保证在主线程执行；`bind_pet_mouse_emitter`
-/// 只做一次短临界区的句柄替换，不阻塞事件循环。
+/// 只做一次短临界区的句柄替换与一次原子自增，不阻塞事件循环。
 #[tauri::command]
 pub fn start_pet_mouse_stream(window: WebviewWindow, state: State<'_, PetMouseStreamState>) {
-    bind_pet_mouse_emitter(&state.emitter, window.clone());
+    bind_pet_mouse_emitter(&state.emitter, &state.revision, window);
     if state.started.swap(true, Ordering::SeqCst) {
         return;
     }
@@ -99,14 +104,20 @@ pub fn start_pet_mouse_stream(window: WebviewWindow, state: State<'_, PetMouseSt
     });
 
     // 节流线程：16ms 轮询最新坐标，变化才 emit（鼠标静止零事件）；每轮重新读取
-    // 接收窗口，保证窗口重建后事件仍然投递到桌宠。
+    // 接收窗口，保证窗口重建后事件仍然投递到桌宠。接收窗口换代（revision 变化）
+    // 时忽略去重，强制补发一次当前坐标——新页面需要一次事件才能算出穿透态。
     let emitter = state.emitter.clone();
+    let revision = state.revision.clone();
     thread::spawn(move || {
         let mut last_sent: Option<MouseCursorPos> = None;
+        let mut bound_revision = revision.load(Ordering::SeqCst);
         loop {
+            let current_revision = revision.load(Ordering::SeqCst);
+            let rebound = current_revision != bound_revision;
+            bound_revision = current_revision;
             let current = latest.lock().expect("pet mouse store poisoned").take();
             if let Some(pos) = current {
-                if last_sent != Some(pos) {
+                if rebound || last_sent != Some(pos) {
                     last_sent = Some(pos);
                     let target = emitter
                         .lock()
@@ -123,9 +134,17 @@ pub fn start_pet_mouse_stream(window: WebviewWindow, state: State<'_, PetMouseSt
 }
 
 /// 把鼠标事件接收窗口指向最新挂载的桌宠窗口（窗口重建后必须调用）。
-fn bind_pet_mouse_emitter(slot: &Arc<Mutex<Option<WebviewWindow>>>, window: WebviewWindow) {
+///
+/// 自增 `revision` 让节流线程知道「换了接收方」：即使光标没动、去重判定会跳过发送，
+/// 也必须补发一次位置，否则重建后的桌宠收不到任何鼠标事件、穿透态无法按命中区计算。
+fn bind_pet_mouse_emitter(
+    slot: &Arc<Mutex<Option<WebviewWindow>>>,
+    revision: &Arc<AtomicUsize>,
+    window: WebviewWindow,
+) {
     let mut current = slot.lock().unwrap_or_else(|error| error.into_inner());
     *current = Some(window);
+    revision.fetch_add(1, Ordering::SeqCst);
 }
 
 /// 平台分发：macOS 走 CGEventTap，其它平台走 rdev。

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,12 @@ import ReactDOM from 'react-dom/client'
 import { ToastProvider } from './components/toast-provider'
 import { queryClient } from './config/client'
 import { App } from './layout'
+import { disableWakeLock } from './utils/disable-wake-lock'
 import '@/utils/logger'
 import './style/main.css'
+
+// 渲染前先禁用屏幕唤醒锁：本应用无需屏幕常亮，任何 <video> 播放都会让系统无法息屏（issue #469）。
+disableWakeLock()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/pet/hooks/use-omit-ignore-cursor-events.ts
+++ b/src/pet/hooks/use-omit-ignore-cursor-events.ts
@@ -27,12 +27,12 @@ interface RustPetStatus {
  * 穿透切换一律经由 Rust 命令 `set_pet_ignore_cursor_events` 而非直接调用
  * `setIgnoreCursorEvents`：Linux / Wayland 下 tao 处理 `CursorIgnoreEvents(true)`
  * 时对底层 GdkWindow 直接 `unwrap()`（tao 0.35.3 event_loop.rs:457，上游截至
- * 0.37.0 未修复），窗口从未显示（未 realize）即 panic 崩掉整个桌面端。本应用
- * 在 setup 阶段总会预创建隐藏的 pet 窗口（`desktop::pet::init_pet_window`），
- * 全新安装默认不启用桌宠则窗口永远不 show，其 WebView 仍会收到首个全局鼠标
- * 事件并请求穿透——挂载即崩（issue #437）。Rust 侧对不可见窗口吞掉 `true`
- * 请求，前端再叠加一层：跟踪窗口可见性（`pet://status`），窗口隐藏时直接跳过
- * 穿透请求，避免对禁用桌宠的默认安装逐次移动鼠标都产生无效 IPC。
+ * 0.37.0 未修复），窗口从未显示（未 realize）即 panic 崩掉整个桌面端（issue #437）。
+ * Rust 侧对不可见窗口吞掉 `true` 请求；前端再叠加一层：跟踪窗口可见性
+ * （`pet://status`），窗口隐藏时直接跳过穿透请求，避免无效 IPC。
+ *
+ * 桌宠窗口只在「显示宠物」期间存在（收起即销毁，见 issue #469，本 hook 随页面
+ * 一起重挂载），因此启动时不再存在「永久隐藏窗口也会请求穿透」的路径。
  *
  * issue #394 的「延后到首个 device-mouse-move 再应用」仍然保留：避免挂载时
  * 立刻与事件循环竞争，但真正防止 panic 的是上面的两层可见性保护。

--- a/src/pet/main.tsx
+++ b/src/pet/main.tsx
@@ -1,10 +1,15 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { disableWakeLock } from '@/utils/disable-wake-lock'
 import { App } from './app'
 import './main.css'
 
 const root = document.getElementById('root') as HTMLElement
 root.className = 'h-full w-full'
+
+// 桌宠动画是常驻播放的 <video>：Chromium 会因此持有 Video Wake Lock，让系统无法息屏
+// （issue #469）。渲染前禁用屏幕唤醒锁，收起宠物/窗口隐藏时都不会再阻止息屏。
+disableWakeLock()
 
 // 禁用桌宠窗口右键菜单：桌宠窗口是装饰性的透明置顶小窗，右键不应弹出
 // WebView 默认 context menu（Chromium/WebView2 尊重 contextmenu 的 preventDefault）。

--- a/src/utils/disable-wake-lock.ts
+++ b/src/utils/disable-wake-lock.ts
@@ -1,16 +1,23 @@
 /**
- * 禁用 Screen Wake Lock（屏幕唤醒锁）。
+ * 禁用 Screen Wake Lock（页面可申请的「屏幕唤醒锁」）。
  *
- * 背景（issue #469）：桌宠窗口用 `<video>` 播放 WebM 动画，Chromium/WebView2 对
- * 「播放中（未暂停）的 video」**无条件**持有 Video Wake Lock——与窗口是否可见、
- * 是否 muted 都无关。锁一旦被持有，Windows 就无视「关闭显示器」超时，屏幕永远不黑
- * （且视频持续播放空占 CPU）。`收起宠物` 只是隐藏窗口，视频仍在播放，锁不会被释放。
+ * 背景（issue #469）：桌宠窗口用 `<video>` 播放 WebM 动画，播放期间系统无法息屏——
+ * Windows 无视「关闭显示器」超时，屏幕永远不黑，还长时间空占 CPU。
  *
- * 本应用没有任何「保持屏幕常亮」的正当需求（长任务进度靠 UI/通知表达，不靠锁屏），
- * 因此直接在 WebView 内把 `navigator.wakeLock.request` 换成永远 reject 的实现：
- * 页面（含 dsh 界面、第三方代码、内置插件）后续任何申请都会立刻失败，Chromium 因
- * 此不再持有屏幕唤醒锁。方法被替换（而非删除 API）可让页面拿到明确的 Error，
- * 避免 `TypeError: navigator.wakeLock.request is not a function` 这类误导性崩溃。
+ * # 这里挡的是哪把锁（两把锁不要混淆）
+ *
+ * 1. **Screen Wake Lock（本模块）**：页面经 `navigator.wakeLock.request('screen')`
+ *    主动申请的锁。任何页面代码（dsh 界面、第三方代码、内置插件）都能申请，本应用
+ *    没有任何常亮的正当需求，因此整体禁掉。
+ * 2. **Video Wake Lock（不由本模块负责）**：Chromium/WebView2 内部对「播放中
+ *    （未暂停）的 `<video>`」**无条件**申请的 `kPreventDisplaySleep`，与页面是否调用
+ *    wakeLock API、与 muted / 窗口可见性都无关。禁用本模块的 `navigator.wakeLock`
+ *    **不会**释放它——释放它的唯一办法是让视频停下来：`desktop::pet::set_pet_window_visible(false)`
+ *    会**销毁**桌宠窗口（而不是 hide），webview 随窗口消失，媒体管线一并停止（见
+ *    issue #469 的第二处修复）。`muted` 也不是解药：muted 只影响音频，不解除该锁。
+ *
+ * 之所以仍然保留本模块：它把「页面主动申请常亮」这条路径彻底封死，避免将来某个
+ * 页面（设置页、插件面板）再加一个与桌宠无关的常亮申请；成本只是一次方法替换。
  *
  * 幂等：两个入口（src/main.tsx 主窗口 / src/pet/main.tsx 桌宠窗口）都会调用，
  * 重复调用保留首次记录的原函数，恢复时不会把替换后的实现存成「原函数」。

--- a/src/utils/disable-wake-lock.ts
+++ b/src/utils/disable-wake-lock.ts
@@ -1,0 +1,58 @@
+/**
+ * 禁用 Screen Wake Lock（屏幕唤醒锁）。
+ *
+ * 背景（issue #469）：桌宠窗口用 `<video>` 播放 WebM 动画，Chromium/WebView2 对
+ * 「播放中（未暂停）的 video」**无条件**持有 Video Wake Lock——与窗口是否可见、
+ * 是否 muted 都无关。锁一旦被持有，Windows 就无视「关闭显示器」超时，屏幕永远不黑
+ * （且视频持续播放空占 CPU）。`收起宠物` 只是隐藏窗口，视频仍在播放，锁不会被释放。
+ *
+ * 本应用没有任何「保持屏幕常亮」的正当需求（长任务进度靠 UI/通知表达，不靠锁屏），
+ * 因此直接在 WebView 内把 `navigator.wakeLock.request` 换成永远 reject 的实现：
+ * 页面（含 dsh 界面、第三方代码、内置插件）后续任何申请都会立刻失败，Chromium 因
+ * 此不再持有屏幕唤醒锁。方法被替换（而非删除 API）可让页面拿到明确的 Error，
+ * 避免 `TypeError: navigator.wakeLock.request is not a function` 这类误导性崩溃。
+ *
+ * 幂等：两个入口（src/main.tsx 主窗口 / src/pet/main.tsx 桌宠窗口）都会调用，
+ * 重复调用保留首次记录的原函数，恢复时不会把替换后的实现存成「原函数」。
+ */
+
+/** 被替换掉的原生实现；仅用于测试恢复环境，业务代码不应调用。 */
+let originalRequest: WakeLock['request'] | undefined
+
+/**
+ * 标记「当前 request 已是本模块的禁用实现」。存在标记时直接跳过，使替换真正幂等
+ * （不会把替换实现再包一层），也让 restoreWakeLock 能区分原生实现与自己的补丁。
+ */
+const DISABLED_MARKER: unique symbol = Symbol.for('deepseek-harness.wakeLockDisabled') as typeof DISABLED_MARKER
+
+/** 打过补丁的 request：函数类型本身没有 symbol 键，用交叉类型描述这个运行时标记。 */
+type MarkedRequest = WakeLock['request'] & { [DISABLED_MARKER]?: boolean }
+
+/**
+ * 把 `navigator.wakeLock.request` 替换为必失败的实现（幂等）。
+ *
+ * 无 Wake Lock API 的环境（旧 WebView2 / 非浏览器）直接 no-op。
+ */
+export function disableWakeLock(): void {
+  if (typeof navigator === 'undefined' || !('wakeLock' in navigator) || navigator.wakeLock === undefined)
+    return
+  const wakeLock = navigator.wakeLock
+  if ((wakeLock.request as MarkedRequest)[DISABLED_MARKER] === true)
+    return
+  originalRequest ??= wakeLock.request.bind(wakeLock)
+  const request = function request(): Promise<WakeLockSentinel> {
+    return Promise.reject(new Error('WAKELOCK_DISABLED: screen wake lock is disabled by DeepSeek Harness Desktop'))
+  }
+  // 打标记后重复调用直接返回，替换不会被套娃；restoreWakeLock 也据此区分原生实现。
+  ;(request as MarkedRequest)[DISABLED_MARKER] = true
+  wakeLock.request = request
+}
+
+/** 恢复原生实现并清理记录；仅供测试，业务代码不需要。 */
+export function restoreWakeLock(): void {
+  if (originalRequest === undefined)
+    return
+  if (typeof navigator !== 'undefined' && 'wakeLock' in navigator && navigator.wakeLock !== undefined)
+    navigator.wakeLock.request = originalRequest
+  originalRequest = undefined
+}

--- a/test/disable-wake-lock.test.ts
+++ b/test/disable-wake-lock.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import type { Mock } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { disableWakeLock, restoreWakeLock } from '../src/utils/disable-wake-lock'
+
+/**
+ * 原生 `navigator.wakeLock.request` 的替身：默认放行并返回一个哨兵对象，
+ * `acquire` 记录调用次数，用来证明「禁用后页面再也拿不到唤醒锁」而不是只看抛不抛错。
+ */
+function createWakeLockStub() {
+  const request = vi.fn((type: WakeLockType) => Promise.resolve({ type, release: vi.fn() })) as Mock<WakeLock['request']>
+  Object.defineProperty(navigator, 'wakeLock', {
+    configurable: true,
+    // 赋值断言：Node 环境没有原生 WakeLock 实现，这里用替身顶上
+    value: { request },
+    writable: true,
+  })
+  return request
+}
+
+function removeWakeLock() {
+  Reflect.deleteProperty(navigator, 'wakeLock')
+}
+
+describe('disableWakeLock', () => {
+  beforeEach(() => {
+    removeWakeLock()
+  })
+
+  afterEach(() => {
+    restoreWakeLock()
+    removeWakeLock()
+  })
+
+  it('rejects every screen wake lock request so the screen can sleep again', async () => {
+    const native = createWakeLockStub()
+    disableWakeLock()
+
+    await expect(navigator.wakeLock.request('screen')).rejects.toThrow('WAKELOCK_DISABLED')
+    // 关键回归点：不只是抛错，原生的加锁入口必须一次都没被走到。
+    expect(native).not.toHaveBeenCalled()
+  })
+
+  it('rejects system wake lock requests as well', async () => {
+    const native = createWakeLockStub()
+    disableWakeLock()
+
+    await expect(navigator.wakeLock.request('system')).rejects.toThrow('WAKELOCK_DISABLED')
+    expect(native).not.toHaveBeenCalled()
+  })
+
+  it('leaves the sentinel released state unreachable (no lock is ever handed out)', async () => {
+    createWakeLockStub()
+    disableWakeLock()
+
+    const acquired = await navigator.wakeLock.request('screen').catch((error: unknown) => error)
+    expect(acquired).toBeInstanceOf(Error)
+    // 唤醒锁不该以「返回了对象」的形式静默生效；页面拿到的只能是 Error。
+    expect(acquired).not.toHaveProperty('release')
+  })
+
+  it('is idempotent across both entry points and never chains its own override', async () => {
+    const native = createWakeLockStub()
+    disableWakeLock()
+    const patched = navigator.wakeLock.request
+    disableWakeLock()
+
+    expect(navigator.wakeLock.request).toBe(patched)
+    restoreWakeLock()
+    // 恢复后必须能真正加锁：重复调用若把替换实现记成「原函数」，这里就会永远 reject。
+    await expect(navigator.wakeLock.request('screen')).resolves.toBeDefined()
+    expect(native).toHaveBeenCalledOnce()
+  })
+
+  it('is a no-op when the environment has no Wake Lock API', () => {
+    expect(() => disableWakeLock()).not.toThrow()
+    expect(() => restoreWakeLock()).not.toThrow()
+  })
+})
+
+describe('pet window wake lock contract', () => {
+  /**
+   * 桌宠窗口是常驻播放的 WebView：只要动画 `<video>` 没被禁用唤醒锁，系统就无法息屏
+   * （issue #469）。这里锁死两个入口都调用了 disableWakeLock，避免将来只改一个入口。
+   */
+  it('disables the wake lock in both window entries', () => {
+    const mainSource = readFileSync(new URL('../src/main.tsx', import.meta.url), 'utf8')
+    const petSource = readFileSync(new URL('../src/pet/main.tsx', import.meta.url), 'utf8')
+
+    expect(mainSource).toContain('disableWakeLock()')
+    expect(petSource).toContain('disableWakeLock()')
+  })
+
+  it('keeps every pet animation video muted', () => {
+    const source = readFileSync(new URL('../src/pet/components/pet.tsx', import.meta.url), 'utf8')
+    const videos = source.match(/<video[\s\S]*?\/>/g) ?? []
+
+    // 双 video 缓冲（前台/后台）各一个；两个都不能出声，否则桌宠动画会突然发声。
+    expect(videos).toHaveLength(2)
+    for (const video of videos)
+      expect(video).toMatch(/\bmuted\b/)
+  })
+})

--- a/test/pet-window-lifecycle.test.ts
+++ b/test/pet-window-lifecycle.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * 桌宠窗口生命周期契约（issue #469）。
+ *
+ * 「收起宠物」必须是**销毁窗口**而不是 hide：隐藏只是把窗口从屏幕上撤下，WebView 与
+ * 页面都还在，桌宠的 `<video>` 继续解码播放——Chromium/WebView2 对「播放中（未暂停）
+ * 的 video」无条件持有 Video Wake Lock，屏幕永远无法息屏，且白占 CPU。这些用例把
+ * 该语义锁在源码层面：Rust 侧一旦退回 `hide()` 或重新预创建隐藏窗口，测试即失败。
+ */
+function readSource(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+}
+
+/** 截取指定函数体的源码（从 ` fn name` 起，到下一个顶层 `}` 后换行 + 空行为止）。 */
+function functionBody(source: string, name: string): string {
+  const start = source.indexOf(`pub fn ${name}`)
+  expect(start, `expected to find fn ${name}`).toBeGreaterThan(-1)
+  const rest = source.slice(start)
+  const end = rest.indexOf('\n}\n')
+  return end === -1 ? rest : rest.slice(0, end)
+}
+
+describe('pet window collapse (destroy, not hide)', () => {
+  const petWindow = readSource('../src-tauri/src/desktop/pet.rs')
+
+  it('destroys the pet webview window instead of hiding it', () => {
+    const body = functionBody(petWindow, 'set_pet_window_visible')
+
+    expect(body).toContain('.destroy()')
+    expect(body).not.toContain('.hide()')
+    // 隐藏分支必须先把已存在的窗口销毁，不能在窗口缺失时静默成功（那会留下
+    // 「状态说已收起、窗口其实还在」的假象）。
+    expect(body).toContain('PET_WINDOW_DESTROY_FAILED')
+  })
+
+  it('never creates a hidden pet window while the pet is disabled', () => {
+    const body = functionBody(petWindow, 'init_pet_window')
+
+    // 未启用直接返回，不建窗口：没人看的 webview 同样会加载 pet.html 播放动画。
+    expect(body).toContain('pet_enabled')
+    expect(body).not.toContain('ensure_pet_window')
+    expect(body).not.toContain('.hide()')
+  })
+})
+
+describe('pet window collapse state sync', () => {
+  const bridge = readSource('../src-tauri/src/bridge/pet.rs')
+
+  it('collapses transient visibility and the host session stream together', () => {
+    const body = functionBody(bridge, 'collapse_pet')
+
+    // 销毁窗口之外还要落瞬态可见性与会话流，否则侧栏图标仍显示「已激活」、
+    // 宿主侧还会持续为桌宠推送会话数据。
+    expect(body).toContain('visible = false')
+    expect(body).toContain('set_pet_window_visible(app, false)')
+    expect(body).toContain('sync_pet_session_stream(app, false)')
+  })
+
+  it('routes the window close request through the same collapse path', () => {
+    const builder = readSource('../src-tauri/src/desktop/builder.rs')
+
+    expect(builder).toContain('collapse_pet(&handle)')
+  })
+})
+
+describe('recreated pet window keeps its mouse stream', () => {
+  const mouse = readSource('../src-tauri/src/desktop/pet_mouse.rs')
+
+  it('rebinds the global mouse emitter to the window that just mounted', () => {
+    // 窗口销毁重建后旧句柄失效：若节流线程一直握着旧窗口，重建后的桌宠收不到
+    // 鼠标位置，点击穿透就再也无法按命中区恢复。
+    expect(mouse).toContain('bind_pet_mouse_emitter')
+    expect(mouse).toContain('state.emitter.clone()')
+  })
+})

--- a/test/pet-window-lifecycle.test.ts
+++ b/test/pet-window-lifecycle.test.ts
@@ -75,4 +75,11 @@ describe('recreated pet window keeps its mouse stream', () => {
     expect(mouse).toContain('bind_pet_mouse_emitter')
     expect(mouse).toContain('state.emitter.clone()')
   })
+
+  it('forces one cursor update after a rebind, even without cursor movement', () => {
+    // 去重（last_sent）会跳过「光标没动」的发送：换窗口后若不强制补发一次，
+    // 新页面收不到任何 device-mouse-move，穿透态停在整窗接收事件，透明区域吞点击。
+    expect(mouse).toContain('revision.fetch_add')
+    expect(mouse).toContain('rebound')
+  })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
       'test/toast.test.ts',
       // issue #469：桌面端不得持有屏幕唤醒锁（桌宠 <video> 会间接加锁，导致无法息屏）。
       'test/disable-wake-lock.test.ts',
+      // issue #469：收起桌宠必须是销毁窗口（隐藏窗口里的视频仍在播放并持锁）。
+      'test/pet-window-lifecycle.test.ts',
     ],
     maxWorkers: 4,
     testTimeout: 30_000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vitest/config'
 
 /**
- * 根测试配置：运行内置插件（packages/**）及 toast 生命周期回归测试，限制并发 worker 数与放宽超时。
+ * 根测试配置：运行内置插件（packages/**）及壳层状态机/入口契约回归测试，
+ * 限制并发 worker 数与放宽超时。
  *
- * 仓库根还 vendored 了 dsh 核心源码（src/、source/、test/），其测试依赖 dsh 核心
- * 的 `@/` paths 解析（在插件 workspace 的 vitest 下不可用），故 exclude 出本范围。
+ * 仓库根还 vendored 了 dsh 核心源码（source/ 与 test/ 下的部分用例），其测试依赖
+ * dsh 核心的 `@/` paths 解析（在插件 workspace 的 vitest 下不可用），故 exclude 出
+ * 本范围；壳层自身的用例按文件显式列入 include。
  *
  * dsh-tauri-worktree 的 operation.test 会创建真实 git 仓库（clone/checkout/
  * discard），全量并行（默认 cpu-1 个 worker）时与其他文件的 git 操作竞争系统
@@ -12,7 +14,12 @@ import { defineConfig } from 'vitest/config'
  */
 export default defineConfig({
   test: {
-    include: ['packages/**/*.{test,spec}.{ts,tsx,js,mjs,cjs}', 'test/toast.test.ts'],
+    include: [
+      'packages/**/*.{test,spec}.{ts,tsx,js,mjs,cjs}',
+      'test/toast.test.ts',
+      // issue #469：桌面端不得持有屏幕唤醒锁（桌宠 <video> 会间接加锁，导致无法息屏）。
+      'test/disable-wake-lock.test.ts',
+    ],
     maxWorkers: 4,
     testTimeout: 30_000,
     hookTimeout: 30_000,


### PR DESCRIPTION
## 问题

Chromium/WebView2 对「播放中（未暂停）的 `<video>`」**无条件**持有 Video Wake Lock——与窗口是否可见、是否 `muted` 都无关。桌宠窗口常驻播放 WebM 动画，于是：

1. Windows 无视「关闭显示器」超时，屏幕永远不黑；
2. `收起宠物` 只是隐藏窗口，视频仍在背后播放，锁不释放；
3. 视频长时间空占 CPU。

## 改动（#469 建议的两种方案一起）

- **禁用屏幕唤醒锁**：新增 `src/utils/disable-wake-lock.ts`，把 `navigator.wakeLock.request` 替换成永远 reject 的幂等实现（`screen`/`system` 都拒绝）。方法被替换而非删除 API，页面拿到的是明确的 `Error`，不会出现 `navigator.wakeLock.request is not a function` 这类误导性崩溃。
- **两个入口都在渲染前调用**：`src/main.tsx`（主窗口）与 `src/pet/main.tsx`（桌宠窗口）各自 `disableWakeLock()`；桌宠窗口是问题源头，主窗口一并防住 dsh 界面/插件的申请。
- **`<video muted>`**：桌宠双 video 缓冲原本已带 `muted`，本次用测试把它锁死（结合上一条，动画不再持锁也不会出声）。

## 测试

`test/disable-wake-lock.test.ts`（已加入根 `vitest.config.ts` 的 `include`，CI 的 `pnpm test` 会执行）：

- `navigator.wakeLock.request('screen'/'system')` 必 reject，且**原生加锁入口一次都不会被调用**（不只是看抛不抛错）；
- 页面拿不到 sentinel，即唤醒锁不会以「返回对象」的形式静默生效；
- 幂等：重复调用不套娃，`restoreWakeLock()` 后能真正加锁；
- 无 Wake Lock API 的环境是 no-op；
- 契约：两个入口都调用了 `disableWakeLock()`，桌宠两个 `<video>` 都保持 `muted`。

## 验证

- `pnpm exec vitest run test/disable-wake-lock.test.ts` → 7 passed
- `pnpm exec eslint <改动文件>` → 0 problem
- `pnpm run typecheck` 中改动文件 0 error
- `pnpm exec vite build` 通过，产物中两个入口都引入了该模块

Fixes #469

## 追加改动：收起宠物 = 销毁窗口（不再 hide）

`hide()` 只是把窗口从屏幕上撤下：WebView 进程与页面都还在，桌宠的双 `<video>` 继续解码播放，Chromium/WebView2 因此**无条件持有 Video Wake Lock**，屏幕永远无法息屏，还白占 CPU。所以「收起」必须销毁窗口实例：

- `desktop/pet.rs`：`set_pet_window_visible(false)` → `window.destroy()`。`destroy()` 是非阻塞的事件投递（`proxy.send_event(Message::Destroy)`，任何线程安全）；窗口创建仍只发生在非主线程——`tauri-runtime-wry` 的 `create_window` 经 channel 等主线程回包，**主线程调用必然死锁**，因此 `show_pet` / `set_pet_enabled` 保持 `AppHandle` 命令（异步运行时执行），`hide_pet` 与窗口关闭事件只走 destroy。
- `desktop/pet.rs`：`init_pet_window` 在未启用时**不再预创建隐藏窗口**（没人看的 webview 同样会加载 pet.html 播放动画）。
- `bridge/pet.rs`：抽出 `collapse_pet`（销毁窗口 + 置瞬态 `visible=false` + 停宿主会话流订阅），`hide_pet` 复用它；`show_pet` / `set_pet_enabled(true)` 按需重建窗口。
- `desktop/pet_mouse.rs`：鼠标事件接收窗口改成共享槽 + 前端每次挂载刷新句柄。窗口重建后旧 handle 失效，否则桌宠收不到 `device-mouse-move`，点击穿透永远无法按命中区恢复（宠物会整窗吞掉输入）。
- `desktop/builder.rs`：桌宠窗口自身的关闭请求（Alt+F4 等）走同一条 `collapse_pet` 路径。
- 新增 `test/pet-window-lifecycle.test.ts`：锁死「销毁而非 hide」「未启用不建窗口」「收起同步瞬态与会话流」「窗口重建后鼠标流重绑」四条契约。

**验证**：`cargo test --all-features --locked` → 524 passed；`cargo check` 无新增 warning；新增前端用例通过；`eslint` / `typecheck` 改动文件 0 error。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Collapsing the pet now fully closes its window, releasing video resources and allowing it to be recreated when shown again.
  - Closing the pet through the system close action now follows the same collapse behavior.
  - Mouse interactions continue working correctly after the pet is reopened.
  - Pet animations no longer prevent the device from sleeping by requesting a screen wake lock.

- **Tests**
  - Added coverage for pet window lifecycle and wake-lock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->