### PR TITLE
chore: release v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "type": "module",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "description": "Desktop application for DeepSeek Harness (dsh) — one-click local install and launch, no Node.js setup required.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.12.3"
+version = "0.13.0"
 description = "Desktop application for DeepSeek Harness (dsh)"
 authors = [ "deepseek-harness-desktop contributors" ]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness Desktop",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "identifier": "io.github.hairyf.deepseek-harness-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release `v0.13.0` (`0.12.3` → `0.13.0`).

### Features

- **pet**: allow clearing the selected pet from settings (04ee802)

### Bug Fixes

- **pet**: skip redundant disable when clearing an already-disabled pet (fac2842)
- **pet**: resync status when clearing selection fails (0ba7e42)
- **wayland**: scope EGL software-rendering workaround to AppImage runtime (4f8f75c)
- **turnrewind**: 嵌套仓库不再让运行中读数凭空多出文件 (d371fc3)

### Refactors

- **shell**: 全面接入 reause，桌面桥收敛到插件侧 (4e19459)

### Documentation

- **readme**: 移除首屏预览表格，hero 图片直达预览页 (5391eed)
- 新增通用软件开发规范与协议（DEVLOPMENT.SPEC） (4d48215)
- **readme-es**: fix typo (surten efecto) (1b6b031)
- **readme-es**: clarify zero-setup means no manual install (2f6a85f)
- **readme**: add Spanish translation and cross-link locales (1a4ed61)

### Tests

- **turnrewind**: 嵌套仓库断言不依赖文件系统枚举顺序 (6e12346)

### Chores

- remove spec review (68e0b87)

### Other Changes

- Merge pull request #502 from dsh-tauri-desk/fix/pet-clear-and-appimage-wayland (6a9a81a)
- Merge pull request #499 from Diez111/docs/readme-spanish (d53ddbc)
- Merge pull request #500 from dsh-tauri-desk/refactor/shell-reause-migration (1ff92b4)
- Merge pull request #491 from dsh-tauri-desk/fix/turnrewind-live-diff-nested-repos (aa7e693)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.13.0 across all release components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->