### PR TITLE
Fix/wayland pet support

### DIFF
--- a/packages/dsh-tauri-pet/src/client/components/pet-settings.tsx
+++ b/packages/dsh-tauri-pet/src/client/components/pet-settings.tsx
@@ -190,7 +190,8 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
     setBusy(true)
     setError(null)
     try {
-      setPetStatus(await setPetEnabled(false))
+      if (enabled)
+        setPetStatus(await setPetEnabled(false))
       setPetStatus(await setActivePet(''))
     }
     catch (clearError) {

--- a/packages/dsh-tauri-pet/src/client/components/pet-settings.tsx
+++ b/packages/dsh-tauri-pet/src/client/components/pet-settings.tsx
@@ -84,6 +84,9 @@ function readAsBase64(file: File): Promise<string> {
   })
 }
 
+/**
+ * 桌宠设置页：预设 / Chat / Codex 三类宠物卡片（选择、启用、取消选择）、开关、大小滑条与导入。
+ */
 export function PetSettings(props: PetSettingsProps): ReactElement {
   useMountStyle(petSettingsStyle, 'dsh-tauri-pet-settings-styles')
   usePetLocale()
@@ -175,21 +178,30 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
     }
   }
 
-  /** 取消选择：清空已选宠物；仍在启用时一并关闭桌宠（无内容可渲染，不留空窗口）。 */
+  /**
+   * 取消选择：清空已选宠物；仍在启用时一并关闭桌宠（无内容可渲染，不留空窗口）。
+   *
+   * 先关闭再清空：若第二步失败，最坏情况也只是保留选择但窗口已销毁，
+   * 不会留下一个空窗口。任一步失败都从后端重拉状态，避免界面与持久层不一致。
+   */
   async function clearSelection(): Promise<void> {
     if (busy || active === '')
       return
     setBusy(true)
     setError(null)
     try {
-      let nextStatus = await setActivePet('')
-      if (nextStatus.enabled)
-        nextStatus = await setPetEnabled(false)
-      setPetStatus(nextStatus)
+      setPetStatus(await setPetEnabled(false))
+      setPetStatus(await setActivePet(''))
     }
     catch (clearError) {
       console.error('[dsh-tauri-pet] clear selection failed:', clearError)
       setError(text('clearFailed'))
+      try {
+        setPetStatus(await fetchPetStatus())
+      }
+      catch {
+        // 后端不可达时保留最后已知状态，下次成功请求会自动同步。
+      }
     }
     finally {
       setBusy(false)

--- a/packages/dsh-tauri-pet/src/client/components/pet-settings.tsx
+++ b/packages/dsh-tauri-pet/src/client/components/pet-settings.tsx
@@ -175,6 +175,27 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
     }
   }
 
+  /** 取消选择：清空已选宠物；仍在启用时一并关闭桌宠（无内容可渲染，不留空窗口）。 */
+  async function clearSelection(): Promise<void> {
+    if (busy || active === '')
+      return
+    setBusy(true)
+    setError(null)
+    try {
+      let nextStatus = await setActivePet('')
+      if (nextStatus.enabled)
+        nextStatus = await setPetEnabled(false)
+      setPetStatus(nextStatus)
+    }
+    catch (clearError) {
+      console.error('[dsh-tauri-pet] clear selection failed:', clearError)
+      setError(text('clearFailed'))
+    }
+    finally {
+      setBusy(false)
+    }
+  }
+
   /** 启用/关闭桌宠：纯持久开关，关闭后重启不再自动拉起。 */
   async function toggleEnabled(): Promise<void> {
     if (busy)
@@ -257,9 +278,9 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
                   name={item.name}
                   desc={item.desc ?? ''}
                   active={active === item.id}
-                  disabled={busy || active === item.id}
-                  actionLabel={active === item.id ? text('selected') : text('enable')}
-                  onAction={() => { void enablePreset(item.id) }}
+                  disabled={busy}
+                  actionLabel={text(active === item.id ? 'clear' : 'enable')}
+                  onAction={() => { void (active === item.id ? clearSelection() : enablePreset(item.id)) }}
                 />
               ))}
               {chatPets.map(item => (
@@ -270,9 +291,9 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
                   name={item.name}
                   desc={item.description ?? ''}
                   active={active === item.id}
-                  disabled={busy || active === item.id}
-                  actionLabel={text(active === item.id ? 'selected' : 'select')}
-                  onAction={() => { void choose(item.id) }}
+                  disabled={busy}
+                  actionLabel={text(active === item.id ? 'clear' : 'select')}
+                  onAction={() => { void (active === item.id ? clearSelection() : choose(item.id)) }}
                 />
               ))}
             </div>
