### PR TITLE
fix(pet): macOS 预设桌宠改用 HEVC-with-Alpha MOV，修复黑底（#434）

### DIFF
--- a/packages/dsh-tauri-pet/README.md
+++ b/packages/dsh-tauri-pet/README.md
@@ -11,9 +11,13 @@ DeepSeek Harness 的桌宠插件。它在设置页提供 `Pets` 与 `Codex` 两�
   `/hatch-dsh-pet 根据你对我的了解，养一只宠物`，不会自动提交。
 - **Codex**：显示 Codex 来源（`~/.codex/pets`）的宠物卡片；工具栏只有
   **Import**，用于导入 `.zip` 资源包。
-- 预设宠物媒体（WebM / GIF / config.jsonc）不再随本包内置：用户在设置页
+- 预设宠物媒体（WebM / MOV / GIF / config.jsonc）不再随本包内置：用户在设置页
   「下载」后安装到 `~/.dsh/pets/<id>`，桌宠窗口按 `config.jsonc` 的动画池
-  （动画名 = webm 文件名主名）直接播放下载产物，无运行时回退。
+  （动画名 = 动画文件名主名）直接播放下载产物，无运行时回退。
+  macOS 的 WKWebView 不认 VP9-alpha WebM（alpha 被丢弃、透明区域渲染成黑色，
+  issue #434），因此 macOS 按清单 `platforms.macos` 改从
+  [`dsh-tauri-desk/dsh-pet-mov`](https://github.com/dsh-tauri-desk/dsh-pet-mov)
+  只下载 `config.jsonc` + `mov/`（HEVC-with-Alpha），其余平台继续用上游 WebM。
 - 宠物大小滑条保持 50–200%，默认 100%。侧栏绿色圆点表示窗口当前 **visible** 状态，
   而不是只表示持久化的 `enabled` 状态。首次点击会永久启用；之后只显示或隐藏窗口，
   不会因隐藏而写入 `enabled=false`。
@@ -57,7 +61,7 @@ skill provider 或默认根目录。
 | `download_preset_pet` | 后台下载并安装预设宠物 |
 | `get_preset_download_progress` | 轮询预设宠物下载/解压进度 |
 | `get_preset_pet_config` | 读取已安装预设的 `config.jsonc`（dsh-pet 协议，校验后返回） |
-| `get_preset_pet_assets` | 列出已安装预设的 WebM URL manifest（dsh-pet 协议按需流式提供） |
+| `get_preset_pet_assets` | 列出已安装预设的动画 URL manifest（WebM 或 macOS 的 HEVC MOV，dsh-pet 协议按需流式提供） |
 | `import_pet` | 导入 Codex `.zip` 资源包 |
 | `set_pet_activity` | 更新 `idle`、`turn`、`moving-left`、`moving-right`、`waving`、`waiting`、`running`、`review` 或 `failed` |
 

--- a/packages/dsh-tauri-pet/docs/sync-log.md
+++ b/packages/dsh-tauri-pet/docs/sync-log.md
@@ -20,6 +20,30 @@
 
 ## 同步记录
 
+### 2026 —— 修复 macOS 预设宠物黑底（issue #434，分支 `fix/434-macos-hevc-alpha-mov-pet`）
+
+不是上游同步，而是**素材编码格式**在 macOS 上不可用导致的黑底，记录在此以便后续核对素材来源。
+
+- **现象**：macOS 启用预设桌宠后，宠物是一个黑色矩形（透明区域全黑），Windows/Chromium 正常，且无任何 error 事件。
+- **根因**：预设宠物走 `<video>` 播放 VP9-alpha WebM，而 WKWebView（WebKit）解码时**直接丢弃 alpha 平面**
+  并按不透明渲染（[WebKit #64837](https://github.com/WebKit/WebKit/pull/64837) 2026 才合入）。窗口/WebView/CSS
+  透明链路与 Tauri 均无问题，黑底是视频像素层。Safari 原生支持的透明视频是 **HEVC-with-Alpha**
+  （`AVVideoCodecType.hevcWithAlpha`，`hvc1`），而该编码器只有 macOS 有。
+- **素材侧**：新建 [`dsh-tauri-desk/dsh-pet-mov`](https://github.com/dsh-tauri-desk/dsh-pet-mov)，
+  用 GitHub Actions 的 macOS runner 把上游 `dsh-pet/assets/webm` 批量转码为 `mov/*.mov`
+  （`ffmpeg -pix_fmt bgra` 解码 → `swift hevc_alpha_encoder.swift` 编码），
+  仓库**只保留 `config.jsonc` 与 `mov/`**（113 个 mov，约 79 MiB）。流水线按周跟随上游 `main` 重编，
+  产物由机器人提交回该仓库；桌面端以 codeload tarball 下载，不需要 Release。
+- **桌面侧**：
+  - `preset-pets.json` 新增 `platforms` 覆盖块：`macos` 换 `repo` = `dsh-tauri-desk/dsh-pet-mov`、
+    `ref` = 该仓库已生成的提交、`assets` = `""`（仓库根即素材）、`sizeMb` = 79；其余平台不变。
+  - `preset_pet.rs`：`read_platform_catalog` 按 `std::env::consts::OS` 并回覆盖块；
+    解压层支持**空前缀**（整个仓库即素材，仍需剥掉 `<repo>-<ref>/` 与安全校验）；
+    协议层放开 `mov/` 子目录与 `.mov` 扩展名，MIME 为 `video/quicktime`（WKWebView 才交给 AVFoundation）；
+    `get_preset_pet_assets` 改为按 `mov/` → `webm/` 的优先级选源（文件名主名与 `config.jsonc`
+    池条目一致，前端无需感知格式）。macOS 用户升级后清单 `ref` 变化会触发设置页的「更新」入口，
+    更新即从 webm 安装切到 mov 安装。
+
 ### 2026 —— 修复「会话被用户中止后 toast 与动画一直持续」（分支 `fix/pet-abort-hang`）
 
 不是上游同步，而是宿主收尾信号缺失导致的桌宠挂死，记录在此以便后续核对收尾语义。
@@ -231,6 +255,9 @@ PR #414、#415 的 GitHub CI 均已通过。
 1. 获取参考仓库最新版本与提交：`git -C source/dsh-pet fetch origin && git -C source/dsh-pet log --oneline e1ff8c1..origin/main`（dsh-dafeiyu 同理）。
 2. 若 dsh-pet 有新版本：评估影响面（`src/shared/work-status.ts`、`src/host/work-status.ts`、client 轮询、资产入库 commit），
    确认新 WebM/config 字段后升级 `preset-pets.json` 的 ref。
+   - 同时确认 `platforms.macos` 的 `ref` 是否要跟到 dsh-pet-mov 的新产物 commit
+     （该仓库按周跟随上游 `main` 重编并把 mov 提交回自己的 `main`；两边 ref 都要升，
+     否则 macOS 会停在旧动画集；该仓库无需 Release，桌面端直接下 codeload tarball）。
 3. 先更新本文件「同步基线」和「待同步」，再修改 host/client 实现。
 4. 同步协议时同时检查：
    - `src-tauri/resources/preset-pets.json`

--- a/src-tauri/resources/preset-pets.json
+++ b/src-tauri/resources/preset-pets.json
@@ -7,6 +7,14 @@
     "repo": "https://github.com/PC2005-cloud/dsh-pet",
     "ref": "e1ff8c1e4001878cbb80441262d530e16541f138",
     "assets": "dsh-pet/assets",
-    "sizeMb": 113
+    "sizeMb": 113,
+    "platforms": {
+      "macos": {
+        "repo": "https://github.com/dsh-tauri-desk/dsh-pet-mov",
+        "ref": "be0f3bb494cb71a4c73f916c0b92d25a3ab4d002",
+        "assets": "",
+        "sizeMb": 79
+      }
+    }
   }
 ]

--- a/src-tauri/src/bridge/preset_pet.rs
+++ b/src-tauri/src/bridge/preset_pet.rs
@@ -15,6 +15,12 @@
 //!
 //! 安全约束与 `import_pet` 同一纪律：拒绝 traversal/绝对路径/反斜杠/冒号、
 //! symlink/特殊条目、条目数/单文件/总量上限、全局互斥串行、staging 原子安装。
+//!
+//! 平台差异（issue #434）：macOS 的 WKWebView 解码 VP9-alpha WebM 时会丢弃 alpha
+//! 平面，透明区域渲染成不透明黑色且不触发 error 事件。因此 macOS 通过清单 `platforms`
+//! 覆盖块改从 `dsh-tauri-desk/dsh-pet-mov`（只保留 `config.jsonc` + `mov/`）下载
+//! HEVC-with-Alpha `.mov`，其余平台继续用上游 WebM；协议层同时接受 `mov/` 子目录与
+//! `.mov` 扩展名，`get_preset_pet_assets` 按目录存在性自动选源。
 
 use crate::config;
 use crate::desktop::pet as pet_window;
@@ -49,7 +55,7 @@ const PET_PRESET_USER_AGENT: &str =
 
 /// 清单条目（`resources/preset-pets.json` 的一个元素）。
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct PresetPetSpec {
     id: String,
     name: String,
@@ -68,6 +74,59 @@ struct PresetPetSpec {
     /// 下载尺寸（MiB，用于卡片上的 `[number]mb` 标签）。
     #[serde(default)]
     size_mb: Option<f64>,
+    /// 按平台覆盖素材来源，键为 `std::env::consts::OS`（如 `macos`）。
+    /// 当前平台命中时在 `read_preset_catalog` 里并回基础条目（见 issue #434：
+    /// macOS 的 WKWebView 不认 VP9-alpha WebM，改从 HEVC-with-Alpha 仓库下载）。
+    #[serde(default)]
+    platforms: HashMap<String, PresetPetPlatformOverride>,
+}
+
+/// 平台覆盖块（`PresetPetSpec::platforms` 的一项）：只写需要改的字段，其余继承基础条目。
+///
+/// 两个结构都 `deny_unknown_fields`：清单随安装包分发，字段名写错（如 `sizeMB`）必须
+/// 立刻报 `PET_PRESET_CATALOG_INVALID`，而不是被 serde 静默忽略后沿用基础取值。
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PresetPetPlatformOverride {
+    #[serde(default)]
+    desc: Option<String>,
+    /// 浏览图 URL；macOS 移植仓库只保留 `config.jsonc` + `mov/`，覆盖时可指向原仓库预览图。
+    #[serde(default)]
+    image: Option<String>,
+    #[serde(default)]
+    repo: Option<String>,
+    #[serde(default)]
+    assets: Option<String>,
+    #[serde(default)]
+    r#ref: Option<String>,
+    #[serde(default)]
+    size_mb: Option<f64>,
+}
+
+/// 并回当前平台的覆盖块（`platform` 为 `std::env::consts::OS` 的值）。
+/// 没有该平台的键时原样返回；覆盖块里没写的字段保持基础条目取值。
+fn apply_platform_override(spec: &mut PresetPetSpec, platform: &str) {
+    let Some(overrides) = spec.platforms.remove(platform) else {
+        return;
+    };
+    if let Some(value) = overrides.desc {
+        spec.desc = Some(value);
+    }
+    if let Some(value) = overrides.image {
+        spec.image = Some(value);
+    }
+    if let Some(value) = overrides.repo {
+        spec.repo = value;
+    }
+    if let Some(value) = overrides.assets {
+        spec.assets = value;
+    }
+    if let Some(value) = overrides.r#ref {
+        spec.r#ref = Some(value);
+    }
+    if let Some(value) = overrides.size_mb {
+        spec.size_mb = Some(value);
+    }
 }
 
 /// 已安装预设宠物的版本记录文件名（安装目录根下，记录安装时的 ref）。
@@ -164,6 +223,15 @@ fn read_preset_catalog(app: &AppHandle) -> Result<Vec<PresetPetSpec>, String> {
     serde_json::from_slice(&bytes).map_err(|error| {
         format!("PET_PRESET_CATALOG_INVALID: invalid preset-pets.json: {error}")
     })
+}
+
+/// 读取清单并套用当前平台的覆盖块（macOS 换 HEVC-with-Alpha 素材仓库，见 #434）。
+fn read_platform_catalog(app: &AppHandle, platform: &str) -> Result<Vec<PresetPetSpec>, String> {
+    let mut catalog = read_preset_catalog(app)?;
+    for spec in &mut catalog {
+        apply_platform_override(spec, platform);
+    }
+    Ok(catalog)
 }
 
 /// 预设宠物安装根目录：与 Chat 宠物共用 DSH 数据目录（`~/.dsh/pets` / `~/.dsh.dev/pets`）。
@@ -487,8 +555,15 @@ fn extract_preset_assets_with_progress(
         let _root = components.next(); // `<repo>-<ref>/` 根目录
         let relative = components.as_path();
         // 只接受 assets 前缀下的条目；根目录条目与仓库其它文件跳过。
-        let Ok(relative) = relative.strip_prefix(prefix_path) else {
-            continue;
+        // 空前缀（`assets: ""`）表示整个仓库就是素材（如 dsh-pet-mov 只保留
+        // `config.jsonc` + `mov/`），此时不做前缀过滤。
+        let relative = if prefix.is_empty() {
+            relative
+        } else {
+            let Ok(relative) = relative.strip_prefix(prefix_path) else {
+                continue;
+            };
+            relative
         };
         if relative.as_os_str().is_empty() {
             continue; // assets 目录本身的条目
@@ -732,7 +807,7 @@ async fn run_preset_download(app: &AppHandle, spec: PresetPetSpec, replace: bool
 /// 列出预设宠物清单（含安装状态与版本更新提示）。
 #[tauri::command]
 pub fn list_preset_pets(app: AppHandle) -> Result<Vec<PresetPetListItem>, String> {
-    let catalog = read_preset_catalog(&app)?;
+    let catalog = read_platform_catalog(&app, std::env::consts::OS)?;
     let root = preset_pets_root(&app);
     let mut items = Vec::with_capacity(catalog.len());
     let mut ids = HashSet::new();
@@ -770,7 +845,7 @@ pub fn list_preset_pets(app: AppHandle) -> Result<Vec<PresetPetListItem>, String
 #[tauri::command]
 pub fn download_preset_pet(app: AppHandle, id: String) -> Result<(), String> {
     let id = id.trim().to_string();
-    let catalog = read_preset_catalog(&app)?;
+    let catalog = read_platform_catalog(&app, std::env::consts::OS)?;
     let spec = catalog
         .into_iter()
         .find(|entry| entry.id == id)
@@ -825,7 +900,7 @@ pub fn download_preset_pet(app: AppHandle, id: String) -> Result<(), String> {
 #[tauri::command]
 pub fn update_preset_pet(app: AppHandle, id: String) -> Result<(), String> {
     let id = id.trim().to_string();
-    let catalog = read_preset_catalog(&app)?;
+    let catalog = read_platform_catalog(&app, std::env::consts::OS)?;
     let spec = catalog
         .into_iter()
         .find(|entry| entry.id == id)
@@ -948,10 +1023,13 @@ fn percent_decode_segment(value: &str) -> Result<String, String> {
         .map_err(|_| "PET_PRESET_ASSET_PATH_INVALID: asset name is not valid UTF-8".to_string())
 }
 
-/// 已安装预设宠物目录下的受控相对路径（webm/ 或 preview/ 单层子目录内）。
+/// 已安装预设宠物目录下的受控相对路径（webm/、mov/ 或 preview/ 单层子目录内）。
+///
+/// `mov/` 只出现在 macOS：WKWebView 不认 VP9-alpha WebM（alpha 平面被 parser 丢弃，
+/// 透明区域渲染成黑色且无 error 事件），改播 HEVC-with-Alpha `.mov`（issue #434）。
 fn resolve_preset_asset(app: &AppHandle, id: &str, subdir: &str, name: &str) -> Result<PathBuf, String> {
-    if !matches!(subdir, "webm" | "preview") {
-        return Err("PET_PRESET_ASSET_PATH_INVALID: subdir must be webm or preview".to_string());
+    if !matches!(subdir, "webm" | "mov" | "preview") {
+        return Err("PET_PRESET_ASSET_PATH_INVALID: subdir must be webm, mov or preview".to_string());
     }
     let root = preset_pets_root(app);
     let dir = installed_dir(&root, id);
@@ -1011,6 +1089,18 @@ fn preset_asset_path(path: &str) -> Option<(&str, &str, &str)> {
     Some((id, subdir, name))
 }
 
+/// 预设媒体扩展名 → Content-Type；同时充当扩展名白名单（None = 拒绝该资源）。
+/// `.mov` 必须是 `video/quicktime`：WKWebView 交给 AVFoundation 解码 HEVC-with-Alpha
+/// （`hvc1`）时才认得 alpha 通道。
+fn preset_asset_mime(name: &str) -> Option<&'static str> {
+    match name.rsplit_once('.').map(|(_, extension)| extension) {
+        Some("webm") => Some("video/webm"),
+        Some("mov") => Some("video/quicktime"),
+        Some("gif") => Some("image/gif"),
+        _ => None,
+    }
+}
+
 /// 为 dsh-pet 自定义协议读取已安装预设宠物的媒体文件；调用方已在 builder 限制为 pet WebView。
 /// 与旧内置协议同一安全纪律：webview 白名单 + GET/HEAD + 路径三层解析 + canonicalize
 /// 包含性校验 + 符号链接拒绝 + 单文件大小上限 + Range 单字节区间。
@@ -1037,11 +1127,12 @@ pub fn preset_pet_asset_response(
     let Ok(relative) = safe_relative_path(&name) else {
         return protocol_error(StatusCode::FORBIDDEN, "PET_PRESET_ASSET_PATH_INVALID: asset name is not a safe relative path");
     };
-    if relative.components().count() != 1
-        || !matches!(name.rsplit_once('.').map(|(_, ext)| ext), Some("webm" | "gif"))
-    {
-        return protocol_error(StatusCode::FORBIDDEN, "PET_PRESET_ASSET_PATH_INVALID: asset must be a single webm/gif file");
+    if relative.components().count() != 1 {
+        return protocol_error(StatusCode::FORBIDDEN, "PET_PRESET_ASSET_PATH_INVALID: asset must be a single file");
     }
+    let Some(mime) = preset_asset_mime(&name) else {
+        return protocol_error(StatusCode::FORBIDDEN, "PET_PRESET_ASSET_PATH_INVALID: asset must be a single webm/mov/gif file");
+    };
     let path = match resolve_preset_asset(app, id, subdir, &name) {
         Ok(path) => path,
         Err(error) => return protocol_error(StatusCode::NOT_FOUND, &error),
@@ -1052,7 +1143,6 @@ pub fn preset_pet_asset_response(
     let Ok(length) = file.metadata().map(|metadata| metadata.len()) else {
         return protocol_error(StatusCode::NOT_FOUND, "PET_PRESET_ASSET_READ_FAILED: asset metadata unavailable");
     };
-    let mime = if name.ends_with(".webm") { "video/webm" } else { "image/gif" };
     let base = Response::builder()
         .header("Content-Type", mime)
         .header("Accept-Ranges", "bytes");
@@ -1109,8 +1199,54 @@ fn parse_single_byte_range(value: &str, length: u64) -> Option<(u64, u64)> {
     (end >= start).then_some((start, end))
 }
 
-/// 列出已安装预设宠物的全部媒体（webm 动画 + preview 首张 gif 兜底图）。
-/// 池条目（config.jsonc 里的动画名）即 webm 文件名主名，与 dsh-pet 协议一致。
+/// 动画子目录候选：(目录名, 扩展名)，按优先级排列。
+///
+/// macOS 安装的是仓库 [dsh-tauri-desk/dsh-pet-mov] 的 HEVC-with-Alpha `mov/`，
+/// 其余平台是上游 VP9-alpha 的 `webm/`。两者文件名主名都等于 config.jsonc 的池
+/// 条目，播放层按主名取 URL，因此这里只按目录存在性选源，前端无需感知格式。
+const PRESET_ANIMATION_DIRS: [(&str, &str); 2] = [("mov", ".mov"), ("webm", ".webm")];
+
+/// 按优先级挑选动画目录，返回 主名 → 协议 URL 的映射（目录全缺/为空返回空表）。
+///
+/// 同一份 config.jsonc 的池条目对两种格式通用：命中第一个有内容的动画目录即停，
+/// 不会因为残留了另一种格式的目录而给出两套重叠 URL。
+fn collect_animation_assets(dir: &Path, id: &str) -> Result<BTreeMap<String, String>, String> {
+    let mut assets = BTreeMap::new();
+    for (subdir, extension) in PRESET_ANIMATION_DIRS {
+        let animation_dir = dir.join(subdir);
+        if !animation_dir.is_dir() {
+            continue;
+        }
+        let mut entries = fs::read_dir(&animation_dir)
+            .map_err(|error| format!("PET_PRESET_ASSETS_READ_FAILED: failed to list {}: {error}", animation_dir.display()))?;
+        let mut files = Vec::new();
+        while let Some(entry) = entries.next() {
+            let entry = entry.map_err(|error| format!("PET_PRESET_ASSETS_READ_FAILED: {error}"))?;
+            let file_name = entry.file_name();
+            let Some(name) = file_name.to_str() else { continue };
+            if name.ends_with(extension) {
+                files.push(name.to_string());
+            }
+        }
+        if files.is_empty() {
+            continue;
+        }
+        files.sort();
+        for file in files {
+            let stem = file.strip_suffix(extension).unwrap_or(&file).to_string();
+            let url = format!(
+                "{PRESET_ASSET_ORIGIN}/{id}/{subdir}/{}",
+                percent_encode_segment(&file)
+            );
+            assets.insert(stem, url);
+        }
+        break;
+    }
+    Ok(assets)
+}
+
+/// 列出已安装预设宠物的全部媒体（动画 + preview 首张 gif 兜底图）。
+/// 池条目（config.jsonc 里的动画名）即动画文件名主名，与 dsh-pet 协议一致。
 #[tauri::command]
 pub fn get_preset_pet_assets(app: AppHandle, id: String) -> Result<PresetPetAssets, String> {
     let id = id.trim();
@@ -1121,30 +1257,7 @@ pub fn get_preset_pet_assets(app: AppHandle, id: String) -> Result<PresetPetAsse
     if !dir.is_dir() {
         return Err(format!("PET_PRESET_NOT_INSTALLED: preset pet {id} is not installed"));
     }
-    let webm_dir = dir.join("webm");
-    let mut assets = BTreeMap::new();
-    if webm_dir.is_dir() {
-        let mut entries = fs::read_dir(&webm_dir)
-            .map_err(|error| format!("PET_PRESET_ASSETS_READ_FAILED: failed to list {}: {error}", webm_dir.display()))?;
-        let mut files = Vec::new();
-        while let Some(entry) = entries.next() {
-            let entry = entry.map_err(|error| format!("PET_PRESET_ASSETS_READ_FAILED: {error}"))?;
-            let file_name = entry.file_name();
-            let Some(name) = file_name.to_str() else { continue };
-            if name.ends_with(".webm") {
-                files.push(name.to_string());
-            }
-        }
-        files.sort();
-        for file in files {
-            let stem = file.trim_end_matches(".webm").to_string();
-            let url = format!(
-                "{PRESET_ASSET_ORIGIN}/{id}/webm/{}",
-                percent_encode_segment(&file)
-            );
-            assets.insert(stem, url);
-        }
-    }
+    let mut assets = collect_animation_assets(&dir, id)?;
     // 兜底图：preview 目录第一张 gif（按文件名排序，与 dsh-pet preview 语义一致）。
     let preview_dir = dir.join("preview");
     if preview_dir.is_dir() {
@@ -1429,6 +1542,90 @@ mod tests {
         assert_eq!(spec.r#ref, None);
         assert_eq!(spec.size_mb, Some(113.0));
         assert_eq!(spec.image, None);
+        assert!(spec.platforms.is_empty());
+    }
+
+    #[test]
+    fn platform_override_switches_only_macos_to_the_mov_repository() {
+        // 与 resources/preset-pets.json 同形状：macOS 换仓库/空前缀/尺寸，其余继承。
+        let base: PresetPetSpec = serde_json::from_str(
+            r#"{
+                "id": "maid-deepseek-whale",
+                "name": "Maid DeepSeek Whale",
+                "desc": "base",
+                "image": "https://example.com/preview.gif",
+                "repo": "https://github.com/PC2005-cloud/dsh-pet",
+                "ref": "e1ff8c1",
+                "assets": "dsh-pet/assets",
+                "sizeMb": 113,
+                "platforms": {
+                    "macos": {
+                        "repo": "https://github.com/dsh-tauri-desk/dsh-pet-mov",
+                        "ref": "be0f3bb",
+                        "assets": "",
+                        "sizeMb": 79
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        // 非 macOS：覆盖块不生效，仍用上游 webm 仓库。
+        let mut untouched = base.clone();
+        apply_platform_override(&mut untouched, "windows");
+        assert_eq!(untouched.repo, "https://github.com/PC2005-cloud/dsh-pet");
+        assert_eq!(untouched.assets, "dsh-pet/assets");
+        assert_eq!(untouched.r#ref.as_deref(), Some("e1ff8c1"));
+        assert_eq!(untouched.size_mb, Some(113.0));
+        assert_eq!(
+            tarball_urls(&untouched).unwrap()[0],
+            "https://codeload.github.com/PC2005-cloud/dsh-pet/tar.gz/e1ff8c1"
+        );
+
+        // macOS：换到只含 config.jsonc + mov/ 的仓库，assets 为空前缀（仓库根即素材）。
+        let mut macos = base;
+        apply_platform_override(&mut macos, "macos");
+        assert_eq!(macos.repo, "https://github.com/dsh-tauri-desk/dsh-pet-mov");
+        assert_eq!(macos.assets, "");
+        assert_eq!(macos.r#ref.as_deref(), Some("be0f3bb"));
+        assert_eq!(macos.size_mb, Some(79.0));
+        // 覆盖块未写的字段继续继承基础条目。
+        assert_eq!(macos.desc.as_deref(), Some("base"));
+        assert_eq!(macos.image.as_deref(), Some("https://example.com/preview.gif"));
+        assert_eq!(
+            tarball_urls(&macos).unwrap()[0],
+            "https://codeload.github.com/dsh-tauri-desk/dsh-pet-mov/tar.gz/be0f3bb"
+        );
+        // 覆盖块被消费后不再残留，避免同一 spec 二次套用。
+        assert!(macos.platforms.is_empty());
+    }
+
+    #[test]
+    fn shipped_catalog_parses_and_macos_override_is_downloadable() {
+        // 随包分发的清单是唯一事实来源：字段名/形状写错必须在这里炸，
+        // 而不是等用户点「下载」才在运行时静默沿用基础取值。
+        let bytes = fs::read(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/preset-pets.json")).unwrap();
+        let mut catalog: Vec<PresetPetSpec> = serde_json::from_slice(&bytes).unwrap();
+        assert!(!catalog.is_empty(), "预设清单不应为空");
+
+        let mov = catalog
+            .iter()
+            .find(|spec| spec.platforms.contains_key("macos"))
+            .expect("至少一个预设应提供 macOS 覆盖块");
+        let (owner, repo) = parse_repo_owner(
+            &mov.platforms["macos"].repo.clone().expect("macOS 覆盖块必须给出 repo"),
+        )
+        .unwrap();
+        assert_eq!((owner.as_str(), repo.as_str()), ("dsh-tauri-desk", "dsh-pet-mov"));
+        // dsh-pet-mov 只保留 config.jsonc 与 mov/：素材目录就是仓库根。
+        assert_eq!(mov.platforms["macos"].assets.as_deref(), Some(""));
+
+        for spec in &mut catalog {
+            // 基础条目与 macOS 覆盖都必须能构造出下载地址。
+            tarball_urls(spec).unwrap();
+            apply_platform_override(spec, "macos");
+            tarball_urls(spec).unwrap();
+        }
     }
 
     #[test]
@@ -1460,6 +1657,7 @@ mod tests {
             assets: "dsh-pet/assets".to_string(),
             r#ref: Some("f0f772e".to_string()),
             size_mb: None,
+            platforms: HashMap::new(),
         };
         let urls = tarball_urls(&spec).unwrap();
         assert_eq!(
@@ -1492,6 +1690,116 @@ mod tests {
         );
         assert!(!staging.join("README.md").exists());
         assert!(!staging.join("src/client.ts").exists());
+    }
+
+    #[test]
+    fn empty_assets_prefix_extracts_the_whole_repository_root() {
+        // dsh-pet-mov 只保留 config.jsonc + mov/，清单用空前缀把仓库根当素材目录。
+        let tarball = build_tar_gz(&[
+            ("dsh-pet-mov-be0f3bb/config.jsonc", br#"{"animations":{}}"#),
+            ("dsh-pet-mov-be0f3bb/mov/待机呼吸休闲.mov", b"mov-bytes"),
+            ("dsh-pet-mov-be0f3bb/README.md", b"readme"),
+        ]);
+        let directory = TestDirectory::new("root-prefix");
+        fs::create_dir_all(&directory.0).unwrap();
+        let tarball_path = directory.0.join("pkg.tar.gz");
+        fs::write(&tarball_path, &tarball).unwrap();
+        let staging = directory.0.join("staging");
+        extract_preset_assets(&tarball_path, &staging, "").unwrap();
+        assert!(staging.join("config.jsonc").is_file());
+        assert!(staging.join("mov/待机呼吸休闲.mov").is_file());
+        assert_eq!(fs::read(staging.join("mov/待机呼吸休闲.mov")).unwrap(), b"mov-bytes");
+        // 仓库根仍以 `<repo>-<ref>/` 第一段被剥掉，不落盘。
+        assert!(!staging.join("dsh-pet-mov-be0f3bb").exists());
+
+        // GitHub codeload 的 tar.gz 首条是 pax 全局头（typeflag 'g'，名为
+        // `pax_global_header`）：空前缀下它不能落盘成文件，也不能覆盖真实条目。
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut archive = tar::Builder::new(&mut encoder);
+            archive.append_pax_extensions([("comment", &b"codeload test"[..])]).unwrap();
+            for (name, bytes) in [
+                ("dsh-pet-mov-be0f3bb/config.jsonc", &br#"{"animations":{}}"#[..]),
+                ("dsh-pet-mov-be0f3bb/mov/待机呼吸休闲.mov", b"mov-bytes"),
+            ] {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(bytes.len() as u64);
+                header.set_mode(0o100644);
+                header.set_cksum();
+                archive.append_data(&mut header, name, Cursor::new(bytes)).unwrap();
+            }
+        }
+        let with_pax = encoder.finish().unwrap();
+        let pax_tarball = directory.0.join("pax.tar.gz");
+        fs::write(&pax_tarball, &with_pax).unwrap();
+        let pax_staging = directory.0.join("pax-staging");
+        extract_preset_assets(&pax_tarball, &pax_staging, "").unwrap();
+        assert!(pax_staging.join("config.jsonc").is_file());
+        assert!(pax_staging.join("mov/待机呼吸休闲.mov").is_file());
+        assert!(!pax_staging.join("pax_global_header").exists(), "pax 全局头不得落盘");
+    }
+
+    #[test]
+    fn asset_mime_whitelists_webm_mov_and_gif_only() {
+        assert_eq!(preset_asset_mime("待机呼吸休闲.webm"), Some("video/webm"));
+        // HEVC-with-Alpha 必须是 video/quicktime，WKWebView 才交给 AVFoundation 解码 alpha。
+        assert_eq!(preset_asset_mime("待机呼吸休闲.mov"), Some("video/quicktime"));
+        assert_eq!(preset_asset_mime("daiji.gif"), Some("image/gif"));
+        for rejected in ["evil.sh", "clip.mp4", "noext", "clip.mov.exe"] {
+            assert_eq!(preset_asset_mime(rejected), None, "应拒绝 {rejected}");
+        }
+    }
+
+    #[test]
+    fn animation_assets_prefer_mov_over_webm() {
+        let directory = TestDirectory::new("anim-source");
+        let macos_pet = directory.0.join("macos-pet");
+        fs::create_dir_all(macos_pet.join("mov")).unwrap();
+        fs::write(macos_pet.join("mov/待机呼吸休闲.mov"), b"mov").unwrap();
+        fs::write(macos_pet.join("mov/东张西望.mov"), b"mov").unwrap();
+        // 目录里的非动画文件不应进入 manifest（池条目只会按主名取 URL）。
+        fs::write(macos_pet.join("mov/notes.txt"), b"skip").unwrap();
+        let assets = collect_animation_assets(&macos_pet, "macos-pet").unwrap();
+        assert_eq!(assets.len(), 2);
+        assert_eq!(
+            assets.get("待机呼吸休闲"),
+            Some(&format!(
+                "{PRESET_ASSET_ORIGIN}/macos-pet/mov/{}",
+                percent_encode_segment("待机呼吸休闲.mov")
+            ))
+        );
+
+        // 只有 webm/（非 macOS 安装）时回落 webm。
+        let other_pet = directory.0.join("other-pet");
+        fs::create_dir_all(other_pet.join("webm")).unwrap();
+        fs::write(other_pet.join("webm/待机呼吸休闲.webm"), b"webm").unwrap();
+        let assets = collect_animation_assets(&other_pet, "other-pet").unwrap();
+        assert_eq!(
+            assets.get("待机呼吸休闲"),
+            Some(&format!(
+                "{PRESET_ASSET_ORIGIN}/other-pet/webm/{}",
+                percent_encode_segment("待机呼吸休闲.webm")
+            ))
+        );
+
+        // 两种目录同时存在时以 mov/ 为准，不会产出两套重叠 URL。
+        fs::create_dir_all(other_pet.join("mov")).unwrap();
+        fs::write(other_pet.join("mov/待机呼吸休闲.mov"), b"mov").unwrap();
+        let assets = collect_animation_assets(&other_pet, "other-pet").unwrap();
+        assert_eq!(assets.len(), 1);
+        assert_eq!(
+            assets.get("待机呼吸休闲"),
+            Some(&format!(
+                "{PRESET_ASSET_ORIGIN}/other-pet/mov/{}",
+                percent_encode_segment("待机呼吸休闲.mov")
+            ))
+        );
+
+        // 目录缺失 / 目录为空都返回空表而不报错。
+        assert!(collect_animation_assets(&directory.0.join("missing"), "missing").unwrap().is_empty());
+        let empty_pet = directory.0.join("empty-pet");
+        fs::create_dir_all(empty_pet.join("mov")).unwrap();
+        assert!(collect_animation_assets(&empty_pet, "empty-pet").unwrap().is_empty());
     }
 
     #[test]
@@ -1726,6 +2034,11 @@ mod tests {
         assert_eq!(
             preset_asset_path("/localhost/maid-deepseek-whale/preview/daiji.gif"),
             Some(("maid-deepseek-whale", "preview", "daiji.gif"))
+        );
+        // macOS 的 HEVC-with-Alpha 素材（dsh-pet-mov 的 mov/）。
+        assert_eq!(
+            preset_asset_path("/maid-deepseek-whale/mov/%E5%BE%85.mov"),
+            Some(("maid-deepseek-whale", "mov", "%E5%BE%85.mov"))
         );
         assert_eq!(preset_asset_path("/a/b/c/d"), None);
         assert_eq!(preset_asset_path("/../escape/webm/x.webm"), None);

--- a/src-tauri/src/desktop/pet.rs
+++ b/src-tauri/src/desktop/pet.rs
@@ -38,7 +38,8 @@ const PET_WINDOW_BOTTOM_PAD: f64 = 10.0;
 /// 顶栏 Toast 区的最小窗口宽度（逻辑像素）：桌宠较小时仍保证气泡可读，
 /// 与 pet WebView 的 PET_BUBBLE_MIN_WIDTH 保持一致。
 const PET_WINDOW_MIN_WIDTH: f64 = 420.0;
-/// 预设 WebM 画布 16:9（高/宽 = 9/16），与 dsh-pet 协议画布比例保持一致。
+/// 预设动画画布 16:9（高/宽 = 9/16），与 dsh-pet 协议画布比例保持一致
+/// （WebM 与 macOS 的 HEVC-with-Alpha MOV 共用同一画布）。
 const PET_BUILTIN_ASPECT: f64 = 9.0 / 16.0;
 /// 自定义 Codex v2 精灵图默认 8x11 的 192x208 比例；实际比例以前端加载后为准，
 /// 这里仅作为窗口初始/DPI 尺寸的近似，避免与前端内置画布比例互相打架。

--- a/src/pet/components/pet.tsx
+++ b/src/pet/components/pet.tsx
@@ -108,7 +108,7 @@ export function Pet(props: PetProps) {
   const adHocRef = useRef(adHoc)
   adHocRef.current = adHoc
   const adHocSeqRef = useRef(0)
-  // 预设宠物资源（config.jsonc + webm manifest）：按宠物 id 一起拉取并整体更新，
+  // 预设宠物资源（config.jsonc + 动画 manifest）：按宠物 id 一起拉取并整体更新，
   // 避免切换宠物时残留上一个宠物的动画池/URL（旧数据在 fetch 完成前不生效）。
   const [petResources, setPetResources] = useState<{
     pet: string
@@ -134,7 +134,9 @@ export function Pet(props: PetProps) {
   const handleEndedRef = useRef<(event?: Event) => void>(() => {})
 
   const activePet = normalizeActivePet(rustStatus.active_pet)
-  // 预设宠物（未限定 id，来自 ~/.dsh/pets 下载产物）走 WebM 协议渲染；
+  // 预设宠物（未限定 id，来自 ~/.dsh/pets 下载产物）走 <video> 协议渲染：
+  // Windows/Linux 是 VP9-alpha WebM，macOS 是 HEVC-with-Alpha MOV（issue #434，
+  // WKWebView 不认 WebM alpha）。此处只认 manifest 给的 URL，不感知格式；
   // 来源限定 id（chat:/codex:）走 Codex v2 精灵图渲染。
   const isPreset = !activePet.includes(':')
   // 预设宠物资源按当前激活宠物生效：切换宠物时旧资源保持到新 fetch 完成，避免闪烁。
@@ -151,7 +153,7 @@ export function Pet(props: PetProps) {
   // 这里给出可见提示引导去设置页下载（issue #401）。全新安装 active_pet 为空串
   // （无默认选择），不会走此分支。
   const presetMissing = isPreset && error?.includes('PET_PRESET_NOT_INSTALLED') === true
-  // 预设宠物配置驱动动画池：池条目是动画名（webm 文件名主名，如 待机呼吸休闲），
+  // 预设宠物配置驱动动画池：池条目是动画名（动画文件名主名，如 待机呼吸休闲），
   // 点击/拖拽/待机链按名字从 assets map 取 URL。配置缺失或命令失败时回落与旧
   // 实现一致的默认池（idle/turn/wave），这些名字在 assets 中不存在时自然不播放。
   const pools = useMemo(() => {
@@ -223,7 +225,7 @@ export function Pet(props: PetProps) {
   }, [])
 
   // 预设宠物按 activePet 拉取协议配置与媒体 manifest；切换宠物时重载。
-  // 已安装预设的 config.jsonc 池条目（待机呼吸休闲 等）即 webm 文件名主名，
+  // 已安装预设的 config.jsonc 池条目（待机呼吸休闲 等）即 动画文件名主名，
   // assets map 的 key 与池条目一一对应，动画链/点击/拖拽直接按名字取 URL。
   useEffect(() => {
     // 无激活宠物（active_pet 为空串，全新安装未选择）时不拉取任何资源，避免
@@ -318,7 +320,7 @@ export function Pet(props: PetProps) {
     // 只用于预设宠物（WebM）；自定义宠物走精灵图渲染，不走视频。
     if (isPreset === false || videoARef.current === null || videoBRef.current === null)
       return undefined
-    // 预设配置池条目 = 动画名 = webm 文件名主名；adHoc 已携带动画名时直接命中，
+    // 预设配置池条目 = 动画名 = 动画文件名主名；adHoc 已携带动画名时直接命中，
     // 会话状态（waiting/running/review/failed/bubble）经 PRESET_SESSION_ANIMATIONS
     // 叠加映射到具体动画名（写代码/轻快记录/玩游戏气急败坏…）。
     const name = resolvePresetName(activity, pools, assets)
@@ -345,7 +347,7 @@ export function Pet(props: PetProps) {
     // 防重：同一播放目标（资源 URL + 循环语义 + 重播序号）不重复加载。
     // override.revision 不是重播依据 —— 会话档位反复下发（同一档位重复到达，或多会话
     // 交错让聚合档位在解析结果相同的动画之间来回切）时，按 revision 重载会让同一个
-    // webm 从头播放：用户看到「气泡信息没变，动画却一直重新播放」。只有点击回应等
+    // 视频从头播放：用户看到「气泡信息没变，动画却一直重新播放」。只有点击回应等
     // 显式重播（seq 递增）或目标真的变化时才重载。
     const nextTarget: PetAnimationTarget = { once, seq, src: source }
     if (!shouldReloadAnimation(appliedRef.current, nextTarget))
@@ -390,7 +392,7 @@ export function Pet(props: PetProps) {
   // 点击回应：clickCount 变化（useDrag 判定「500ms 内两次按下且未拖拽 = 双击」后递增）
   // → 播放一次点击回应动画。adHoc 优先级在会话 override 之上：双击回应可打断会话状态，
   // 播完回落原动画（handleEnded）。动画名来自预设 config.jsonc 的 clicks 池（协议，
-  // 池条目 = 动画名 = webm 文件名主名）；配置缺失/池条目不可播放时回落 waving。
+  // 池条目 = 动画名 = 动画文件名主名）；配置缺失/池条目不可播放时回落 waving。
   useEffect(() => {
     if (props.clickCount === undefined || props.clickCount === prevClickRef.current)
       return undefined
@@ -610,7 +612,7 @@ function isPetStatus(value: string): value is PetStatus {
 }
 
 /**
- * 把预设配置池条目（动画名，webm 文件名主名）映射为可播放状态：预设宠物条目
+ * 把预设配置池条目（动画名，动画文件名主名）映射为可播放状态：预设宠物条目
  * 直接就是动画名（如 待机呼吸休闲 / 点击回应-开心跃动）；兼容旧内置键 'wave'
  * → 'waving' 的归一化。拖拽/方向专用状态不参与回应池；其余必须命中会话状态
  * 或 bubble，否则返回 null（调用方回落默认动画）。

--- a/src/pet/config/index.ts
+++ b/src/pet/config/index.ts
@@ -3,7 +3,7 @@
  *
  * 配置由 Rust 从 ~/.dsh/pets/<id>/config.jsonc 读取、剥注释并校验后经
  * `get_preset_pet_config` 命令返回（字段形状 = 子仓库 dsh-pet assets/config.jsonc
- * 协议的受支持子集，动画池条目 = 动画名 = webm 文件名主名）。本模块只做两件事：
+ * 协议的受支持子集，动画池条目 = 动画名 = 动画文件名主名）。本模块只做两件事：
  * 1. 类型收敛：把命令返回值声明成可直接消费的结构；
  * 2. 权重掷骰：移植 dsh-pet src/shared/pickers.ts 的 rollKind / pickWeightedCategory /
  *    pickCategoryAction（DSH 无自动漫游，move 档由调用方决定保持待机，不在本模块移动窗口），
@@ -155,7 +155,7 @@ export function poolEntryToStatus(entry: string): string {
 }
 
 /**
- * DSH 会话状态 → dsh-pet 动画名（webm 文件名主名）的叠加映射。
+ * DSH 会话状态 → dsh-pet 动画名（动画文件名主名）的叠加映射。
  *
  * 两族状态：
  * 1. 细分工作状态档位（workStatus，host reducer 输出）：thinking/working/result/
@@ -185,7 +185,7 @@ export const PRESET_SESSION_ANIMATIONS: Record<string, string> = {
 }
 
 /**
- * 预设宠物：把播放状态解析为实际动画名（webm 文件名主名，如 待机呼吸休闲）。
+ * 预设宠物：把播放状态解析为实际动画名（动画文件名主名，如 待机呼吸休闲）。
  * - 活动名本身就是可播放动画名（adHoc 池条目 / 会话状态映射名）时直接命中资产；
  * - 会话状态（waiting/running/review/failed/bubble）经 PRESET_SESSION_ANIMATIONS
  *   叠加映射到具体动画名；映射名没有对应资产时返回 null（保持当前动画）；
@@ -274,7 +274,7 @@ export interface PetAnimationTarget {
  * 是否需要重载视频来切换动画（纯函数，可单测）。
  *
  * 【为什么存在】会话档位反复下发时（同一档位重复到达、或多会话交错让聚合档位在
- * 解析结果相同的动画之间来回切），旧实现按 override.revision 递增重载同一个 webm
+ * 解析结果相同的动画之间来回切），旧实现按 override.revision 递增重载同一个视频
  * 并从头播放——用户看到的现象是「气泡信息明明是同一个『整理结果中』，动画却一直
  * 重新播放」。动画是否重播只由播放目标决定：
  * - 目标资源变化（真换了动画 / 换了宠物）→ 重载；

--- a/src/pet/hooks/use-bubble.ts
+++ b/src/pet/hooks/use-bubble.ts
@@ -23,7 +23,7 @@ const FAILED_PULSE_TTL = 1800
 /**
  * 终态档（success/error）聚合保持时长：对齐 dsh-pet 的 BUBBLE_DURATION_MS=10000
  * （终态动画播一次 + 10s 收气泡）语义。不得复用 SUCCESS_TOAST_TIMEOUT(3s)——成功
- * WebM（如 雀跃庆祝）实际播放时长超过 3s 时，聚合状态提前回落会让 app.tsx 的
+ * 终态动画（如 雀跃庆祝）实际播放时长超过 3s 时，聚合状态提前回落会让 app.tsx 的
  * useWatch 调 pet.clear() 掐断未播完的动画（用户报告：成功动画没播完就换回待机）。
  * 动画播完由视频 ended（handleEnded → 清 override）自然回落，toast 收起仍走
  * scheduleHide 的独立 3s（SUCCESS_TOAST_TIMEOUT），二者互不影响。


### PR DESCRIPTION
## 背景

Closes #434

macOS 上启用预设桌宠后，宠物显示为黑色矩形（透明区域全黑），Windows/Chromium 正常，且**无任何 error 事件**。

根因已在 issue 中确认：预设宠物走 `<video>` 播放 **VP9-alpha WebM**，而 WKWebView（WebKit）解码时**直接丢弃 alpha 平面**并按不透明渲染。窗口/WebView/CSS 透明链路和 Tauri 都没有问题，黑底只出在视频像素层。Safari/WKWebView 原生支持的透明视频是 **HEVC-with-Alpha**（`AVVideoCodecType.hevcWithAlpha`，`hvc1`），而该编码器只有 macOS 有 —— 所以素材必须在 macOS runner 上转码，不能在本仓库做。

## 素材侧（已完成，独立仓库）

新建 [`dsh-tauri-desk/dsh-pet-mov`](https://github.com/dsh-tauri-desk/dsh-pet-mov)，用 GitHub Actions 的 macOS runner 把上游 `PC2005-cloud/dsh-pet` 的透明 WebM 批量转码：

```
上游 webm → ffmpeg -c:v libvpx-vp9 -pix_fmt bgra（保留 alpha 的解码）
          → swift hevc_alpha_encoder.swift（AVAssetWriter + hevcWithAlpha）
          → mov/*.mov
```

- 仓库**只保留 `config.jsonc` 与 `mov/`**（106 个动画，约 79 MiB）；`fonts/`、`pic/`、`webm/`、`preview/` 都不落盘。
- 流水线三条触发：`workflow_dispatch`（可指定上游 ref）、`schedule`（每周一跟随上游 `main`）、`repository_dispatch: dsh-pet-updated`；产物由机器人提交回该仓库 `main`，并 `check_alpha.py` 抽检 alpha 真实存在（CI 已跑通）。
- 桌面端以 codeload tarball 下载，**不需要 Release**（沿用现有预设下载通道）。
- 本地目录：`D:\projects\dsh-tauri-desk\dsh-pet-mov`。

## 桌面侧改动

**`src-tauri/resources/preset-pets.json`** — 新增 `platforms` 覆盖块，只改 macOS：

```jsonc
"platforms": {
  "macos": {
    "repo": "https://github.com/dsh-tauri-desk/dsh-pet-mov",
    "ref": "be0f3bb494cb71a4c73f916c0b92d25a3ab4d002",
    "assets": "",   // 仓库根即素材目录（只保留 config.jsonc + mov/）
    "sizeMb": 79
  }
}
```

其余平台**完全不变**，继续用上游 WebM（`repo`/`ref`/`assets`/`sizeMb` 全部继承基础条目）。

**`src-tauri/src/bridge/preset_pet.rs`**

| 改动 | 说明 |
| --- | --- |
| `PresetPetPlatformOverride` + `apply_platform_override` | 按 `std::env::consts::OS` 并回覆盖块，未写的字段继承基础条目；`list_preset_pets` / `download_preset_pet` / `update_preset_pet` 走 `read_platform_catalog` |
| 两个清单结构 `deny_unknown_fields` | 清单随安装包分发，字段名写错（如 `sizeMB`）必须立刻报 `PET_PRESET_CATALOG_INVALID`，而不是被 serde 静默忽略后沿用基础值 |
| 解压支持**空前缀** | `assets: ""` 表示整个仓库即素材；仍剥掉 `<repo>-<ref>/`，安全校验（traversal/symlink/条目数与体积上限）全部保留 |
| 协议放开 `mov/` 与 `.mov` | `resolve_preset_asset` 接受 `webm/mov/preview`；抽出 `preset_asset_mime` 同时充当扩展名白名单，`.mov` → `video/quicktime`（WKWebView 交给 AVFoundation 解码 HEVC-alpha 时才认得 alpha） |
| `collect_animation_assets` | 按 `mov/` → `webm/` 优先级选源；两种格式的文件名主名都等于 `config.jsonc` 的池条目，**前端无需感知格式**（`get_preset_pet_assets` 的返回形状不变） |

**升级路径**：macOS 已装 WebM 的用户，清单 `ref` 变化会触发设置页既有的「更新」入口，更新即从 webm 安装切到 mov 安装；旧安装的 webm 仍可播放，未被破坏。

**文档**：`packages/dsh-tauri-pet/README.md`、`docs/sync-log.md` 记录素材来源、ref 升级流程与两个 ref（上游 webm / dsh-pet-mov）都要升的注意事项。

## 测试

```
cargo test --all-features --locked      # 546 passed, 0 failed
pnpm run lint                           # 0 errors
pnpm typecheck                          # 0 errors
```

新增 5 条单测：

- `platform_override_switches_only_macos_to_the_mov_repository` — 覆盖只对 macOS 生效，其余字段继承；两边的 tarball URL 都正确
- `shipped_catalog_parses_and_macos_override_is_downloadable` — 直接解析随包分发的 `preset-pets.json`，保证字段名写错在测试期就炸
- `empty_assets_prefix_extracts_the_whole_repository_root` — 空前缀整体解压且仍剥掉仓库根
- `asset_mime_whitelists_webm_mov_and_gif_only` — `.mov` → `video/quicktime`，其余扩展名拒绝
- `animation_assets_prefer_mov_over_webm` — mov 优先 / webm 回落 / 同存不产生重叠 URL

另外用脚本核对了 dsh-pet-mov 的产物：**106 个 mov 与 `config.jsonc` 的池条目一一对应**（所有动画名都有对应 mov，没有孤立文件）。

## 需要人工确认的部分

本仓库 CI 只覆盖编译与单测，**真实的 macOS 透明渲染需要一次真机冒烟**（WKWebView 的 alpha 支持无法在 Windows/Linux 上验证）。建议合并前在 macOS 上跑一次：

1. 删除/忽略已有安装 → 设置 → 桌宠 → 下载 Maid DeepSeek Whale → 启用；
2. 确认宠物无黑底、边缘透明、拖拽/点击动画与工作状态 6 档都正常；
3. `~/.dsh/pets/maid-deepseek-whale/` 下应只有 `config.jsonc` + `mov/`。

## 检查清单

- [x] `cargo test --all-features --locked` 全绿
- [x] `pnpm typecheck` / `pnpm run lint` 全绿
- [x] 前端零改动（协议返回形状未变，仅注释措辞对齐两种格式）
- [x] 非 macOS 平台行为与素材来源完全不变
- [x] i18n 无新增文案


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - macOS 预设宠物现使用支持透明效果的 HEVC 视频资源；Windows 和 Linux 继续使用 WebM。
  - 桌面端会根据运行平台自动选择对应动画资源，并支持 macOS 专用资源包。

- **Bug 修复**
  - 修复 macOS 下预设宠物动画可能显示黑色背景的问题。
  - 优化动画资源识别与加载，避免使用不匹配的平台资源。

- **文档**
  - 更新预设宠物资源格式、平台覆盖范围及同步流程说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->