### PR TITLE
fix(panel): 会话区替换兼容核心 0.1.5 的 main keyed 槽

### DIFF
--- a/packages/dsh-tauri-panel/PROTOCOL.md
+++ b/packages/dsh-tauri-panel/PROTOCOL.md
@@ -32,6 +32,18 @@ interface PanelProtocol {
 | `renderPanelContent(spec)` | 切换会话区替换：未替换则打开 `spec.render`，已替换则关闭恢复官方会话界面（toggle 语义）；再调同 `id` → dispose 句柄 → 官方恢复 |
 | `closePanelContent()` | 显式恢复官方会话区；面板内需要跳转到会话的动作用它 |
 
+会话区替换的承载槽随核心版本变化（宿主同时 inject 两个候选，任一版本只有
+对应声明存在，另一候选静默等待）：
+
+| 核心版本 | 承载槽 | 注册形状 |
+| --- | --- | --- |
+| ≤ `0.1.2-rc.1` | `conversation`（`single`） | `{ name: 'conversation', id, priority: -1 }` |
+| ≥ `0.1.5-rc.1` | `main`（`keyed`，cell key `conversation`） | `{ name: 'main', key: 'conversation', priority: -1 }` |
+
+> 0.1.5-rc.1 起布局改为 `renderSlot('main', {}, { entryKey: activePanelId ?? 'conversation' })`，
+> 官方会话条目注册在 `main` 槽的 `conversation` cell，旧的 `conversation` 槽
+> 已不复存在。消费方无需感知该差异——`renderPanelContent` 仍是唯一入口。
+
 `PanelContentSpec`：
 
 ```ts
@@ -116,6 +128,11 @@ return ctx.slots.register(
 
 - **rc.2 ↔ alpha 双版本**：全部新增为「可选字段 / 能力探测 / 自实现镜像」，既有
   方法（`ActionItem` / `renderPanelContent` / `closePanelContent`）与消费方零破坏；
+- **会话区承载槽双候选**（`0.1.5-rc.1` 回归）：`0.1.5-rc.1` 把会话区并入
+  `main` keyed 槽、删除旧 `conversation` 槽。宿主同时 `inject` 两个候选
+  （`conversation` 单槽 + `main`/`conversation` keyed 条目），按核心实际声明择一
+  生效；只注册旧槽会导致 inject 回调永不执行 → 面板内容区不替换，只剩侧栏条目
+  选中样式；
 - **旧 WebView**（无 ResizeObserver / PointerEvent / rAF）：`supported=false`，
   手柄不渲染、宽度固定（`--dsh-chat-content-width` 回退 `780px`），仅 console.warn 一次；
 - **renderer 补丁缺失**：`<SlotOutlet>` 为 `undefined` → 侧栏面板整体不注册

--- a/packages/dsh-tauri-panel/README.md
+++ b/packages/dsh-tauri-panel/README.md
@@ -5,7 +5,7 @@
 ## 能力
 
 - **整槽替换 sidebar**（priority -1 shadow 官方 `ui-sidebar`）：紧凑 logoRow + 面板区（新会话 + 第三方功能项）+ 官方子槽透传（`<SlotOutlet>`，无 renderer 补丁时整体降级不注册）。
-- **内容区替换**：以 `priority: -1` 动态注册 `conversation` 槽 → 面板视图替换官方对话区；`panel.protocol` 提供 `ActionItem` / `renderPanelContent` / `closePanelContent`。
+- **内容区替换**：动态注册会话区承载槽的 `priority: -1` 条目 → 面板视图替换官方对话区；承载槽按核心版本双候选（≤`0.1.2-rc.1` 的 `conversation` 单槽 / ≥`0.1.5-rc.1` 的 `main` keyed 槽 `conversation` cell，同时 inject、择一生效）；`panel.protocol` 提供 `ActionItem` / `renderPanelContent` / `closePanelContent`。
 - **内容宽度拖拽**：内容列左右对称 `data-width-handle` 手柄（pointer capture + rAF 节流 + 外向 2× 位移），偏好持久化 `localStorage['dsh.conversation.contentWidth']`，与官方共用同一 CSS 变量协议（`--dsh-chat-content-width` / `--dsh-chat-user-width` / `--dsh-conversation-column-width`），rc.2 / alpha 双版本兼容、自给自足发布。
 - **协议可选能力**（方案 C）：`setPanelWidth` / `resetPanelWidth` / `getPanelWidth` / `openDetails` / `closeDetails`，消费方 `?.()` 探测调用。
 

--- a/packages/dsh-tauri-panel/src/client/constants/index.ts
+++ b/packages/dsh-tauri-panel/src/client/constants/index.ts
@@ -1,9 +1,35 @@
+import type { PanelViewSeatTarget } from '../types'
+
 /** Stable client-side identifiers shared by the panel implementation. */
 export { PANEL_CONTENT_ADAPTIVE_MAX, PANEL_CONTENT_ADAPTIVE_MIN, PANEL_CONTENT_DEFAULT, PANEL_CONTENT_EDGE_BUDGET, PANEL_CONTENT_MIN, PANEL_WIDTH_PREF_KEY, PANEL_WIDTH_VARS } from './width'
 
 export const PANEL_PROTOCOL_SERVICE = 'panel.protocol'
+/**
+ * ≤ 0.1.2-rc.1 核心的会话区槽：布局直接 `renderSlot('conversation')`，官方
+ * ui-conversation 是唯一注册者，桌面端以 priority -1 动态注册 shadow 它。
+ */
 export const PANEL_VIEW_SLOT = 'conversation'
+/**
+ * ≥ 0.1.5-rc.1 核心把会话区并入 keyed 槽 `main`：布局改为
+ * `renderSlot('main', {}, { entryKey: activePanelId ?? 'conversation' })`，官方
+ * 会话条目以 `{ name: 'main', key: 'conversation' }` 注册；旧 `conversation`
+ * 槽在核心中已不存在（声明/渲染都没有）。
+ */
+export const PANEL_VIEW_MAIN_SLOT = 'main'
+/** `main` keyed 槽里承载官方会话的 cell key（与布局的 entryKey 一致）。 */
+export const PANEL_VIEW_MAIN_KEY = 'conversation'
 export const PANEL_VIEW_COMPONENT_ID = 'dsh-tauri-panel-conversation-seat'
+/**
+ * 会话区替换的槽位候选：同时 inject 两个版本各自的槽，按核心版本择一生效。
+ *
+ * 只注册旧 `conversation` 槽时，0.1.5+ 核心里的声明永不出现 → inject 回调永不
+ * 执行 → 内容区不替换，只剩侧栏条目的选中样式（回归现象）。两个候选天然版本
+ * 互斥（同一核心只会声明其中一个），同时 inject 零副作用：未声明的候选静默等待。
+ */
+export const PANEL_VIEW_SEAT_TARGETS: readonly PanelViewSeatTarget[] = [
+  { id: PANEL_VIEW_COMPONENT_ID, slot: PANEL_VIEW_SLOT },
+  { key: PANEL_VIEW_MAIN_KEY, slot: PANEL_VIEW_MAIN_SLOT },
+]
 export const PANEL_STYLE_ID = 'dsh-tauri-panel-styles'
 export const SIDEBAR_STYLE_ID = 'dsh-tauri-panel-sidebar-styles'
 export const ACTION_ITEM_STYLE_ID = 'dsh-tauri-panel-action-item-styles'

--- a/packages/dsh-tauri-panel/src/client/register/panel-service.ts
+++ b/packages/dsh-tauri-panel/src/client/register/panel-service.ts
@@ -4,11 +4,12 @@
  * 协议能力见 PROTOCOL.md。机制（全部在宿主，单一权威）：
  *   - 服务经 ctx.reflect.provide('panel.protocol', api) 暴露（cordis
  *     ReflectService，官方 runtime 同款用法 ctx.reflect.provide("sessions", this)）；
- *   - renderPanelContent：conversation 槽（single/session-maybe，layout 声明、
- *     官方 ui-conversation priority 0 是唯一注册者）以 priority -1 **动态注册**
- *     → 整个右侧会话区被替换（CenterColumn 内、零定位层）；官方条目被
- *     shadow 但仍 live（children/locale 有效）。再调（同 id）→ dispose 句柄
- *     → 官方恢复（toggle 语义）。
+ *   - renderPanelContent：会话区槽以 priority -1 **动态注册** shadow 官方条目
+ *     → 整个右侧会话区被替换（CenterColumn 内、零定位层）；官方条目被 shadow
+ *     但仍 live（children/locale 有效）。再调（同 id）→ dispose 句柄 → 官方恢复
+ *     （toggle 语义）。槽位形状随核心版本（见 PANEL_VIEW_SEAT_TARGETS）：
+ *     ≤0.1.2-rc.1 的 `conversation` 单槽 / ≥0.1.5-rc.1 的 `main` keyed 槽
+ *     （cell key `conversation`）。
  *   - 不能常驻注册 + SlotOutlet 透传：SlotOutlet 对 single 槽只渲染 live 条目，
  *     自己 live 后渲染官方条目 = 自递归（无公开 API 渲染被 shadow 条目）。
  */

--- a/packages/dsh-tauri-panel/src/client/service/controller.test.ts
+++ b/packages/dsh-tauri-panel/src/client/service/controller.test.ts
@@ -1,0 +1,173 @@
+/**
+ * controller.test.ts — 会话区替换控制器的槽位注册回归。
+ *
+ * 核心 0.1.5-rc.1 把会话区并入 keyed 槽 `main`（cell key `conversation`），旧
+ * `conversation` 单槽消失：只 inject 旧槽时声明永不出现 → 内容区不替换，只剩
+ * 侧栏条目选中样式。控制器必须同时 inject 两个版本候选。
+ */
+
+import type { ClientContext } from 'dsh-tauri/client'
+import type { PanelContentSpec } from '../types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PANEL_VIEW_COMPONENT_ID } from '../constants'
+import { createPanelConversationController } from './controller'
+
+// dsh-tauri 的 dist bundle 以 `window.__ModuleLoader__.load(...)` 包裹，脱离宿主
+// 加载器后无法在 node 环境求值；只 mock 控制器实际消费的三个工厂。
+vi.mock('dsh-tauri/client', () => ({
+  createExternalStore: <T>(initial: T) => {
+    let state = initial
+    const listeners = new Set<() => void>()
+    return {
+      getSnapshot: () => state,
+      set: (next: T | ((current: T) => T)) => {
+        const value = typeof next === 'function' ? (next as (current: T) => T)(state) : next
+        if (Object.is(value, state))
+          return
+        state = value
+        for (const listener of [...listeners])
+          listener()
+      },
+      subscribe: (listener: () => void) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
+    }
+  },
+  createHooks: () => ({ callHook: vi.fn(() => Promise.resolve()) }),
+  createLifecycleController: () => ({
+    add: vi.fn(),
+    dispose: vi.fn(),
+    isDisposed: () => false,
+  }),
+}))
+
+// conversation-seat.cssr / conversation-seat.tsx 依赖 dsh-tauri-ui/client 的
+// cssr 实例与 useMountStyle；测试不渲染组件，给最小桩件即可。
+vi.mock('dsh-tauri-ui/client', () => {
+  const node = { mount: () => {}, render: () => '', unmount: () => {} }
+  const chain = (): unknown => node
+  return {
+    cssr: { bem: { b: chain, e: chain, m: chain }, c: chain },
+    mountStyle: () => () => {},
+    useMountStyle: () => {},
+  }
+})
+
+interface RegisteredEntry {
+  component: unknown
+  options: Record<string, unknown>
+}
+
+interface SlotsStub {
+  ctx: ClientContext
+  injected: string[]
+  registerDisposers: Array<ReturnType<typeof vi.fn>>
+  registered: RegisteredEntry[]
+}
+
+/** 记录 inject/register 调用的最小 slots 服务桩件（register 返回独立 disposer）。 */
+function createSlotsStub(): SlotsStub {
+  const injected: string[] = []
+  const registered: RegisteredEntry[] = []
+  const registerDisposers: Array<ReturnType<typeof vi.fn>> = []
+  const slots = {
+    inject: (slot: string, setup: () => unknown) => {
+      injected.push(slot)
+      const dispose = setup()
+      return () => {
+        if (typeof dispose === 'function')
+          (dispose as () => void)()
+      }
+    },
+    register: (options: unknown, component: unknown) => {
+      registered.push({ component, options: options as Record<string, unknown> })
+      const dispose = vi.fn()
+      registerDisposers.push(dispose)
+      return dispose
+    },
+  }
+  return {
+    ctx: { slots } as unknown as ClientContext,
+    injected,
+    registerDisposers,
+    registered,
+  }
+}
+
+function spec(id: string, locale?: string): PanelContentSpec {
+  return { id, locale, render: () => null }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('document', {
+    addEventListener: vi.fn(),
+    querySelector: vi.fn(() => null),
+    removeEventListener: vi.fn(),
+  })
+})
+
+describe('createPanelConversationController 会话区替换槽位（0.1.5 回归）', () => {
+  it('open 同时 inject 旧 conversation 单槽与 0.1.5 的 main keyed 槽', () => {
+    const slots = createSlotsStub()
+    const controller = createPanelConversationController()
+
+    controller.toggle(slots.ctx, spec('demo', 'panel-x'))
+
+    expect(slots.injected).toEqual(['conversation', 'main'])
+    expect(slots.registered).toHaveLength(2)
+    expect(slots.registered[0].options).toMatchObject({
+      id: PANEL_VIEW_COMPONENT_ID,
+      locale: 'panel-x',
+      name: 'conversation',
+      priority: -1,
+    })
+    expect(slots.registered[1].options).toMatchObject({
+      key: 'conversation',
+      locale: 'panel-x',
+      name: 'main',
+      priority: -1,
+    })
+    // keyed 槽不能带 single 槽的 id（两种 shape 各自独立）
+    expect(slots.registered[1].options.id).toBeUndefined()
+  })
+
+  it('未声明 locale 时回退宿主 panel 命名空间', () => {
+    const slots = createSlotsStub()
+    const controller = createPanelConversationController()
+
+    controller.toggle(slots.ctx, spec('demo'))
+
+    for (const entry of slots.registered)
+      expect(entry.options.locale).toBe('panel')
+  })
+
+  it('同 id 再 toggle 关闭：释放两个候选的注册并清空 viewId', () => {
+    const slots = createSlotsStub()
+    const controller = createPanelConversationController()
+    const content = spec('demo')
+
+    controller.toggle(slots.ctx, content)
+    expect(controller.viewId()).toEqual({ id: 'demo' })
+
+    controller.toggle(slots.ctx, content)
+    expect(controller.viewId()).toBeNull()
+    for (const dispose of slots.registerDisposers)
+      expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('切换不同 id：先释放旧候选，再为新 id 重新注册两个候选', () => {
+    const slots = createSlotsStub()
+    const controller = createPanelConversationController()
+
+    controller.toggle(slots.ctx, spec('alpha'))
+    expect(slots.registered).toHaveLength(2)
+
+    controller.toggle(slots.ctx, spec('beta'))
+    expect(slots.injected).toEqual(['conversation', 'main', 'conversation', 'main'])
+    expect(slots.registered).toHaveLength(4)
+    // 旧 alpha 的两个候选被释放；新 beta 的两个仍存活（等 close 释放）。
+    expect(slots.registerDisposers.map(dispose => dispose.mock.calls.length)).toEqual([1, 1, 0, 0])
+    expect(controller.viewId()).toEqual({ id: 'beta' })
+  })
+})

--- a/packages/dsh-tauri-panel/src/client/service/controller.tsx
+++ b/packages/dsh-tauri-panel/src/client/service/controller.tsx
@@ -2,17 +2,23 @@
  * service/controller.tsx — 会话区替换控制器：拥有 inject 句柄、当前规格与
  * capture 层 pointerdown 监听；close() 恢复官方会话界面并释放全部资源。
  *
+ * 槽位按核心版本双候选（同时 inject，见 PANEL_VIEW_SEAT_TARGETS）：
+ *   - ≤ 0.1.2-rc.1：`conversation` 单槽；
+ *   - ≥ 0.1.5-rc.1：`main` keyed 槽的 `conversation` cell。
+ * 只注册旧槽时 0.1.5+ 的声明永不出现 → inject 回调永不执行 → 内容区不替换
+ * （只剩侧栏条目选中样式）。
+ *
  * open/close 走命名钩子（hookable），供诊断与第三方联动。重复创建（插件
  * 重载）时旧实例先被其 effect 清理，互不干扰。
  */
 
 import type { ClientContext } from 'dsh-tauri/client'
 import type { ReactElement } from 'react'
-import type { PanelContentSpec } from '../types'
+import type { PanelContentSpec, PanelViewSeatTarget } from '../types'
 import type { PanelWidthController } from './width'
 import { createHooks } from 'dsh-tauri/client'
 import { ConversationSeat } from '../components/conversation-seat'
-import { PANEL_VIEW_COMPONENT_ID, PANEL_VIEW_SLOT } from '../constants'
+import { PANEL_VIEW_SEAT_TARGETS } from '../constants'
 import { setSidebarPanelActive, shouldClosePanelForSidebarTarget } from '../dom/panel'
 import { NS } from '../locales'
 import { panelViewStore } from '../store'
@@ -34,33 +40,52 @@ export interface ConversationLifecycleHooks {
   'view:close': () => void
 }
 
+/**
+ * 把槽位候选翻译成 slots.register options。
+ *
+ * 旧单槽用 `id`（single 槽的稳定标识），≥0.1.5 的 `main` keyed 槽用 `key`
+ * （槽内 cell 选择键）；两者都以 priority -1 shadow 官方会话条目。
+ */
+function seatRegistrationOptions(target: PanelViewSeatTarget, locale: string): Record<string, unknown> {
+  return {
+    ...target.id === undefined ? {} : { id: target.id },
+    ...target.key === undefined ? {} : { key: target.key },
+    locale,
+    name: target.slot,
+    priority: -1,
+  }
+}
+
 /** 创建会话区替换控制器。 */
 export function createPanelConversationController(): PanelConversationController {
   const hooks = createHooks<ConversationLifecycleHooks>()
   const width = createPanelWidthController()
-  let conversationSeat: (() => void) | undefined
+  let seatDisposers: Array<() => void> = []
   let currentSpec: PanelContentSpec | undefined
   let onPointerDownCapture: ((event: PointerEvent) => void) | undefined
 
-  /** 打开会话区替换：动态注册 priority -1 的 conversation 条目。 */
+  /**
+   * 渲染条目：spec 经渲染期快照传入（close() 置空后条目已注销，组件自然卸载）。
+   */
+  function renderSeat(props: { t: (key: string) => string }): ReactElement {
+    return <ConversationSeat t={props.t} spec={currentSpec} width={width} />
+  }
+
+  /**
+   * 打开会话区替换：对每个版本候选 inject 其槽位声明，并动态注册 priority -1
+   * 条目。核心只会声明其中一个槽——另一候选静默等待（见 PANEL_VIEW_SEAT_TARGETS）。
+   */
   function open(ctx: ClientContext, spec: PanelContentSpec): void {
     if (currentSpec && currentSpec.id === spec.id)
       return
-    if (conversationSeat)
+    if (seatDisposers.length > 0)
       close()
     currentSpec = spec
     panelViewStore.set({ id: spec.id })
-    conversationSeat = ctx.slots.inject(PANEL_VIEW_SLOT as never, () =>
-      ctx.slots.register(
-        {
-          name: PANEL_VIEW_SLOT,
-          id: PANEL_VIEW_COMPONENT_ID,
-          priority: -1,
-          locale: spec.locale ?? NS,
-        } as never,
-        // spec 经渲染期快照传入：close() 置空后条目已注销，组件自然卸载。
-        (props: { t: (key: string) => string }): ReactElement => <ConversationSeat t={props.t} spec={currentSpec} width={width} />,
-      ))
+    const locale = spec.locale ?? NS
+    seatDisposers = PANEL_VIEW_SEAT_TARGETS.map(target =>
+      ctx.slots.inject(target.slot as never, () =>
+        ctx.slots.register(seatRegistrationOptions(target, locale) as never, renderSeat)))
     onPointerDownCapture = (event: PointerEvent): void => {
       if (shouldClosePanelForSidebarTarget(event.target instanceof Element ? event.target : null))
         close()
@@ -70,10 +95,11 @@ export function createPanelConversationController(): PanelConversationController
     void hooks.callHook('view:open', spec)
   }
 
-  /** 关闭会话区替换：dispose inject 句柄 → 注销条目 → 官方 ui-conversation 恢复。 */
+  /** 关闭会话区替换：dispose 全部 inject 句柄 → 注销条目 → 官方会话恢复。 */
   function close(): void {
-    conversationSeat?.()
-    conversationSeat = undefined
+    for (const dispose of seatDisposers)
+      dispose()
+    seatDisposers = []
     currentSpec = undefined
     panelViewStore.set(null)
     if (onPointerDownCapture) {

--- a/packages/dsh-tauri-panel/src/client/types/index.ts
+++ b/packages/dsh-tauri-panel/src/client/types/index.ts
@@ -14,6 +14,21 @@ export interface SidebarRootProps {
   t: (key: string) => string
 }
 
+/**
+ * 会话区替换的槽位候选（跨核心版本的 inject 键 + register options 形状）。
+ *
+ * 核心 0.1.5-rc.1 起把会话区并入 keyed 槽 `main`（cell key `conversation`），
+ * 旧 `conversation` 单槽消失；两个候选同时 inject，任一版本只有对应声明存在。
+ */
+export interface PanelViewSeatTarget {
+  /** 需要 inject / register 的槽位声明键（与 register options.name 同值）。 */
+  slot: string
+  /** keyed 槽的 cell key（≥0.1.5 的 `main`）；旧单槽无此字段。 */
+  key?: string
+  /** 旧单槽的条目 id（single 槽的稳定标识）；keyed 槽无此字段。 */
+  id?: string
+}
+
 /** 内容区替换规格（renderPanelContent 入参）。 */
 export interface PanelContentSpec {
   /** 视图唯一标识（同一时刻只存在一个替换；active 态以它匹配 ActionItem）。 */


### PR DESCRIPTION
## 问题

核心 `0.1.5-rc.1` 及以上，`dsh-tauri-panel` 的会话区替换失效：点击面板条目只有侧栏菜单选中效果，右侧会话区不切换。

## 根因

对比两个核心的 `dsh-client-ui-layout`：

| 核心 | 布局渲染 | 说明 |
| --- | --- | --- |
| `0.1.2-rc.1` | `renderSlot("conversation", {})` | `conversation` 是独立单槽 |
| `0.1.5-rc.1` / `0.1.5-alpha.2` | `renderSlot("main", {}, { entryKey: activePanelId ?? "conversation" })` | 会话区并入 keyed 槽 `main`，官方条目以 `{ name: "main", key: "conversation" }` 注册 |

`0.1.5-rc.1` 核心里已经**完全不存在** `conversation` 槽（既无声明也无渲染）。控制器只做 `ctx.slots.inject('conversation', …)`，声明永不出现 → inject 回调永不执行 → 条目从未注册 → 内容区不替换；而 `panelViewStore.set()` / `setSidebarPanelActive()` 照常执行，所以只剩「菜单选中效果」。

## 修复

`controller.open()` 改为对**两个版本候选同时 inject**，按核心实际声明择一生效（同一核心只会声明其中一个：0.1.1/0.1.2 只有 `conversation`，0.1.5 只有 `main`）：

| 核心版本 | 承载槽 | register options |
| --- | --- | --- |
| ≤ `0.1.2-rc.1` | `conversation`（single） | `{ name: 'conversation', id, priority: -1, locale }` |
| ≥ `0.1.5-rc.1` | `main`（keyed，cell key `conversation`） | `{ name: 'main', key: 'conversation', priority: -1, locale }` |

- 候选表收敛为常量 `PANEL_VIEW_SEAT_TARGETS`，类型新增 `PanelViewSeatTarget`；
- `close()` 由单句柄改为释放全部候选句柄；
- 老核心路径行为完全不变，未声明的候选静默等待、零副作用；
- 新增 `controller.test.ts` 回归测试：断言 open 同时 inject/注册两种形状（含 `priority: -1`、`key`/`id` 不混用），并覆盖同 id toggle 关闭与切换 id 的句柄释放；
- `PROTOCOL.md` / `README.md` / `panel-service.ts` 注释同步版本矩阵与降级说明。

## 验证

- `pnpm typecheck` ✅
- `eslint packages/dsh-tauri-panel/src` ✅（仅 `sidebar.tsx` 4 条既有 warning）
- `pnpm run test -- --run` ✅ 39 files / 295 tests
- `pnpm run build:plugins` ✅ build + deploy 全通过；产物 `src-tauri/resources/node_modules/dsh-tauri-panel/dist/client.cjs` 已包含双候选表

## 备注

顺带发现（**未包含在本次改动**）：`packages/dsh-tauri-ui` 的 `SETTINGS_UNDERLAY_SLOT_KEYS = ['sidebar','conversation','details']` 同样锚在旧槽名上，0.1.5 的 DOM 锚点是 `main` / `rightbar`，设置侧边栏打开时的下层遮蔽可能漏掉会话区与右栏。属于设置侧边栏而非本次面板替换问题，如需可在后续 PR 处理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility for replacing the conversation area across multiple core protocol versions.
  - The panel now supports both legacy conversation slots and newer keyed main slots, ensuring content replacement works across supported versions.

- **Documentation**
  - Updated protocol and README documentation with version-specific slot behavior and compatibility guidance.

- **Tests**
  - Added coverage for slot registration, switching, closing, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->