### PR TITLE
chore: release v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.12.0-beta.5",
+  "version": "0.12.0",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.12.0-beta.5",
+  "version": "0.12.0",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.12.0` (`0.12.0-beta.5` → `0.12.0`).

### Bug Fixes

- **turnrewind**: 提示条读数按 turn/会话边界归零，不再跨轮累加 (e9c69b8)

### Documentation

- point built-in plugin links to monorepo (227567f)
- sync plugin inventory and development guidance (fa8ca52)

### Other Changes

- Merge pull request #478 from dsh-tauri-desk/docs/sync-documentation (c4a5988)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Promoted the application from beta to the stable 0.12.0 release.
  - Updated the displayed application version consistently across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->