### PR TITLE
fix(pet): 窗口生命周期操作不得在主线程调用，修复收起后 invoke 全部超时（#469）

### DIFF
--- a/src-tauri/src/bridge/pet.rs
+++ b/src-tauri/src/bridge/pet.rs
@@ -182,7 +182,10 @@ pub fn get_pet_status(app: AppHandle) -> PetStatus {
     status_from_setting(&config::get_store_dat_setting(&app))
 }
 
-/// 启用/停用桌宠；启用同时显示，停用同时**销毁窗口**并永久落盘。
+/// 永久启用/停用桌宠（点击侧栏入口的「关闭桌宠」）。
+///
+/// 停用 = 收起：销毁窗口实例（见 `desktop::pet::set_pet_window_visible`），
+/// 因此必须走 [`defer_pet_window_op`] 在非主线程执行。
 #[tauri::command]
 pub fn set_pet_enabled(app: AppHandle, enabled: bool) -> Result<PetStatus, String> {
     let updated = config::update_store_dat_setting(&app, |setting| {
@@ -192,9 +195,9 @@ pub fn set_pet_enabled(app: AppHandle, enabled: bool) -> Result<PetStatus, Strin
         .lock()
         .unwrap_or_else(|error| error.into_inner())
         .visible = enabled;
-    pet_window::set_pet_window_visible(&app, enabled)?;
-    // 停用即无消费者：停掉宿主会话流订阅（启用时窗口已可见，直接恢复订阅）。
+    // 停用即无消费者：先停掉宿主会话流订阅，窗口销毁随后在后台完成。
     sync_pet_session_stream(&app, enabled);
+    defer_pet_window_op(&app, enabled)?;
     let status = status_from_setting(&updated);
     emit_pet_status(&app, &status);
     Ok(status)
@@ -458,8 +461,8 @@ pub fn move_pet_window(app: AppHandle, delta_x: i32, delta_y: i32) -> Result<(),
 
 /// 显示桌宠窗口；只允许已永久启用的桌宠恢复显示。
 ///
-/// 窗口不存在（首次启用，或上次收起时已被销毁）时在此重建——本命令是 `AppHandle`
-/// 命令，Tauri 在异步运行时执行，不违反「窗口创建不得在主线程」的约束。
+/// 窗口不存在（首次启用，或上次收起时已被销毁）时在此重建；窗口操作统一经
+/// [`defer_pet_window_op`] 丢到非主线程执行。
 #[tauri::command]
 pub fn show_pet(app: AppHandle) -> Result<PetStatus, String> {
     let setting = config::get_store_dat_setting(&app);
@@ -470,9 +473,9 @@ pub fn show_pet(app: AppHandle) -> Result<PetStatus, String> {
         .lock()
         .unwrap_or_else(|error| error.into_inner())
         .visible = true;
-    pet_window::set_pet_window_visible(&app, true)?;
     // 恢复显示 = 重新有消费者：重开会话流订阅。
     sync_pet_session_stream(&app, true);
+    defer_pet_window_op(&app, true)?;
     let status = status_from_setting(&setting);
     emit_pet_status(&app, &status);
     Ok(status)
@@ -480,9 +483,9 @@ pub fn show_pet(app: AppHandle) -> Result<PetStatus, String> {
 
 /// 临时收起桌宠（不改变永久 enabled；重启后已启用宠物重新显示）。
 ///
-/// 「收起」= 销毁窗口实例（`set_pet_window_visible(false)` → `destroy()`），而不是
-/// hide：隐藏窗口里的 `<video>` 仍会播放并持有 Video Wake Lock，屏幕无法息屏
-/// （issue #469）。销毁后 webview 进程消失，视频与锁一并释放，会话流订阅也随即停止。
+/// 「收起」= 销毁窗口实例，而不是 hide：隐藏窗口里的 `<video>` 仍会播放并持有
+/// Video Wake Lock，屏幕无法息屏（issue #469）。销毁后 webview 进程消失，视频与锁
+/// 一并释放，会话流订阅也随即停止。
 #[tauri::command]
 pub fn hide_pet(app: AppHandle) -> Result<PetStatus, String> {
     collapse_pet(&app)?;
@@ -491,18 +494,56 @@ pub fn hide_pet(app: AppHandle) -> Result<PetStatus, String> {
     Ok(status)
 }
 
-/// 收起桌宠窗口：销毁实例、置瞬态不可见、停掉宿主会话流订阅（幂等）。
+/// 收起桌宠窗口：置瞬态不可见、停掉宿主会话流订阅，并**在非主线程**销毁窗口实例。
 ///
-/// 供 `hide_pet` 命令与「桌宠窗口自身收到关闭请求」两条路径共用：后者发生在主线程的
-/// 窗口事件回调里，销毁是异步投递、停流只是 abort 任务句柄，都不阻塞事件循环。
+/// 供 `hide_pet` 命令与「桌宠窗口自身收到关闭请求」两条路径共用（后者发生在主线程的
+/// 窗口事件回调里），两条路径都不会在主线程触碰窗口生命周期 API，见
+/// [`defer_pet_window_op`]。
 pub fn collapse_pet(app: &AppHandle) -> Result<(), String> {
     transient_state()
         .lock()
         .unwrap_or_else(|error| error.into_inner())
         .visible = false;
-    pet_window::set_pet_window_visible(app, false)?;
     // 收起 = 无人渲染：停掉宿主会话流订阅，宿主侧热路径整条短路。
     sync_pet_session_stream(app, false);
+    defer_pet_window_op(app, false)
+}
+
+/// 串行化桌宠窗口的可见性操作，保证「收起 → 再显示」按调用顺序执行。
+fn pet_window_op_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// 把窗口可见性操作丢到异步运行时执行（创建窗口与销毁窗口都**不允许**在主线程调用）。
+///
+/// # 为什么必须离开主线程
+///
+/// Tauri 的 command handler 在主线程执行，而 `tauri-runtime-wry` 对主线程上的窗口
+/// 生命周期消息是**直接 panic**：
+///
+/// - `WindowMessage::Destroy`：`panic!("cannot handle \`WindowMessage::Destroy\` on the
+///   main thread")`（tauri-runtime-wry 2.11.4 lib.rs:3494）；调用点在 `send_user_message`
+///   判定「当前线程 == 主线程」后**同步**派发，因此主线程调 `destroy()` 必崩。
+/// - `create_window`：经 channel 等主线程事件循环回包，主线程调用必然死锁
+///   （同文件 lib.rs:2757 注释）。
+///
+/// 之前的 `hide()` 之所以看起来能用，只是因为 `WindowMessage::Hide` 走了不 panic 的分支；
+/// 换成销毁后就踩中了这条主线程断言（实测表现为：收起宠物后 `show_pet`、
+/// `get_pet_status` 等全部 invoke 超时、主 webview 一起卡住）。
+fn defer_pet_window_op(app: &AppHandle, visible: bool) -> Result<(), String> {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        // 串行锁：并发/快速连点的收起与显示不会交错，最终态等于最后一次调用。
+        let _guard = pet_window_op_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Err(error) = pet_window::set_pet_window_visible(&app, visible) {
+            log::error!("PET_WINDOW_VISIBILITY_FAILED: visible={visible}: {error}");
+            let status = status_from_setting(&config::get_store_dat_setting(&app));
+            emit_pet_status(&app, &status);
+        }
+    });
     Ok(())
 }
 

--- a/src-tauri/src/desktop/pet.rs
+++ b/src-tauri/src/desktop/pet.rs
@@ -285,8 +285,10 @@ pub fn move_pet_window<R: Runtime>(
 /// 创建 `pet` 窗口并恢复上一次保存的位置（无记录则默认定位在主屏右下角略偏上，
 /// 避免遮挡主工作区）。
 ///
-/// **只能在非主线程调用**：内部经 `WebviewWindowBuilder::build()` 创建窗口，
-/// 主线程调用会与事件循环回包互相等待而死锁（见 [`set_pet_window_visible`]）。
+/// 创建窗口只能来自 app setup 或异步运行时的命令任务：`WebviewWindowBuilder::build()`
+/// 经 channel 等主线程事件循环回包，主线程调用会死锁；销毁窗口则**绝不能**在主线程
+/// 调用（`WindowMessage::Destroy` 在主线程直接 panic）。两条约束都由
+/// `bridge::pet::defer_pet_window_op` 统一保证。
 pub fn ensure_pet_window<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<WebviewWindow<R>> {
     if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {
         return Ok(window);
@@ -403,13 +405,17 @@ fn place_pet_at_default<R: Runtime>(window: &WebviewWindow<R>) {
 /// 唤醒锁释放、CPU 归零。代价是重新显示要重建 webview（页面前端挂载时用
 /// `get_pet_status` 拉取状态，不依赖创建时的事件投递）。
 ///
-/// # 为什么 show 分支会创建窗口、而 destroy 分支不会死锁
+/// # 线程约束（务必读完再改）
 ///
-/// `tauri-runtime-wry` 的 `RuntimeHandle::create_window` 经 channel 等待主线程事件循环
-/// 回包，**主线程调用必然死锁**（tauri-runtime-wry 2.11.4 lib.rs:2757 注释）。因此窗口
-/// 创建只允许发生在非主线程：调用方 `set_pet_enabled` / `show_pet` 都是 `AppHandle`
-/// 命令（Tauri 在异步运行时执行）；`hide_pet` 与窗口自己的关闭事件则只走 destroy，
-/// 而 `destroy()` 是 `proxy.send_event(Message::Destroy)` 的**非阻塞**投递，任何线程都安全。
+/// `tauri-runtime-wry` 对主线程上的窗口生命周期消息是「创建会死锁、销毁会 panic」：
+///
+/// - **销毁**走 `WindowMessage::Destroy`，主线程调用直接
+///   `panic!("cannot handle \`WindowMessage::Destroy\` on the main thread")`
+///   （tauri-runtime-wry 2.11.4 lib.rs:3494）。command handler 在主线程执行，所以
+///   收起命令必须经 `bridge::pet::defer_pet_window_op` 丢到异步运行时再调本函数。
+/// - **创建**（`ensure_pet_window` → `WebviewWindowBuilder::build()`）经 channel 等
+///   主线程事件循环回包，仅允许 app setup 或异步运行时任务调用（app setup 在事件
+///   循环初始化前、不与回包竞争，是唯一的主线程例外）。
 pub fn set_pet_window_visible<R: Runtime>(app: &AppHandle<R>, visible: bool) -> Result<(), String> {
     if !visible {
         if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {

--- a/test/pet-window-lifecycle.test.ts
+++ b/test/pet-window-lifecycle.test.ts
@@ -46,6 +46,32 @@ describe('pet window collapse (destroy, not hide)', () => {
   })
 })
 
+describe('pet window lifecycle never runs on the main thread', () => {
+  const bridge = readSource('../src-tauri/src/bridge/pet.rs')
+
+  it('defers every window visibility change off the command thread', () => {
+    // command handler 在主线程执行，而 tauri-runtime-wry 在主线程上：
+    // destroy 直接 panic（lib.rs:3494 "cannot handle WindowMessage::Destroy on the main
+    // thread"）、create_window 经 channel 等事件循环回包而死锁。所以窗口操作必须
+    // 经 defer_pet_window_op 丢到异步运行时。
+    expect(bridge).toContain('fn defer_pet_window_op')
+    expect(bridge).toContain('tauri::async_runtime::spawn')
+    expect(bridge).toContain('let _guard = pet_window_op_lock()')
+
+    for (const name of ['set_pet_enabled', 'show_pet', 'collapse_pet']) {
+      const body = functionBody(bridge, name)
+      expect(body, `${name} must defer the window op`).toContain('defer_pet_window_op')
+      // 命令里不得直接触碰窗口生命周期 API（那正是超时/panic 的来源）。
+      expect(body, `${name} must not call set_pet_window_visible directly`).not.toContain('set_pet_window_visible')
+    }
+  })
+
+  it('serializes concurrent visibility operations with a lock', () => {
+    // 快速连点收起/显示时两次 spawn 会并发；加锁保证最终态等于最后一次调用。
+    expect(bridge).toContain('OnceLock<Mutex<()>>')
+  })
+})
+
 describe('pet window collapse state sync', () => {
   const bridge = readSource('../src-tauri/src/bridge/pet.rs')
 
@@ -55,7 +81,7 @@ describe('pet window collapse state sync', () => {
     // 销毁窗口之外还要落瞬态可见性与会话流，否则侧栏图标仍显示「已激活」、
     // 宿主侧还会持续为桌宠推送会话数据。
     expect(body).toContain('visible = false')
-    expect(body).toContain('set_pet_window_visible(app, false)')
+    expect(body).toContain('defer_pet_window_op(app, false)')
     expect(body).toContain('sync_pet_session_stream(app, false)')
   })
 


### PR DESCRIPTION
## 问题

收起宠物后，`show_pet` / `get_pet_status` 等 invoke 全部超时，主 webview 一起卡住：

```
sidebar-icon.ts:41 [dsh-tauri-pet] sidebar icon toggle failed: Error: NODE_NOT_ANSWERED: invoke show_pet timed out
pet-settings.tsx:258 [dsh-tauri-pet] initial load failed: Error: NODE_NOT_ANSWERED: invoke get_pet_status timed out
```

## 根因

`tauri-runtime-wry` 2.11.4 对主线程上的窗口生命周期消息是「创建会死锁、销毁会 panic」：

- `WindowMessage::Destroy`（lib.rs:3494）：`panic!("cannot handle `WindowMessage::Destroy` on the main thread")`。调用点在 `send_user_message` 判定「当前线程 == 主线程」后**同步**派发，所以主线程调 `destroy()` 必崩。
- `create_window`（lib.rs:2757 注释）：经 channel 等主线程事件循环回包，主线程调用必然死锁。

Tauri 的 command handler 就在主线程执行 —— #471 把 `hide()` 换成 `destroy()` 后，`hide_pet` 正好踩中第一条断言：panic 冲穿事件循环回调，应用进程虽还活着（Windows 仍报 Responding），但 IPC 已全废（前端表现为所有 invoke 超时、主 webview 卡住）。之前的 `hide()` 只是恰好走了不 panic 的 `WindowMessage::Hide` 分支。

## 改动

- `bridge/pet.rs`：新增 `defer_pet_window_op`，把窗口可见性操作丢到 `tauri::async_runtime::spawn` 执行，并用 `OnceLock<Mutex<()>>` 串行化，保证快速连点「收起 → 显示」时最终态等于最后一次调用。`set_pet_enabled` / `show_pet` / `collapse_pet` 一律经它，命令体内不再直接触碰窗口生命周期 API。
- `bridge/pet.rs`：会话流订阅的启停仍留在命令内同步执行（纯 abort / 原子标记，不阻塞事件循环），收起后宿主侧热路径照旧整条短路。
- `desktop/pet.rs`：把线程约束写进 `set_pet_window_visible` 与 `ensure_pet_window` 的文档（销毁不得在主线程 / 创建仅允许 setup 与异步运行时任务）。
- `test/pet-window-lifecycle.test.ts`：新增契约断言 —— 三个命令体必须出现 `defer_pet_window_op`、且**不得**出现 `set_pet_window_visible`；并断言存在串行锁。

## 验证

- 实机（dev 构建）确认：收起宠物后不再出现 invoke 超时，收起 → 显示可反复切换。
- `cargo test --all-features --locked` → 546 passed
- `cargo check` 无新增 warning
- `pnpm exec vitest run test/pet-window-lifecycle.test.ts test/disable-wake-lock.test.ts` → 15 passed
- `eslint` / `typecheck` 改动文件 0 error

## 与 #471 的关系

#471 已合并了 issue #469 的前两部分（禁用 Screen Wake Lock、收起即销毁窗口）；本 PR 只带这一处主线程修复，基于最新 `main`，不含 #471 的历史提交。

Fixes #469


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pet window lifecycle handling to prevent crashes during show, collapse, and enable/disable operations.
  * Serialized window visibility changes for more reliable ordering.
  * Pet window collapse now properly releases associated video and wake-lock resources.

* **Tests**
  * Added coverage for deferred and serialized pet window operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->