### PR TITLE
fix(build): 对齐 tauri-plugin-http 版本，修复发布构建版本校验失败

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4767,9 +4767,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
 dependencies = [
  "anyhow",
  "dunce",
@@ -4791,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-http"
-version = "2.5.9"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+checksum = "7241a0c762649be8fba7dd4cc84684d0e409f26b335a978ef4dd5fe78da74ce6"
 dependencies = [
  "bytes",
  "cookie_store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,9 @@ tauri-plugin-store = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-autostart = "2"
 # 桌宠素材直连远端：插件版 HTTP 从 Rust 发起请求，绕开 githubusercontent 的 CORS。
-tauri-plugin-http = "2"
+# 版本须与 package.json 的 @tauri-apps/plugin-http（catalog:tauri，^2.6.0）保持同一 minor：
+# tauri CLI 会在构建前校验 NPM 包与 Rust crate 的 major/minor 是否一致，不一致直接退出。
+tauri-plugin-http = "2.6"
 image = { version = "0.25", default-features = false, features = [ "png" ] }
 arboard = { version = "3", features = [ "wayland-data-control" ] }
 base64 = "0.22"


### PR DESCRIPTION
## 现象

v0.12.1 发布构建在编译前即失败（三平台一致，[actions/runs/34676511089](https://github.com/dsh-tauri-desk/deepseek-harness-desktop/actions/runs/34676511089/job/103507257355)）：

```
Found version mismatched Tauri packages. Make sure the NPM package and Rust crate versions are on the same major/minor releases:
tauri-plugin-http (v2.5.9) : @tauri-apps/plugin-http (v2.6.0)
```

## 根因

`11829b0`（桌宠远端直连）新增该插件时两侧版本范围没对齐：

| 侧 | 声明 | 实际解析 |
| --- | --- | --- |
| npm（`pnpm-workspace.yaml` → `catalog:tauri`） | `^2.6.0` | 2.6.0 |
| Rust（`src-tauri/Cargo.toml`） | `"2"` | 2.5.9（Cargo.lock 锁定） |

tauri CLI 在 `tauri build` 前会校验 NPM 包与 Rust crate 的 major/minor，不一致直接退出，因此三个平台全部在编译前挂掉。

## 修改

- `src-tauri/Cargo.toml`：`tauri-plugin-http = "2"` → `"2.6"`，与 catalog 的 `^2.6.0` 锁定同一 minor，并补注释说明为何不能写成宽泛的 `"2"`；
- `src-tauri/Cargo.lock`：`tauri-plugin-http` 2.5.9 → 2.6.0（连带 `tauri-plugin-fs` 2.5.1 → 2.5.2，2.6.0 的依赖要求）。

选择升 Rust 侧而不是降 npm 侧：npm 侧的 2.6.0 是本就在用的 JS 实现，Rust 侧 2.5.9 与之 IPC 同源但版本校验过不去；2.6.0 相对 2.5.9 只有文档与 `system-proxy` feature 改名（`macos-system-configuration` 的替代），命令与 scope 未变。

## 验证

按 CI 完全相同的命令在本机复现（`pnpm install --frozen-lockfile` 后）：

```
pnpm tauri build --config release-msi-version.tmp.json --no-bundle
Info Looking up installed tauri packages to check mismatched versions...
Built application at: src-tauri\target\release\deepseek-harness-desktop.exe   # exit 0
```

版本校验通过并完成 release 编译，`capabilities/default.json` 的 `http:default` + `{"url": "https://*.githubusercontent.com/*"}` 无需改动。

## 合并后

v0.12.1 的 tag 指向失败构建的合并提交，仅重跑 workflow 仍会构建同一份旧代码。修复合并后需重新走一次发布（新补丁版本，或把 `v0.12.1` tag 移到修复后的提交再触发），三平台产物才会重建。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the HTTP plugin version to align with the application’s supported plugin release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->