### PR TITLE
chore: release v0.12.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.12.0-beta.4",
+  "version": "0.12.0-beta.5",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.4"
+version = "0.12.0-beta.5"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.4"
+version = "0.12.0-beta.5"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.12.0-beta.4",
+  "version": "0.12.0-beta.5",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.12.0-beta.5` (`0.12.0-beta.4` → `0.12.0-beta.5`).

### Bug Fixes

- **pet**: 窗口生命周期操作不得在主线程调用，修复收起后 invoke 全部超时（#469） (27c42dd)
- **pet**: 窗口重建后强制补发一次鼠标位置，并澄清两把唤醒锁（#469） (41b1a9d)
- **panel**: 会话区替换兼容 0.1.5 的 main keyed 槽 (c08c38f)
- **pet**: 收起宠物改为销毁桌宠窗口，不再只是 hide（#469） (ae90a17)
- **pet**: macOS 预设桌宠改用 HEVC-with-Alpha MOV，修复黑底（#434） (1eb58ca)
- **pet**: 禁用屏幕唤醒锁，桌宠动画不再阻止息屏（#469） (6494ee1)
- **dsh-tauri-ui**: 修正 FilePlus 导出顺序，恢复 lint 通过 (db6b322)
- **profile**: 按 review 修正权限指引的目标目录与平台命令 (2fd0cdf)
- **window**: 采纳 CodeRabbit 复核——多屏空隙与最大化状态 (001ad70)
- **turnrewind**: 同步 cssr 测试里清单行的字号期望（main 既有） (944452e)
- **window**: 尺寸恢复不再被位置/显示器判定绑架（#464） (6240044)
- **lint**: 修复图标导出的 perfectionist 排序回归（main 既有） (181c24a)
- **profile**: actionable permission diagnosis for an unwritable $DSH_HOME (#466) (de0a315)

### Documentation

- 同步插件说明与开发文档（dsh 0.1.5-rc.2 徽章、TurnRewind 内置插件、dsh-tauri-ui 描述） (5278c9e)

### Chores

- change turnrewind style (ee37167)

### Other Changes

- Merge pull request #475 from dsh-tauri-desk/fix/469-pet-window-main-thread (1612d30)
- Merge pull request #473 from dsh-tauri-desk/fix/panel-conversation-main-slot (68c8094)
- Merge pull request #471 from dsh-tauri-desk/fix/469-pet-wake-lock (867da69)
- Merge pull request #472 from dsh-tauri-desk/fix/434-macos-hevc-alpha-mov-pet (223ebe3)
- Merge pull request #470 from dsh-tauri-desk/fix/window-geometry-restore-size (40453a5)
- Merge pull request #468 from dsh-tauri-desk/fix/466-unwritable-profile-permission-diagnosis (b8a9e32)
- Merge branch 'main' of https://github.com/dsh-tauri-desk/deepseek-harness-desktop (4d77ec6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.12.0-beta.5**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->