### PR TITLE
chore: release v0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.12.0"
+version = "0.12.1"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.12.1` (`0.12.0` → `0.12.1`).

### Features

- **pet**: 桌宠渲染改用 dsh-pet-component，预设宠物改为远端直连 (11829b0)

### Bug Fixes

- **worktree**: 节流状态复核，消除 /status 请求风暴 (fd509bf)
- **pet**: 关闭宠物改为持久化，重启不再自动拉起 (71855a1)
- **plugin**: 安装插件时把档案记录的 pnpm store 下传给子进程 (fd8e718)

### Other Changes

- Merge pull request #485 from dsh-tauri-desk/fix/worktree-status-request-storm (b6171ad)
- Merge pull request #484 from dsh-tauri-desk/feat/pet-dsh-pet-component (f6ffb2d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.12.1** across all release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->