### PR TITLE
chore: release v0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.12.2"
+version = "0.12.3"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.12.3` (`0.12.2` → `0.12.3`).

### Bug Fixes

- **worktree**: 归档会话彻底退出检测（不查 /status、不轮询、不订阅） (cb89ec7)
- **worktree**: 归档会话不再逐个打 /status，改用批量绑定判定是否需清理 (0f0144b)
- **worktree**: 所有 /status 一律经节流器；重试链终止条件对齐评审意见 (6d60a5f)
- **worktree**: 未解析会话的重试必须有界，防止请求量随会话数放大 (c60fa83)

### Performance

- **worktree**: 批量 /bindings 取代逐会话首轮 /status，事件侧改为回合结束复核 (0080e7d)

### Other Changes

- Merge pull request #489 from dsh-tauri-desk/fix/worktree-hydration-retry-bound (f1f1933)