@@ -292,9 +313,9 @@ export function PetSettings(props: PetSettingsProps): ReactElement {
               name={item.name}
               desc={item.description ?? ''}
               active={active === item.id}
-              disabled={busy || active === item.id}
-              actionLabel={text(active === item.id ? 'selected' : 'select')}
-              onAction={() => { void choose(item.id) }}
+              disabled={busy}
+              actionLabel={text(active === item.id ? 'clear' : 'select')}
+              onAction={() => { void (active === item.id ? clearSelection() : choose(item.id)) }}
             />
           ))}
     </div>

--- a/packages/dsh-tauri-pet/src/client/locales/index.ts
+++ b/packages/dsh-tauri-pet/src/client/locales/index.ts
@@ -8,6 +8,8 @@ import { PET_CLIENT_NS as NS } from '../constants'
 export { PET_CLIENT_NS as NS } from '../constants'
 
 const DICT_ZH: Record<LocaleKey, string> = {
+  clear: '取消选择',
+  clearFailed: '取消选择失败',
   closePet: '关闭宠物',
   create: '创建',
   createFailed: '创建宠物会话失败',
@@ -20,7 +22,6 @@ const DICT_ZH: Record<LocaleKey, string> = {
   loading: '加载中…',
   name: '宠物',
   select: '选择',
-  selected: '已选',
   setPetFailed: '选择宠物失败',
   setSizeFailed: '设置宠物大小失败',
   sizeHint: '调整桌宠窗口的显示大小（50–200%）',
@@ -31,6 +32,8 @@ const DICT_ZH: Record<LocaleKey, string> = {
 }
 
 const DICT_EN: Record<LocaleKey, string> = {
+  clear: 'Clear selection',
+  clearFailed: 'Failed to clear pet selection',
   closePet: 'Close pet',
   create: 'Create',
   createFailed: 'Failed to create a pet session',
@@ -43,7 +46,6 @@ const DICT_EN: Record<LocaleKey, string> = {
   loading: 'Loading…',
   name: 'Pets',
   select: 'Choose',
-  selected: 'Selected',
   setPetFailed: 'Failed to select pet',
   setSizeFailed: 'Failed to set pet size',
   sizeHint: 'Adjust the pet window size (50–200%)',

--- a/packages/dsh-tauri-pet/src/client/types/index.ts
+++ b/packages/dsh-tauri-pet/src/client/types/index.ts
@@ -80,7 +80,9 @@ export interface ConversationInputLeftProps {
 }
 
 export type LocaleKey
-  = | 'closePet'
+  = | 'clear'
+    | 'clearFailed'
+    | 'closePet'
     | 'create'
     | 'createFailed'
     | 'emptyImported'
@@ -92,7 +94,6 @@ export type LocaleKey
     | 'loading'
     | 'name'
     | 'select'
-    | 'selected'
     | 'setPetFailed'
     | 'setSizeFailed'
     | 'sizeHint'

--- a/src-tauri/src/bridge/pet.rs
+++ b/src-tauri/src/bridge/pet.rs
@@ -188,16 +188,29 @@ pub fn set_pet_enabled(app: AppHandle, enabled: bool) -> Result<PetStatus, Strin
 }
 
 /// 选择桌宠模型包并持久化 active_pet。
+///
+/// 空串表示清除选择（存 `None`，与全新安装一致）：设置页已选卡片可再次点击取消，
+/// 而不是一旦选中就无法撤销。清空后桌宠窗口无内容可渲染，调用方应同时关闭窗口。
 #[tauri::command]
 pub fn set_active_pet(app: AppHandle, id: String) -> Result<PetStatus, String> {
-    let id = id.trim().to_string();
-    validate_active_pet_id(&id)?;
+    let cleared = normalize_set_active_pet_id(&id)?;
     let updated = config::update_store_dat_setting(&app, |setting| {
-        setting.active_pet = Some(id);
+        setting.active_pet = cleared;
     });
     let status = status_from_setting(&updated);
     emit_pet_status(&app, &status);
     Ok(status)
+}
+
+/// 选择 id 归一化：空串（去除首尾空白后）表示清除选择；非空沿用既有合法性校验
+///（预设安全字符集或来源限定 id），非法 id 保持报错而不静默清空。
+fn normalize_set_active_pet_id(id: &str) -> Result<Option<String>, String> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    validate_active_pet_id(trimmed)?;
+    Ok(Some(trimmed.to_string()))
 }
 
 /// 设置宠物大小百分比（设置页滑条，50–200），并实时同步窗口尺寸。
@@ -1212,6 +1225,26 @@ mod tests {
                 "旧版或非法 id {legacy_or_invalid} 应归一为空串（未选择宠物）"
             );
         }
+    }
+
+    #[test]
+    fn set_active_pet_accepts_empty_as_clear() {
+        // 空串/纯空白表示清除选择：存 None（与全新安装一致），而不是非法 id 报错。
+        assert_eq!(normalize_set_active_pet_id(""), Ok(None));
+        assert_eq!(normalize_set_active_pet_id("   "), Ok(None));
+        // 非空保持既有校验：合法 id 原样存（去空白），非法 id 仍然报错。
+        assert_eq!(
+            normalize_set_active_pet_id("  maid-deepseek-whale  "),
+            Ok(Some("maid-deepseek-whale".to_string()))
+        );
+        assert_eq!(
+            normalize_set_active_pet_id("chat:custom-pet"),
+            Ok(Some("chat:custom-pet".to_string()))
+        );
+        assert!(
+            normalize_set_active_pet_id("bad id").is_err(),
+            "非法 id 不应被静默当作清除"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,8 @@ mod service;
 mod task;
 mod utils;
 
+/// 应用入口：先做 Wayland 环境兼容（见 `should_apply_wayland_egl_workaround`），
+/// 再初始化日志、装配桌面端并进入事件循环。
 pub fn run() {
     // Wayland EGL workaround：仅 AppImage 需要（见 `should_apply_wayland_egl_workaround`）。
     if should_apply_wayland_egl_workaround(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,12 +7,11 @@ mod task;
 mod utils;
 
 pub fn run() {
-    // Wayland EGL workaround: AppImage bundles WebKitGTK may fail with
-    // "Could not create default EGL display: EGL_BAD_PARAMETER" on Wayland
-    // compositors (PikaOS/GNOME Wayland, Ubuntu 22.04+). Host WebKit (deb)
-    // works, but AppImage needs compositing disabled. Auto-set when on Wayland
-    // if user hasn't already set it — fixes hairyf#??? (PikaOS report).
-    if std::env::var("XDG_SESSION_TYPE").unwrap_or_default() == "wayland" {
+    // Wayland EGL workaround：仅 AppImage 需要（见 `should_apply_wayland_egl_workaround`）。
+    if should_apply_wayland_egl_workaround(
+        &std::env::var("XDG_SESSION_TYPE").unwrap_or_default(),
+        std::env::var_os("APPIMAGE").is_some(),
+    ) {
         // 与 README 文档一致地同时关闭 compositing 与 DMABUF renderer：只关前者在部分
         // 发行版/驱动上仍会 SIGSEGV（issue #116 的 WebKitGTK 崩溃）。两个参数互相独立，
         // 用户已手动设置其中一个时只补齐另一个。
@@ -65,4 +64,34 @@ pub fn run() {
             }
             _ => {}
         });
+}
+
+/// Wayland EGL workaround 是否生效：仅 AppImage 需要。
+///
+/// AppImage 自带旧 WebKitGTK，打包库与宿主 Wayland 合成器 EGL 不兼容
+/// （"Could not create default EGL display: EGL_BAD_PARAMETER"，PikaOS/GNOME
+/// Wayland、Ubuntu 22.04+），必须关闭合成与 DMABUF renderer 才能建窗。
+/// 宿主安装包（deb/rpm/…）用系统 WebKit，可正常创建 EGL 显示；且强制关闭合成
+/// 会破坏透明窗口（桌宠）与视频渲染，因此非 AppImage 运行时不再强制。
+/// AppImage 运行时必带 `APPIMAGE` 环境变量（runtime 规范），以此判定打包形态。
+fn should_apply_wayland_egl_workaround(session_type: &str, appimage_present: bool) -> bool {
+    session_type == "wayland" && appimage_present
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wayland_workaround_only_inside_appimage() {
+        // AppImage + Wayland：保留旧行为，窗口能建起来。
+        assert!(should_apply_wayland_egl_workaround("wayland", true));
+        // 宿主安装包 + Wayland：系统 WebKit 可建 EGL 显示，不再强制关闭合成
+        //（否则透明桌宠窗口全黑、视频无法渲染）。
+        assert!(!should_apply_wayland_egl_workaround("wayland", false));
+        // 非 Wayland 会话：两种形态都不需要。
+        assert!(!should_apply_wayland_egl_workaround("x11", true));
+        assert!(!should_apply_wayland_egl_workaround("", true));
+        assert!(!should_apply_wayland_egl_workaround("", false));
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to clear the currently selected pet.
  - Pet cards now offer context-sensitive actions for selecting, enabling, or clearing a pet.
  - Added English and Chinese text for clearing pets and related errors.

- **Bug Fixes**
  - Improved handling of blank or whitespace-only pet selections and resynchronized the interface after clearing failures.
  - Refined Wayland rendering behavior for AppImage installations without affecting other Wayland sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->